### PR TITLE
feat: tool-aware pipeline routing

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -154,7 +154,7 @@
     {
       "name": "live-wires",
       "source": "./plugins/live-wires",
-      "version": "1.6.0",
+      "version": "1.7.0",
       "author": {
         "name": "Design Machines"
       },
@@ -270,7 +270,7 @@
     {
       "name": "dm-review",
       "source": "./plugins/dm-review",
-      "version": "1.27.11",
+      "version": "1.28.0",
       "author": {
         "name": "Design Machines",
         "url": "https://designmachines.studio"
@@ -343,7 +343,7 @@
     {
       "name": "pipeline",
       "source": "./plugins/pipeline",
-      "version": "1.11.0",
+      "version": "1.12.0",
       "author": {
         "name": "Design Machines",
         "url": "https://designmachines.studio"

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,13 @@
 
 # Pipeline-generated feature artefacts (per-feature plans, briefs, manifests, prompts)
 plans/
+plans/*/baselines/
+plans/*/baselines-pre-fix/
+plans/*/baselines-post-fix/
+plans/*/screenshots/
+plans/*/prompts/
+plans/*/manifest.json
+plans/*/brainstorm.md
+.worktrees/
+.claude/ux-review/
+todos/

--- a/plugins/dm-review/.claude-plugin/plugin.json
+++ b/plugins/dm-review/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dm-review",
   "description": "Code review orchestrator that launches parallel review agents across accessibility, security, architecture, CSS, voice, and governance domains for Go+Templ+Datastar, Craft CMS, and Live Wires projects",
-  "version": "1.27.11",
+  "version": "1.28.0",
   "author": {
     "name": "Design Machines",
     "url": "https://designmachines.io"

--- a/plugins/dm-review/.codex-plugin/plugin.json
+++ b/plugins/dm-review/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dm-review",
-  "version": "1.27.11",
+  "version": "1.28.0",
   "description": "Code review orchestrator that launches parallel review agents across accessibility, security, architecture, CSS, voice, and governance domains for Go+Templ+Datastar, Craft CMS, and Live Wires projects",
   "author": {
     "name": "Design Machines",

--- a/plugins/dm-review/agents/review/ui-standards-reviewer.md
+++ b/plugins/dm-review/agents/review/ui-standards-reviewer.md
@@ -46,6 +46,32 @@ All recommendations MUST use Live Wires vocabulary. This is non-negotiable:
 
 If you don't know the Live Wires way to express a recommendation, say so and flag for manual review. Never recommend patterns that violate Live Wires philosophy.
 
+## Design Spec Awareness
+
+If your prompt includes a `## Design Spec Context` section (injected by the dm-review orchestrator when a design spec or brainstorm mockup exists), use it as your **PRIMARY evaluation baseline**.
+
+When a design spec exists:
+
+1. For each visual decision listed in the design spec, find the corresponding element on the rendered page
+2. Evaluate whether the rendered element matches the spec's description using SaaS benchmark standards
+3. If it DOES NOT match, flag as **P1** ("Implementation deviates from approved design: spec says [X], rendered shows [Y]")
+4. Spec deviations are MORE important than general SaaS benchmark violations. Evaluate spec compliance BEFORE SaaS benchmarking.
+
+When NO design spec exists, every finding MUST cite its rule source. Valid citation sources:
+
+- **CLAUDE.md section** -- e.g., "CLAUDE.md > Spacing System > baseline rhythm"
+- **Live Wires skill reference** -- e.g., "Live Wires layouts.md: use .stack not manual margin"
+- **Benchmark product + specific pattern** -- e.g., "Linear uses skeleton loaders for async table loading"
+- **Token name** -- e.g., "--line-2 spacing token exists for this value"
+- **WCAG criterion** -- e.g., "WCAG 2.4.7: focus must be visible"
+
+Output format for each finding:
+`"[element] violates [rule-source]: [citation]. Rendered: [X]. Expected: [Y]."`
+
+Findings without citations are INVALID and must be dropped. Do not report "this could be better" without citing what rule or standard defines "better."
+
+**Missing design spec warning:** If you are reviewing UI changes (template or CSS files in the diff) and no design spec was injected via `## Design Spec Context`, flag this as a **P2 process finding**: "No design spec available for UI review -- visual quality evaluation is heuristic-only, which has a documented history of missing implementation gaps. Consider running the pipeline assess phase to establish a design baseline before further UI work."
+
 ## Phase 1: Component Quality Audit
 
 Navigate to each affected page and evaluate components against SaaS standards:

--- a/plugins/dm-review/agents/review/ux-quality-reviewer.md
+++ b/plugins/dm-review/agents/review/ux-quality-reviewer.md
@@ -35,7 +35,18 @@ When a design spec exists:
 4. If it DOES NOT match, flag as **P1** ("Implementation deviates from approved design: spec says [X], rendered shows [Y]")
 5. Spec deviations are MORE important than general heuristic violations. A page can be "good enough" by general standards but still wrong if it doesn't match the approved design.
 
-When NO design spec exists, evaluate against general heuristics only (the existing behavior). Do not invent a spec -- evaluate what you see against best practices.
+When NO design spec exists, evaluate against general heuristics, but every finding MUST cite its rule source. Valid citation sources:
+
+- **CLAUDE.md section** -- e.g., "CLAUDE.md > Spacing System > baseline rhythm"
+- **Live Wires skill reference** -- e.g., "Live Wires layouts.md: use .stack not manual margin"
+- **Benchmark product + specific pattern** -- e.g., "Linear uses skeleton loaders for async table loading"
+- **Token name** -- e.g., "--line-2 spacing token exists for this value"
+- **WCAG criterion** -- e.g., "WCAG 2.4.7: focus must be visible"
+
+Output format for each finding:
+`"[element] violates [rule-source]: [citation]. Rendered: [X]. Expected: [Y]."`
+
+Findings without citations are INVALID and must be dropped. Do not report "this could be better" without citing what rule or standard defines "better." Do not invent a spec -- evaluate what you see against documented best practices and cite them.
 
 **Missing design spec warning:** If you are reviewing UI changes (template or CSS files in the diff) and no design spec was injected via `## Design Spec Context`, flag this as a **P2 process finding**: "No design spec available for UI review -- visual quality evaluation is heuristic-only, which has a documented history of missing implementation gaps (see `docs/post-mortems/2026-04-07-pipeline-ui-refinement-postmortem.md`). Consider running the pipeline assess phase to establish a design baseline before further UI work." This is a process finding, not a code finding -- it signals that the review's ability to catch visual quality issues is degraded.
 

--- a/plugins/dm-review/agents/review/visual-browser-tester.md
+++ b/plugins/dm-review/agents/review/visual-browser-tester.md
@@ -127,7 +127,20 @@ If your prompt includes a `## Design Spec Context` section (injected by the dm-r
 3. **Evaluate match:** Compare what the design spec describes against what the screenshot shows. State explicitly what you see.
 4. **Flag deviations as P1:** "Design spec says [X], rendered page shows [Y]." Implementation deviating from the approved design is a P1 finding. Every visual finding -- P1, P2, or P3 -- is tracked as a mandatory fix under the zero-deferral policy. See `plugins/dm-review/skills/review/references/severity-mapping.md` for the full escalation rules.
 
-If no design spec was injected, skip this phase. Do not invent a spec.
+If no design spec was injected, skip this phase for spec comparison. However, for ALL non-spec phases (responsive testing, interaction states, CSS compliance), every finding MUST cite its rule source. Valid citation sources:
+
+- **CLAUDE.md section** -- e.g., "CLAUDE.md > Spacing System > baseline rhythm"
+- **Live Wires skill reference** -- e.g., "Live Wires layouts.md: use .stack not manual margin"
+- **Benchmark product + specific pattern** -- e.g., "Linear uses skeleton loaders for async table loading"
+- **Token name** -- e.g., "--line-2 spacing token exists for this value"
+- **WCAG criterion** -- e.g., "WCAG 2.4.7: focus must be visible"
+
+Output format for each finding:
+`"[element] violates [rule-source]: [citation]. Rendered: [X]. Expected: [Y]."`
+
+Findings without citations are INVALID and must be dropped. Do not report "this could be better" without citing what rule or standard defines "better."
+
+**Missing design spec warning:** If you are reviewing UI changes (template or CSS files in the diff) and no design spec was injected via `## Design Spec Context`, flag this as a **P2 process finding**: "No design spec available for visual browser testing -- visual quality evaluation is heuristic-only. Consider running the pipeline assess phase to establish a design baseline before further UI work."
 
 This phase complements the ux-quality-reviewer's design spec awareness (which evaluates from a design quality perspective) by testing at the rendering level -- catching cases where CSS inheritance, layout context, or scheme color differences produce a different visual result than the code suggests.
 

--- a/plugins/live-wires/.claude-plugin/plugin.json
+++ b/plugins/live-wires/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "live-wires",
   "description": "Live Wires CSS framework for editorial websites with layout primitives and baseline rhythm",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "author": {
     "name": "Design Machines"
   },

--- a/plugins/live-wires/.codex-plugin/plugin.json
+++ b/plugins/live-wires/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "live-wires",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "Live Wires CSS framework for editorial websites with layout primitives and baseline rhythm",
   "author": {
     "name": "Design Machines"

--- a/plugins/live-wires/references/lint-rules.md
+++ b/plugins/live-wires/references/lint-rules.md
@@ -1,0 +1,93 @@
+# Live Wires Lint Rules
+
+These rules are consumed by the pipeline execution-orchestrator's livewires-lint step. Hard-fail rules block chunk commits. Warning rules are reported but don't block.
+
+The css-reviewer agent stays for nuanced cases the linter can't catch (layout choice evaluation, contextual token selection, whether a component is the right abstraction for the context, etc.).
+
+---
+
+## Hard-Fail Rules
+
+### LW-INLINE
+
+**Severity:** hard-fail
+**Applies to:** `.html`, `.templ`, `.twig`
+**Detection:** `grep -n 'style="' <files>`
+**What it catches:** Inline style attributes bypass the cascade and Live Wires token system. All styling must go through CSS classes, design tokens, or layout primitives.
+**QA shortcode:** LW-INLINE
+
+### LW-BASELINE
+
+**Severity:** hard-fail
+**Applies to:** `.css`
+**Detection:** `grep -nE '(margin|padding|gap):\s*[0-9]+(px|rem|em)' <files> | grep -vE ':\s*1px'`
+**What it catches:** Raw numeric spacing values instead of `--line-*` tokens. The `1px` exclusion allows border widths. All spacing (margin, padding, gap) must use baseline rhythm tokens (`var(--line-half)`, `var(--line-1)`, `var(--line-2)`, etc.).
+**QA shortcode:** LW-BASELINE
+
+### LW-INVENTED
+
+**Severity:** hard-fail
+**Applies to:** `.css`, `.html`, `.templ`, `.twig`
+**Detection:** Manual check -- extract class names from changed files and compare against the canonical inventory in `layouts.md`, `utilities.md`, and `components.md`. Classes not in the inventory are invented.
+**What it catches:** Ad-hoc class names that bypass the Live Wires design system. Use existing layout primitives (`.stack`, `.grid`, `.cluster`, `.sidebar`, `.center`, `.section`, `.box`, `.cover`, `.reel`), utility classes, or component classes. If a pattern repeats 3+ times, propose a new component through the proper channel.
+**QA shortcode:** LW-INVENTED
+
+### LW-BEM
+
+**Severity:** hard-fail
+**Applies to:** `.css`, `.html`, `.templ`, `.twig`
+**Detection:** `grep -nE '__' <files>`
+**What it catches:** BEM double-underscore naming (`block__element`). Live Wires uses single-dash modifiers for components (`button-accent`) and double-dash modifiers for layout primitives (`stack--compact`). BEM naming is not part of the system.
+**QA shortcode:** LW-BEM
+
+### LW-LAYER
+
+**Severity:** hard-fail
+**Applies to:** `.css`
+**Detection:** Check for CSS rules outside `@layer` blocks. Rules at the top level of a CSS file (not inside any `@layer`) violate the cascade layer architecture.
+**What it catches:** CSS rules outside the cascade layer system. All CSS must be placed in the appropriate `@layer` (settings, generic, elements, blocks, utilities, overrides). Unlayered CSS has unpredictable specificity.
+**QA shortcode:** LW-LAYER
+
+---
+
+## Warning Rules
+
+### LW-STATE
+
+**Severity:** warning
+**Applies to:** `.css`, `.html`, `.templ`, `.twig`
+**Detection:** `grep -nE '\.(is-|active|disabled)' <files>`
+**What it catches:** jQuery-era state classes (`.is-active`, `.active`, `.disabled`). Live Wires uses `data-state="active"` and `data-state="disabled"` attributes for state management.
+**QA shortcode:** LW-STATE
+
+### LW-HARDCODED-COLOR
+
+**Severity:** warning
+**Applies to:** `.css`
+**Detection:** `grep -nE '#[0-9a-fA-F]{3,8}|rgb\(|rgba\(|hsl\(|hsla\(' <files>`
+**What it catches:** Hardcoded color values instead of semantic tokens (`--color-accent`, `--color-bg`, `--color-fg`, `--ink`, `--paper`) or scheme classes (`.scheme-subtle`, `.scheme-accent`, `.scheme-dark`).
+**QA shortcode:** LW-HARDCODED-COLOR
+
+### LW-TRIPLET
+
+**Severity:** warning
+**Applies to:** `.css`
+**Detection:** Check for `font-size` declarations without matching `line-height` and `letter-spacing` (tracking) declarations in the same rule block.
+**What it catches:** Incomplete typography declarations. Live Wires requires the full triplet (size + line-height + tracking) or a utility class (`.text-2xl`) that bundles all three. Bare `font-size` declarations break vertical rhythm.
+**QA shortcode:** LW-TRIPLET
+
+### LW-LOGICAL
+
+**Severity:** warning
+**Applies to:** `.css`
+**Detection:** `grep -nE '(margin|padding|border)-(top|bottom|left|right):' <files>`
+**What it catches:** Physical CSS properties instead of logical properties. Use `margin-block-start` instead of `margin-top`, `padding-inline` instead of `padding-left`/`padding-right`, etc. Logical properties support RTL layouts and are the Live Wires convention.
+**QA shortcode:** LW-LOGICAL
+
+### LW-VARIANT
+
+**Severity:** warning
+**Applies to:** `.css`, `.html`, `.templ`, `.twig`
+**Detection:** Check modifier naming convention -- layout primitives use double-dash (`stack--compact`, `grid--3`), components use single-dash (`button-accent`, `card-flush`). Mismatched conventions are flagged.
+**What it catches:** Wrong modifier convention. Double-dash for layout primitive variants, single-dash for component variants. Mixing conventions makes the system harder to read.
+**QA shortcode:** LW-VARIANT

--- a/plugins/pipeline/.claude-plugin/plugin.json
+++ b/plugins/pipeline/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "pipeline",
   "description": "Autonomous feature development pipeline: assess current state, research context, generate execution prompts with dependency ordering, adversarial review (with ambiguity surfacing), orchestrate concurrent worktree execution with review-fix loops and surgical-change discipline, and deliver clean branches",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "author": {
     "name": "Design Machines",
     "url": "https://designmachines.io"

--- a/plugins/pipeline/.codex-plugin/plugin.json
+++ b/plugins/pipeline/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pipeline",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "description": "Autonomous feature development pipeline: assess current state, research context, generate execution prompts with dependency ordering, adversarial review (with ambiguity surfacing), orchestrate concurrent worktree execution with review-fix loops and surgical-change discipline, and deliver clean branches",
   "author": {
     "name": "Design Machines",

--- a/plugins/pipeline/agents/workflow/execution-orchestrator.md
+++ b/plugins/pipeline/agents/workflow/execution-orchestrator.md
@@ -929,6 +929,38 @@ Log cleanup stats: `Artifact cleanup: removed N ephemeral + M run-scoped files, 
 
 Mark `FINAL 4b. Artifact cleanup` complete.
 
+## Step 5c: Campaign State Write
+
+If the manifest contains a non-null `campaignSlug`:
+
+1. Read the final-requirements-crosscheck.md to extract covered and deferred requirements
+2. Read the final dm-review results for the findings summary
+3. Create `.campaign/` directory in the target repo root if absent
+4. Write `.campaign/state.json` following the schema at `${CLAUDE_PLUGIN_ROOT}/plugins/pipeline/references/campaign-state-schema.md`:
+
+```json
+{
+  "campaignSlug": "<from manifest>",
+  "lastFeatureSlug": "<feature slug>",
+  "branch": "<featureBranch>",
+  "commit": "<HEAD SHA>",
+  "completedAt": "<ISO 8601 now>",
+  "requirementsCovered": ["<from crosscheck>"],
+  "requirementsDeferred": ["<from crosscheck>"],
+  "dmReviewFindingsSummary": {
+    "p1": 0, "p2": 0, "p3": 0,
+    "mergeRecommendation": "<from Step 4>"
+  },
+  "nextSuggestedFeature": null
+}
+```
+
+5. Commit: `git commit -m "pipeline: write campaign state for <campaignSlug>"`
+
+If `campaignSlug` is null or absent, skip this step with: `"Campaign state: skipped (no campaignSlug in manifest)"`
+
+Mark `FINAL 4c. Campaign state write` complete.
+
 ## Step 6: Summary Report
 
 Present this report:

--- a/plugins/pipeline/agents/workflow/execution-orchestrator.md
+++ b/plugins/pipeline/agents/workflow/execution-orchestrator.md
@@ -467,6 +467,45 @@ If any check fails:
 
 Mark `[chunk-id] 5. Validate subagent output` complete.
 
+### 3e.5: Live Wires Lint Guard
+
+Check if any files modified by this chunk match `.html`, `.templ`, `.twig`, or `.css`. If none match, skip this step with: `"livewires-lint: skipped (no CSS/HTML/template files modified)"`
+
+If lint-applicable files exist:
+
+1. Resolve the Live Wires plugin root via dual-cache pattern:
+   ```bash
+   LW_ROOT=""
+   for CACHE in "$HOME/.claude/plugins/cache/depot/live-wires" "$HOME/.codex/plugins/cache/depot/live-wires"; do
+     LW_ROOT=$(ls -td "$CACHE"/*/ 2>/dev/null | head -1)
+     [ -n "$LW_ROOT" ] && break
+   done
+   ```
+
+2. Read lint rules from `${LW_ROOT}/references/lint-rules.md`
+
+3. Run all **hard-fail** grep checks on the chunk's modified files:
+   - **LW-INLINE:** `grep -n 'style="' <files>` on .html/.templ/.twig
+   - **LW-BASELINE:** `grep -nE '(margin|padding|gap):\s*[0-9]+(px|rem|em)' <files> | grep -vE ':\s*1px'` on .css
+   - **LW-BEM:** `grep -nE '__' <files>` on .css/.html/.templ/.twig
+   - **LW-LAYER:** Check for CSS rules outside `@layer` blocks on .css
+
+4. If ANY hard-fail rule triggers:
+   - Block the chunk commit
+   - Report violations with file:line references
+   - Dispatch a fix subagent (or fix directly) to resolve violations
+   - Re-run lint after fix
+   - Maximum 2 lint-fix iterations. After 2 failed attempts, escalate as P1 finding.
+
+5. Run all **warning** grep checks:
+   - **LW-STATE:** `grep -nE '\.(is-|active|disabled)' <files>`
+   - **LW-HARDCODED-COLOR:** `grep -nE '#[0-9a-fA-F]{3,8}|rgb\(|rgba\(' <files>` on .css
+   - **LW-LOGICAL:** `grep -nE '(margin|padding|border)-(top|bottom|left|right):' <files>` on .css
+
+6. Warning rules: report in the chunk receipt but don't block commit.
+
+Mark `[chunk-id] 5.5. Run livewires-lint` complete.
+
 ### 3f: Pre-Review Anti-Pattern Scan
 
 Before running dm-review, run a targeted grep for known anti-patterns in the chunk's changed files. dm-review agents review broadly; this step catches framework-specific mistakes they miss.

--- a/plugins/pipeline/agents/workflow/execution-orchestrator.md
+++ b/plugins/pipeline/agents/workflow/execution-orchestrator.md
@@ -335,14 +335,23 @@ For each chunk, complete ALL sub-steps. Do not skip any.
 
 ### 3a: Classify Chunk
 
-Examine the chunk's `filesToModify` list and classify:
+Read the chunk's `kind` field from the manifest and map to the orchestrator's classification labels:
+
+| Manifest `kind` | Orchestrator classification |
+|------------------|-----------------------------|
+| `ui` | UI |
+| `logic` | Logic |
+| `integration` | Integration |
+| `config` | Trivial |
+
+**Fallback (older manifests without `kind`):** If the `kind` field is absent, fall back to the runtime file-extension heuristic:
 
 - **UI:** Any file ends in `.templ`, `.twig`, `.html`, `.css`, or lives in a `pages/`, `templates/`, `views/` directory
 - **Logic:** Files end in `.go`, `.py`, `.ts`, `.php` and are handlers, services, or migrations -- no templates
 - **Trivial:** Only `.md`, `.json`, `.yaml`, `.toml`, config, or documentation files
 - **Integration:** The chunk title or prompt contains "wire," "integrate," "connect," or it modifies route files, `main.go`, or navigation templates
 
-Log: "Chunk [chunk-id] classified as: [type]"
+Log: "Chunk [chunk-id] classified as: [type] (source: manifest kind | file-extension heuristic)"
 
 Mark `[chunk-id] 1. Classify chunk` complete.
 
@@ -365,6 +374,27 @@ Before dispatching, apply input guardrails (per `plugins/dm-review/skills/review
 Mark `[chunk-id] 3. Apply input guardrails` complete.
 
 ### 3d: Dispatch Implementation Subagent
+
+**Executor routing:** Read the chunk's `executor` field from the manifest.
+
+**When `executor: codex` (or derived from `kind: logic` / `kind: config`):**
+
+1. Resolve the Codex plugin root using the dual-cache resolver pattern:
+   ```bash
+   CODEX_ROOT=""
+   for CACHE in "$HOME/.claude/plugins/cache/openai-codex/codex" "$HOME/.codex/plugins/cache/openai-codex/codex"; do
+     CODEX_ROOT=$(ls -td "$CACHE"/*/ 2>/dev/null | head -1)
+     [ -n "$CODEX_ROOT" ] && break
+   done
+   ```
+2. If `CODEX_ROOT` is found, invoke: `node "${CODEX_ROOT}/scripts/codex-companion.mjs" task --write "<chunk prompt>"`
+3. Parse task output for completion (exit code 0 + commit present in worktree)
+4. On success: proceed to eval gate (Step 3e onward)
+5. On failure (auth error, plugin not installed, timeout): log `"Codex unavailable for chunk [id], falling back to Claude execution."` and dispatch via the existing Claude subagent path below
+
+Do NOT use slash command invocation (`/codex:*`) -- use direct node CLI invocation. Slash commands are unreliable from subagent context.
+
+**When `executor: claude` (or field absent, or Codex fallback):**
 
 Launch a subagent with the full prompt content inlined (do not pass a file path), working directory set to the worktree, and this template:
 
@@ -522,7 +552,7 @@ Run `/codex:review` once. If zero findings, proceed. If findings, fix and re-run
 EVAL_GATE_PASSED: [chunk-id] | classification: [type] | iterations: [N] | findings_remaining: [N] | deferred: [N]
 ```
 
-This receipt is consumed by the merge step. Without it, merge is blocked.
+The `[type]` value uses the classification from the manifest's `kind` field when available (mapped per Step 3a), falling back to the runtime heuristic classification for older manifests. This receipt is consumed by the merge step. Without it, merge is blocked.
 
 Mark `[chunk-id] 7. Run evaluation gate` complete.
 

--- a/plugins/pipeline/agents/workflow/execution-orchestrator.md
+++ b/plugins/pipeline/agents/workflow/execution-orchestrator.md
@@ -148,6 +148,7 @@ FINAL 2. Requirements cross-check against original-prompt.md (write final-requir
 FINAL 3. Check manifest.noMergeOnCompletion and decide merge policy
 FINAL 4. Record session to ai-memory
 FINAL 4b. Artifact cleanup (write receipt, delete ephemeral/run-scoped artifacts)
+FINAL 4c. Campaign state write (when campaignSlug present)
 FINAL 5. Present summary report
 ```
 

--- a/plugins/pipeline/commands/pipeline.md
+++ b/plugins/pipeline/commands/pipeline.md
@@ -12,23 +12,28 @@ Full autonomous feature development pipeline. Takes an idea and delivers a clean
 
 Before starting, assess the feature scope and select the appropriate mode:
 
-**Simple mode** -- Use when the feature is small enough for a single context window:
+**Lean mode** -- Use when the feature is small enough for single-pass execution but still needs quality gates:
 
-- Touches fewer than 5 files
+- Touches fewer than 10 files (Opus can sustain coherent multi-file builds without chunking)
 - One logical concern (not multiple subsystems)
 - No dependency ordering needed (everything is sequential)
-- Can be implemented and reviewed in one pass
+- Can be implemented in one pass
 
-In simple mode, skip Phases 4-5 (chunking and adversarial review). Instead:
+Lean mode skips Phase 4 (chunking, manifest generation, prompts) and iterative review loops. It keeps Phase 5 adversarial review (runs once, non-iteratively) and the final dm-review pass (runs once, not in a loop). This preserves the generator/evaluator separation while eliminating chunking overhead.
+
+In lean mode:
 
 1. Run Phases 1-3 (assess, research, plan) normally
 2. Execute the plan as a single implementation pass (no manifest, no chunking)
-3. Run `/dm-review-loop` on the result
-4. Deliver
+3. Run Phase 5 adversarial review once (non-iteratively)
+4. Run dm-review once (non-iteratively, no loop)
+5. Deliver
+
+**Rationale:** Post-mortems documented that skipping adversarial review and dm-review compounds failures. "Structural criteria are necessary but not sufficient" (`docs/post-mortems/2026-04-07-pipeline-ui-refinement-postmortem.md`). "The pattern across all failures is: optimizing for speed over correctness" (`docs/post-mortems/2026-04-10-pipeline-visual-testing-postmortem.md`). Evidence-free assertions emerge when gates are skipped (`docs/post-mortems/2026-04-10-pipeline-visual-testing-postmortem.md`, lines 41-47).
 
 **Full mode** (default) -- Use for everything else. All phases execute in order.
 
-**How to decide:** If the plan from Phase 3 has more than one logical step that could be parallelized or that touches separate file groups, use full mode. If it's a single coherent change, use simple mode. When in doubt, use full mode.
+**How to decide:** If the plan from Phase 3 has more than one logical step that could be parallelized or that touches separate file groups, use full mode. If it's a single coherent change that still benefits from quality checks, use lean mode. When in doubt, use full mode.
 
 ## Model-Adaptive Complexity
 
@@ -36,7 +41,7 @@ The pipeline's complexity should match the model's capabilities. Some harness co
 
 **If running on Opus 4.6 (or newer):**
 
-- Chunking is optional for medium-complexity features (5-10 files). Opus can sustain coherent multi-hour builds without explicit sprint decomposition. Consider simple mode more aggressively.
+- Chunking is optional for medium-complexity features (5-10 files). Opus can sustain coherent multi-hour builds without explicit sprint decomposition. Consider lean mode more aggressively.
 - The adversarial review (Phase 5) is still valuable -- self-evaluation remains unreliable regardless of model capability.
 - dm-review-loop is still mandatory -- the separation of generator from evaluator is an architectural principle, not a model limitation.
 

--- a/plugins/pipeline/references/campaign-state-schema.md
+++ b/plugins/pipeline/references/campaign-state-schema.md
@@ -1,0 +1,53 @@
+# Campaign State Schema
+
+The campaign state file (`.campaign/state.json`) enables cross-session state persistence between the prototype repo (assembly) and the production repo (assembly-baseplate). It records the outcome of each pipeline run so the next planning session can pick up where the last one left off.
+
+## Schema
+
+```json
+{
+  "campaignSlug": "governance-v1",
+  "lastFeatureSlug": "proposal-voting",
+  "branch": "feature/proposal-voting",
+  "commit": "abc123def456789",
+  "completedAt": "2026-05-11T14:30:00Z",
+  "requirementsCovered": [
+    "Add vote handler and routes",
+    "Display vote counts on proposal page",
+    "Wire voting into proposal detail with Datastar"
+  ],
+  "requirementsDeferred": [
+    "Quorum threshold visualization"
+  ],
+  "dmReviewFindingsSummary": {
+    "p1": 0,
+    "p2": 1,
+    "p3": 3,
+    "mergeRecommendation": "APPROVE WITH FIXES"
+  },
+  "nextSuggestedFeature": "member-equity-tracking"
+}
+```
+
+## Field Definitions
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `campaignSlug` | string | Campaign identifier matching the manifest's `campaignSlug` field |
+| `lastFeatureSlug` | string | Feature slug of the most recent pipeline run |
+| `branch` | string | Feature branch name from the completed run |
+| `commit` | string | HEAD SHA of the feature branch at completion |
+| `completedAt` | string | ISO 8601 datetime of pipeline completion |
+| `requirementsCovered` | string[] | List of requirements addressed in this run (from final-requirements-crosscheck.md) |
+| `requirementsDeferred` | string[] | List of requirements not addressed, with reasons (from final-requirements-crosscheck.md) |
+| `dmReviewFindingsSummary` | object | Summary of final dm-review findings: `{ p1: number, p2: number, p3: number, mergeRecommendation: string }` |
+| `nextSuggestedFeature` | string or null | Suggested next feature from the campaign plan. Null if no campaign plan exists or no next feature is obvious. |
+
+## Read/Write Conventions
+
+- **Orchestrator writes** after a successful pipeline run (Step 5c in execution-orchestrator.md)
+- **Planning session reads** before writing the next master prompt -- uses `requirementsCovered`, `requirementsDeferred`, and `nextSuggestedFeature` to scope the next feature
+- **File location:** `.campaign/state.json` in the production repo root
+- **Create** the `.campaign/` directory if absent
+- **Overwrite** (not append) -- the latest run is the current state. Previous state is available via git history.
+- The file is committed to the production repo so both sides (prototype and production) can read it

--- a/plugins/pipeline/skills/promptcraft/SKILL.md
+++ b/plugins/pipeline/skills/promptcraft/SKILL.md
@@ -29,6 +29,19 @@ Read the plan and identify discrete chunks of work. A chunk is:
 3. Integration work (wiring things together) depends on the pieces it connects
 4. Test-only chunks are rare -- tests should live with their implementation chunk
 5. Configuration/deployment chunks run last
+6. After determining `filesToModify` for each chunk, classify its `kind` using the file-extension heuristic:
+   - `ui`: any `.templ`, `.twig`, `.html`, `.css`, or files in `pages/`, `templates/`, `views/`
+   - `logic`: `.go`, `.py`, `.ts`, `.php` handlers/services/migrations without templates
+   - `integration`: prompt contains wiring verbs ("wire," "integrate," "connect") OR modifies route files / `main.go`
+   - `config`: `.md`, `.json`, `.yaml`, `.toml`, docs
+
+   Then derive `executor` from `kind`:
+   - `logic` -> `codex`
+   - `config` -> `codex`
+   - `ui` -> `claude`
+   - `integration` -> `claude`
+
+   When a chunk's files span multiple categories, classify up: `ui` > `integration` > `logic` > `config`.
 
 ### Phase 2: Context Extraction
 
@@ -170,6 +183,24 @@ Write each prompt to `plans/<feature-slug>/prompts/<chunk-id>.md`. Prompts are T
 ### Phase 5: Manifest Generation
 
 Generate `plans/<feature-slug>/manifest.json` following the schema in `references/manifest-schema.md`. The manifest is a Tier 2 (run-scoped) artifact -- auto-deleted after successful execution.
+
+Each chunk object in the manifest MUST include `kind` and `executor` fields (classified in Phase 1, step 6). Example:
+
+```json
+{
+  "id": "01-database-migration",
+  "title": "Add vote columns to proposals table",
+  "prompt": "prompts/01-database-migration.md",
+  "level": 0,
+  "parallelGroup": null,
+  "dependsOn": [],
+  "filesToModify": ["internal/database/migrations/003_add_votes.sql"],
+  "companionSkills": ["assembly:development"],
+  "estimatedComplexity": "small",
+  "kind": "logic",
+  "executor": "codex"
+}
+```
 
 The manifest encodes:
 - Chunk ordering and dependencies

--- a/plugins/pipeline/skills/promptcraft/references/manifest-schema.md
+++ b/plugins/pipeline/skills/promptcraft/references/manifest-schema.md
@@ -13,6 +13,7 @@ The manifest file (`manifest.json`) encodes everything the execution-orchestrato
   "generatedAt": "2026-03-27T10:00:00Z",
   "overlapRisk": "low|medium|high",
   "noMergeOnCompletion": false,
+  "campaignSlug": null,
   "chunks": [
     {
       "id": "01-database-migration",
@@ -25,7 +26,9 @@ The manifest file (`manifest.json`) encodes everything the execution-orchestrato
         "internal/database/migrations/003_add_votes.sql"
       ],
       "companionSkills": ["assembly:development"],
-      "estimatedComplexity": "small"
+      "estimatedComplexity": "small",
+      "kind": "logic",
+      "executor": "codex"
     },
     {
       "id": "02a-vote-handler",
@@ -39,7 +42,9 @@ The manifest file (`manifest.json`) encodes everything the execution-orchestrato
         "internal/router/routes.go"
       ],
       "companionSkills": ["assembly:development"],
-      "estimatedComplexity": "medium"
+      "estimatedComplexity": "medium",
+      "kind": "logic",
+      "executor": "codex"
     },
     {
       "id": "02b-vote-display",
@@ -53,7 +58,9 @@ The manifest file (`manifest.json`) encodes everything the execution-orchestrato
         "internal/view/proposal/components.templ"
       ],
       "companionSkills": ["assembly:development", "live-wires:livewires"],
-      "estimatedComplexity": "medium"
+      "estimatedComplexity": "medium",
+      "kind": "ui",
+      "executor": "claude"
     },
     {
       "id": "03-integration",
@@ -67,7 +74,9 @@ The manifest file (`manifest.json`) encodes everything the execution-orchestrato
         "internal/view/proposal/show.templ"
       ],
       "companionSkills": ["assembly:development"],
-      "estimatedComplexity": "medium"
+      "estimatedComplexity": "medium",
+      "kind": "integration",
+      "executor": "claude"
     }
   ],
   "executionPlan": {
@@ -115,6 +124,7 @@ The `chunks` array is authoritative. The `executionPlan` object is a cached deno
 | `generatedAt` | string | ISO 8601 timestamp of manifest generation |
 | `overlapRisk` | enum | "low" (0-1 overlapping files), "medium" (2-4), "high" (5+) |
 | `noMergeOnCompletion` | boolean | Optional. Default `false`. When `true`, the execution-orchestrator runs every chunk and the final review, but does NOT merge the feature branch into `baseBranch`. The caller retains the branch for manual review. Use when you want pipeline automation without the final merge (e.g. review-first workflows, fix-pass runs that should keep the branch open for iteration). |
+| `campaignSlug` | string or null | Optional. Campaign identifier for cross-session state tracking. When present, the orchestrator writes `.campaign/state.json` after the run. When null or absent, campaign state is skipped. |
 
 ### Chunk
 
@@ -129,6 +139,8 @@ The `chunks` array is authoritative. The `executionPlan` object is a cached deno
 | `filesToModify` | string[] | Files this chunk will create or modify |
 | `companionSkills` | string[] | Skills to load in format "plugin:skill" |
 | `estimatedComplexity` | enum | "small" (1-2 files), "medium" (3-5 files), "large" (6+ files) |
+| `kind` | enum | Chunk type classification: `"ui"`, `"logic"`, `"integration"`, or `"config"`. Inferred from `filesToModify` during prompt generation. Used by the execution-orchestrator for evaluation depth and by the `executor` field for tool routing. See Classification Rules below. |
+| `executor` | enum | Execution tool: `"codex"` or `"claude"`. Derived from `kind`. Determines whether the chunk is dispatched to Codex (OpenAI) or Claude for implementation. See Executor Mapping below. |
 
 ### Execution Plan
 
@@ -143,6 +155,34 @@ The `chunks` array is authoritative. The `executionPlan` object is a cached deno
 | `parallelChunks` | number | Number of chunks that will run in parallel |
 | `sequentialChunks` | number | Number of chunks that must run sequentially |
 | `maxConcurrency` | number | Maximum simultaneous worktrees needed |
+
+## Classification Rules
+
+The `kind` field is inferred from `filesToModify` during prompt generation (Phase 1 of promptcraft):
+
+| Kind | Condition |
+|------|-----------|
+| `ui` | Any file ends in `.templ`, `.twig`, `.html`, `.css`, or lives in a `pages/`, `templates/`, `views/` directory |
+| `logic` | Files end in `.go`, `.py`, `.ts`, `.php` and are handlers, services, or migrations -- no templates |
+| `integration` | Prompt contains wiring verbs ("wire," "integrate," "connect") OR chunk modifies route files, `main.go`, or navigation templates |
+| `config` | Only `.md`, `.json`, `.yaml`, `.toml`, documentation, or configuration files |
+
+When a chunk's files span multiple categories, classify up: `ui` > `integration` > `logic` > `config`.
+
+## Executor Mapping
+
+The `executor` field is derived from `kind`:
+
+| Kind | Executor | Rationale |
+|------|----------|-----------|
+| `logic` | `codex` | Backend-only work doesn't need Claude's visual reasoning |
+| `config` | `codex` | Documentation and configuration edits are mechanical |
+| `ui` | `claude` | Visual verification and Live Wires judgment require Claude |
+| `integration` | `claude` | Cross-chunk wiring and route verification require Claude's broader context |
+
+## Graceful Fallback
+
+If Codex auth is absent or the Codex plugin is not installed, all chunks execute on Claude regardless of the `executor` field. The orchestrator logs: `"Codex unavailable for chunk [id], falling back to Claude execution."` and proceeds with the existing Claude subagent dispatch path. The `executor` field is advisory -- it never blocks execution.
 
 ## Naming Conventions
 


### PR DESCRIPTION
## Summary

- **Phase 6 executor classifier**: Manifest schema gains `kind` (ui/logic/integration/config) and `executor` (codex/claude) per chunk. Promptcraft infers both from `filesToModify`. Orchestrator routes execution to Codex companion for logic/config chunks with graceful Claude fallback.
- **Lean mode**: Renames "simple mode" -- skips chunking/manifest but keeps adversarial review + dm-review (both run once, non-iteratively). Cites post-mortems documenting gate-skipping failures.
- **Live Wires lint guard**: New `references/lint-rules.md` in live-wires plugin (5 hard-fail + 5 warning rules). Orchestrator runs lint step after every chunk edit, before commit. Hard-fails block commit and re-enter fix loop.
- **Campaign state**: Schema at `references/campaign-state-schema.md`. Orchestrator writes `.campaign/state.json` after runs when `campaignSlug` is in the manifest. Cross-repo read for planning sessions.
- **dm-review hybrid citation**: All 3 subjective agents (ux-quality-reviewer, ui-standards-reviewer, visual-browser-tester) now require rule-source citations when no design spec exists. Uncited findings are invalid. ui-standards-reviewer gains full Design Spec Awareness section.

## Test plan

- [x] `./tools/validate-composition.sh --all` passes (version sync, dual compat, search index, SKILL.md integrity)
- [ ] Verify `grep -ci "simple mode" plugins/pipeline/commands/pipeline.md` returns 0
- [ ] Verify `grep -c "Findings without citations are INVALID" plugins/dm-review/agents/review/{ux-quality,ui-standards,visual-browser}*.md` returns 3
- [ ] Verify `plugins/pipeline/references/campaign-state-schema.md` exists with complete JSON shape
- [ ] Verify `plugins/live-wires/references/lint-rules.md` has 5 hard-fail + 5 warning rules
- [ ] Run a test pipeline on a small feature to verify executor routing and lint guard integration

🤖 Generated with [Claude Code](https://claude.com/claude-code)