### PR TITLE
Register the-local plugin and add Userback MCP to Assembly

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Design Machines' AI plugin marketplace",
-    "version": "1.1.0"
+    "version": "1.2.0"
   },
   "plugins": [
     {
@@ -68,6 +68,11 @@
       "name": "dm-review",
       "source": "./plugins/dm-review",
       "description": "Code review orchestrator with parallel agents for accessibility, security, architecture, CSS, voice, governance, and visual browser testing"
+    },
+    {
+      "name": "the-local",
+      "source": "./plugins/the-local",
+      "description": "Self-hosted Matrix network for the workplace democracy movement. Element Web branding, Synapse config, and server ops."
     }
   ]
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,6 +69,7 @@ To update, fetch the page with `notion-fetch`, then use `notion-update-page` wit
 | **project-scaffolder** | Claude Code project infrastructure scaffolding with hooks, agents, and CLAUDE.md |
 | **accessibility-compliance** | WCAG 2.2 auditing and enforcement for Live Wires, Templ+Datastar, and Craft CMS |
 | **dm-review** | Code review orchestrator with parallel agents and visual browser testing across all DM stacks |
+| **the-local** | Self-hosted Matrix network (The Local) -- Element Web branding, Synapse config, server ops |
 
 ## Common Operations
 

--- a/plugins/assembly/.claude-plugin/plugin.json
+++ b/plugins/assembly/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "assembly",
   "description": "Assembly governance application development with Go, Templ, and Datastar",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "author": {
     "name": "Design Machines"
   }

--- a/plugins/assembly/skills/development/SKILL.md
+++ b/plugins/assembly/skills/development/SKILL.md
@@ -457,6 +457,7 @@ Official and third-party Claude Code plugins that complement this skill:
 | **playwright** | Browser tools | E2E visual testing beyond curl smoke tests |
 | **superpowers** | `/debug`, `/verify` | Debug tricky Go issues, verify builds |
 | **feature-dev** | `/feature-dev` | Structured feature development with architecture exploration |
+| **userback** | Feedback tools (MCP) | Triage user feedback, read console/network logs, update status. HTTP endpoint: `https://mcp.userback.io/v1/mcp/` (OAuth) |
 
 ## Cross-References
 


### PR DESCRIPTION
## Summary
- Register new `the-local` plugin (v1.0.0) in marketplace manifest and CLAUDE.md plugin table — self-hosted Matrix network with 3 skills (element-branding, server-ops, synapse-config) and 3 commands (create-user, deploy, logs)
- Add Userback MCP (`https://mcp.userback.io/v1/mcp/`) to Assembly's ecosystem integration table for feedback triage during development
- Bump marketplace version 1.1.0 → 1.2.0, Assembly version 2.4.0 → 2.5.0
- Notion manual page updated with both changes (13 plugins, 27 skills)

## Test plan
- [ ] Verify `marketplace.json` is valid JSON
- [ ] Confirm the-local appears in CLAUDE.md plugin table
- [ ] Verify Assembly SKILL.md ecosystem table includes Userback row
- [ ] Check Notion manual page reflects updated stats and new plugin entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)