### PR TITLE
pipeline: HTML planning artifacts with JSON data islands

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -270,7 +270,7 @@
     {
       "name": "dm-review",
       "source": "./plugins/dm-review",
-      "version": "1.30.0",
+      "version": "1.30.1",
       "author": {
         "name": "Design Machines",
         "url": "https://designmachines.studio"
@@ -343,7 +343,7 @@
     {
       "name": "pipeline",
       "source": "./plugins/pipeline",
-      "version": "1.14.0",
+      "version": "1.15.0",
       "author": {
         "name": "Design Machines",
         "url": "https://designmachines.studio"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -275,6 +275,7 @@ Use sparingly. The full validator (`bash tools/validate-composition.sh --all`) r
 - Agent files are categorized by purpose: `review/` for code review agents, `workflow/` for automation agents.
 - Plugin JSON requires `name`, `description`, `version`, `author`, and `capabilities`. Optional fields include `keywords`, `repository`, `author.url`, `pluginDependencies`, and `optionalPluginDependencies`.
 - The marketplace manifest at `.claude-plugin/marketplace.json` must stay in sync with the actual plugin directories.
+- **Artifact format (pipeline planning phase):** the four pipeline planning artifacts -- `brainstorm`, `assessment`, `research`, `plan` -- are emitted as self-contained **HTML carrying a JSON data island** (a `<script type="application/json" id="pipeline-data">` block). The HTML links the target project's compiled CSS; the island is what downstream agents read (via `extract-json-island.sh`) instead of grepping prose. Agent-only handoffs (`original-prompt.md`, `prompts/*.md`, `manifest.json`, crosscheck) stay **Markdown/JSON**. Terminal status reports (dm-review reports, pipeline receipts, delivery reports) stay **inline/markdown** -- HTML buys nothing for a one-shot status summary. Templates and the rationale live in `plugins/pipeline/skills/promptcraft/references/templates/` and `docs/html-artifacts.md`.
 
 ## Pipeline Enforcement
 

--- a/docs/html-artifacts.md
+++ b/docs/html-artifacts.md
@@ -1,0 +1,148 @@
+# HTML Artifacts for the Pipeline Planning Phase
+
+The pipeline's four planning-phase artifacts — `brainstorm`, `assessment`,
+`research`, `plan` — are emitted as **self-contained HTML carrying a JSON data
+island**, not markdown. This document explains why, the template architecture,
+the data-island schema, the editable copy-back loop, the host-CSS detection
+ladder, and what stays out of HTML.
+
+## Why HTML
+
+As Opus runs grew to hours, plans ballooned to ~1000 lines of markdown and humans
+stopped reading them. A plan you don't read is a plan you don't steer. HTML is a
+richer review medium — inline mockups, rendered diagrams, editable decision
+tables — so the human actually engages with the spec. A good spec decides where
+the multi-hour, multi-dollar autonomous run spends its effort: you're a compute
+allocator now, and the planning artifact is the allocation.
+
+The catch: `plan`, `assessment`, and `brainstorm` are not purely human-facing.
+They are also the inter-agent handoff medium (promptcraft parses the plan,
+plan-adversary reviews it, the orchestrator reads the brainstorm). So each
+dual-purpose artifact is **one HTML file** that carries both halves: human-
+readable prose/widgets, plus a machine-readable `<script type="application/json"
+id="pipeline-data">` island. No dual emission, no drift. Agents read the island;
+humans read the page.
+
+## Scope
+
+| Artifact | Format | Path |
+|---|---|---|
+| `brainstorm` | HTML + island | `plans/<slug>/brainstorm.html` |
+| `assessment` | HTML + island | `plans/<slug>/assessment.html` |
+| `research` | HTML + island | `plans/<slug>/research.html` |
+| `plan` | HTML + island | `plans/<slug>/plan.html` |
+| dm-review report · pipeline receipt · delivery report | **inline / markdown (unchanged)** | — |
+| `original-prompt.md` · `prompts/NN-*.md` · `manifest.json` · crosscheck · facets · state files | **markdown / JSON (unchanged)** | — |
+
+Terminal status reports stay inline because HTML buys nothing for a one-shot
+summary that is read once and discarded. Agent-only handoffs stay markdown/JSON
+because no human reviews them in a browser.
+
+## Template architecture
+
+Templates live in `plugins/pipeline/skills/promptcraft/references/templates/`:
+
+```
+base.html                 # shell: head, host-CSS slot, landmarks, dark/print CSS
+sections/{assessment,research,brainstorm,plan}.html
+widgets/decision-table.html · widget-scripts.js · mockup-frame.html · diagram-mermaid.html
+data-island.html · baseline.css
+detect-host-css.sh · extract-json-island.sh · README.md
+```
+
+An emitting agent: (1) runs `detect-host-css.sh` to resolve the host stylesheet,
+(2) fills `sections/<kind>.html`, (3) splices in widgets and inlines
+`widget-scripts.js` when a decision-table is present, (4) builds the island from
+`data-island.html`, (5) substitutes `base.html`'s slots and writes the file. No
+build step. Full assembly recipe and slot list: `templates/README.md`.
+
+`base.html` accessibility baseline: `<header>/<nav>/<main>/<footer>` landmarks,
+skip-link first, `<meta name="color-scheme" content="light dark">`, a
+`prefers-color-scheme: dark` fallback, and a print stylesheet that hides nav and
+the copy buttons. Only `<script defer>` is used.
+
+## Data-island schema
+
+```jsonc
+// assessment.html — keyRequirements IS the cached requirements source
+{ "artifact": "assessment", "slug": "<slug>",
+  "keyRequirements": ["..."], "testPersonas": [{"name","id","role","useFor"}],
+  "recentLessons": ["..."], "baselineScreenshots": [{"route","viewport","path"}] }
+
+// research.html — synthesized brief; facet files stay markdown
+{ "artifact": "research", "slug": "<slug>",
+  "findings": ["..."], "references": [{"title","url|path","source"}] }
+
+// brainstorm.html — what promptcraft Phase 2.5 + the orchestrator extract
+{ "artifact": "brainstorm", "slug": "<slug>",
+  "visualDecisions": [{"area","decision","variant|token|treatment","rationale"}] }
+
+// plan.html (feature) — chunks map 1:1 to prompts/NN-<slug>.md
+{ "artifact": "plan", "slug": "<slug>",
+  "chunks": [{"n":"01","slug":"reader-service","scope","acceptance","deps":[]}],
+  "decisions": [{"id","decision","rationale","alternatives"}],
+  "requirementsCoverage": [{"requirement","chunk"}] }
+
+// plan.html (epic / high-level) — enumerates sibling sub-plans
+{ "artifact": "plan", "slug": "<slug>",
+  "subPlans": [{"n","slug","featureDir"}], "decisions": [...], "requirementsCoverage": [...] }
+```
+
+Never copy raw secrets (bearer tokens, session values) into `testPersonas` —
+record field names only (see the assess skill's Fixture Discovery redaction note).
+
+Downstream agents read the island instead of grepping prose:
+
+```bash
+bash plugins/pipeline/skills/promptcraft/references/templates/extract-json-island.sh \
+  plans/<slug>/plan.html | python3 -c 'import json,sys; print(len(json.load(sys.stdin)["chunks"]))'
+```
+
+## Editable copy-back loop
+
+Decision tables render with `contenteditable` cells and a **Copy table as JSON**
+button. The reviewer edits decisions in the browser, clicks Copy (the table
+serializes to island-shaped JSON on the clipboard), and pastes it back to Claude
+or into the artifact's `#pipeline-data` island. Each editable section sets
+`data-island-key="<key>"`; each `<th data-field="...">` names the JSON key, and a
+`data-list="true"` header serializes its column as an array. The serializer lives
+once in `widgets/widget-scripts.js`.
+
+## Host-CSS detection ladder
+
+`detect-host-css.sh` (run from the target project root) prints either a complete
+`<link rel="stylesheet">` or the literal `FALLBACK`. First match wins:
+
+1. `.dm-review-css` override file (single-line path) → verbatim
+2. Assembly: `go.mod` + `internal/assets/css/` → `/static/css/assembly.css`
+3. Live Wires: `package.json` `livewires` dep OR `src/css/0_settings/` → `/dist/livewires.css` (override via `livewires.config.json` `cssPath`)
+4. Tailwind: `tailwind.config.*` + `dist/output.css` → `/dist/output.css`
+5. Craft: `config/general.php` → `/css/site.css`
+6. else → `FALLBACK` (caller inlines `baseline.css` into a `<style>` block)
+
+## Plans directory convention
+
+Artifacts live in flat sibling **feature dirs** under `plans/` (the
+assembly-baseplate convention): `plans/<feature-slug>/{assessment,research,
+brainstorm,plan}.html` alongside `prompts/NN-<slug>.md`, `manifest.json`,
+`original-prompt.md`, and the `baselines/` / `prototype-evidence/` dirs. A
+**high-level/epic plan** is its own dir whose `prompts/<major>.<minor>-<slug>.md`
+seed sibling feature dirs; its `plan.html` uses the epic variant (`subPlans`).
+The pipeline does not auto-generate the epic→sub-plan tree — that orchestration
+stays a manual workflow layer; `plan.html` is merely layout-aware (it links
+siblings and maps chunks to `prompts/NN-*.md`).
+
+## Validation
+
+`./tools/validate-composition.sh` runs `validate_html_templates()`: `base.html`
+has every `{{...}}` slot, fragments have balanced comments/script tags, sections
+reference their island, and the two helpers are executable + `bash -n` clean.
+(We deliberately avoid `xmllint --html` — libxml2's HTML4 parser emits false
+errors on HTML5 semantic elements while still exiting 0.)
+
+## Notion sync
+
+Notion renders raw HTML as text, so the canonical artifact stays in-repo. When
+syncing a pipeline run to the depot manual or ops dashboard, upload screenshots
+of the rendered HTML and/or a short markdown summary — do not paste the HTML
+source.

--- a/plugins/dm-review/.claude-plugin/plugin.json
+++ b/plugins/dm-review/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dm-review",
   "description": "Code review orchestrator that launches parallel review agents across accessibility, security, architecture, CSS, voice, and governance domains for Go+Templ+Datastar, Craft CMS, and Live Wires projects",
-  "version": "1.30.0",
+  "version": "1.30.1",
   "author": {
     "name": "Design Machines",
     "url": "https://designmachines.io"

--- a/plugins/dm-review/.codex-plugin/plugin.json
+++ b/plugins/dm-review/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dm-review",
-  "version": "1.30.0",
+  "version": "1.30.1",
   "description": "Code review orchestrator that launches parallel review agents across accessibility, security, architecture, CSS, voice, and governance domains for Go+Templ+Datastar, Craft CMS, and Live Wires projects",
   "author": {
     "name": "Design Machines",

--- a/plugins/dm-review/skills/review/SKILL.md
+++ b/plugins/dm-review/skills/review/SKILL.md
@@ -213,7 +213,7 @@ Check for design specifications that browser-based agents should evaluate agains
 1. Look for spec files in order of specificity:
    - `docs/superpowers/specs/*.md` -- formal design specs (use most recently modified)
    - `.superpowers/brainstorm/` -- brainstorm mockups (HTML files with visual decisions as inline styles)
-   - `plans/*/brainstorm.md` -- pipeline brainstorm output
+   - `plans/*/brainstorm.html` -- pipeline brainstorm output (HTML with a `visualDecisions` JSON island)
 2. If ANY spec files are found, read them and extract a structured summary:
    - Visual decisions (layout choices, spacing tokens, component variants, color usage)
    - Approved design patterns (specific markup structures, class choices)

--- a/plugins/pipeline/.claude-plugin/plugin.json
+++ b/plugins/pipeline/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "pipeline",
   "description": "Autonomous feature development pipeline: assess current state, research context, generate execution prompts with dependency ordering, adversarial review (with ambiguity surfacing), orchestrate concurrent worktree execution with review-fix loops and surgical-change discipline, and deliver clean branches",
-  "version": "1.14.0",
+  "version": "1.15.0",
   "author": {
     "name": "Design Machines",
     "url": "https://designmachines.io"

--- a/plugins/pipeline/.codex-plugin/plugin.json
+++ b/plugins/pipeline/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pipeline",
-  "version": "1.14.0",
+  "version": "1.15.0",
   "description": "Autonomous feature development pipeline: assess current state, research context, generate execution prompts with dependency ordering, adversarial review (with ambiguity surfacing), orchestrate concurrent worktree execution with review-fix loops and surgical-change discipline, and deliver clean branches",
   "author": {
     "name": "Design Machines",

--- a/plugins/pipeline/agents/workflow/execution-orchestrator.md
+++ b/plugins/pipeline/agents/workflow/execution-orchestrator.md
@@ -276,7 +276,7 @@ ENTRIES=(
   'plans/*/screenshots/'
   'plans/*/prompts/'
   'plans/*/manifest.json'
-  'plans/*/brainstorm.md'
+  'plans/*/brainstorm.html'
   '.worktrees/'
   '.claude/ux-review/'
   'todos/'
@@ -624,7 +624,7 @@ For UI and Integration chunks, verify the rendered output in a browser against t
 
 Before taking screenshots, check for design specifications:
 
-1. `plans/<feature-slug>/brainstorm.md` — pipeline brainstorm output
+1. `plans/<feature-slug>/brainstorm.html` — pipeline brainstorm output (read the `visualDecisions` island with `${CLAUDE_PLUGIN_ROOT}/plugins/pipeline/skills/promptcraft/references/templates/extract-json-island.sh`)
 2. `docs/superpowers/specs/*.md` — formal design specs (use most recent)
 3. `.superpowers/brainstorm/` — brainstorm mockups (HTML files with inline styles)
 
@@ -927,7 +927,7 @@ rm -rf plans/<feature-slug>/baselines/ plans/<feature-slug>/baselines-pre-fix/ p
 
 ```bash
 rm -rf plans/<feature-slug>/prompts/
-rm -f plans/<feature-slug>/manifest.json plans/<feature-slug>/brainstorm.md
+rm -f plans/<feature-slug>/manifest.json plans/<feature-slug>/brainstorm.html
 ```
 
 On failure, preserve Tier 2 for debugging. Log: `Artifact cleanup (partial -- run failed): preserved prompts and manifest for debugging.`

--- a/plugins/pipeline/agents/workflow/plan-adversary.md
+++ b/plugins/pipeline/agents/workflow/plan-adversary.md
@@ -17,10 +17,12 @@ Terse. No preamble, no narrative framing, no "thank you for the plan" sentiments
 
 You receive:
 
-1. A plan file (markdown)
+1. A plan file (`plan.html` carrying a `#pipeline-data` JSON island). Read its structured `chunks`/`decisions`/`requirementsCoverage` with `${CLAUDE_PLUGIN_ROOT}/plugins/pipeline/skills/promptcraft/references/templates/extract-json-island.sh plans/<feature-slug>/plan.html`, and read the rendered prose for narrative context. (A hand-written markdown plan may be passed when invoked outside `/pipeline`.)
 2. A set of execution prompts (markdown files in a prompts/ directory)
 3. A manifest.json with dependency ordering
 4. An `original-prompt.md` with the user's verbatim input and extracted Key Requirements
+
+Your own findings output (the `## Output Format` per-finding blocks) stays **markdown** -- it is returned to the caller, not a human-facing artifact.
 
 ## Review Perspectives
 
@@ -112,7 +114,7 @@ When the plan targets Assembly (`assembly-baseplate` or `internal/fixtures/`), v
 
 For each chunk classified as UI or Integration, verify the prompts are set up for visual quality enforcement:
 
-- [ ] Does the chunk have a `## Visual References` section citing a design spec, brainstorm mockup, or original prompt's visual requirements? If no visual baseline exists, flag as **IMPORTANT**: "UI chunk [chunk-id] has no visual baseline to verify against -- visual quality will be evaluated by heuristics only, which has a documented history of missing implementation gaps."
+- [ ] Does the chunk have a `## Visual References` section citing a design spec, the `brainstorm.html` `visualDecisions` island, or the original prompt's visual requirements? If no visual baseline exists, flag as **IMPORTANT**: "UI chunk [chunk-id] has no visual baseline to verify against -- visual quality will be evaluated by heuristics only, which has a documented history of missing implementation gaps."
 - [ ] Does the chunk have `### Visual Acceptance Criteria` with at least 2 criteria describing visual IMPRESSIONS (not just structural class names)? "Button uses `button--outline-danger` class" is structural. "Block and Abstain buttons are visually smaller and lighter than the main position buttons" is an impression. Both are needed; impressions catch the gap between "correct class" and "correct visual effect."
 - [ ] Does each visual acceptance criterion include a browser-verifiable test? A criterion is browser-verifiable if it can be confirmed by screenshot comparison or getComputedStyle extraction. "Code is clean" is not verifiable. "Button has font-size < 1rem per getComputedStyle" is verifiable.
 - [ ] For chunks modifying the same visual area (e.g., sidebar, form, card), do the visual criteria align across chunks? One chunk shouldn't say "prominent headings" while another says "subdued headings."

--- a/plugins/pipeline/commands/pipeline-assess.md
+++ b/plugins/pipeline/commands/pipeline-assess.md
@@ -18,9 +18,9 @@ If the input above is empty, ask: "What area should I assess? Give me a feature 
 
 1. Load the assess skill from `plugins/pipeline/skills/assess/SKILL.md`
 2. Execute the full assessment protocol (code + UX in parallel)
-3. Save the Assessment Brief to `plans/assessment-<area-slug>.md`
+3. Save the Assessment Brief to `plans/<area-slug>/assessment.html` (HTML + data island, per the assess skill's Artifact Format)
 4. Present the brief to the user
 
 ## After Assessment
 
-Ask: "Assessment saved to `plans/assessment-<slug>.md`. Want to run the full pipeline from here (`/pipeline`), or use this brief as context for your own planning?"
+Ask: "Assessment saved to `plans/<slug>/assessment.html` (open it in a browser to review). Want to run the full pipeline from here (`/pipeline`), or use this brief as context for your own planning?"

--- a/plugins/pipeline/commands/pipeline.md
+++ b/plugins/pipeline/commands/pipeline.md
@@ -105,6 +105,21 @@ Create this ledger with TodoWrite at the start. Update it as you complete each p
 
 Mark each item as you complete it. Do not mark a GATE as complete until AskUserQuestion has returned a response from the user. If you find yourself proceeding past a GATE without an AskUserQuestion response, you have violated the gate.
 
+## Artifact Format (planning phase)
+
+The four planning-phase artifacts -- **brainstorm, assessment, research, plan** -- are written as self-contained **HTML carrying a JSON data island**, not markdown. Each links the target project's compiled CSS so it renders in the project's own skin, and embeds a `<script type="application/json" id="pipeline-data">` island that later phases read instead of grepping prose.
+
+At every "Save the ..." step below, emit HTML this way:
+
+1. Detect host CSS from the project root:
+   ```bash
+   HOST_CSS_LINK=$(bash "${CLAUDE_PLUGIN_ROOT}/skills/promptcraft/references/templates/detect-host-css.sh" 2>/dev/null || echo "FALLBACK")
+   ```
+   On `FALLBACK`, inline `templates/baseline.css` into a `<style>` block instead of using a `<link>`.
+2. Assemble `templates/base.html` + `templates/sections/<kind>.html` + any widgets + the data island, per `templates/README.md`. Write the result to `plans/<feature-slug>/<kind>.html`.
+
+Agent-only handoffs (`original-prompt.md`, `prompts/*.md`, `manifest.json`, `final-requirements-crosscheck.md`) stay markdown/JSON. Terminal status reports (delivery report, receipt) stay inline/markdown -- they are NOT HTML. Read an artifact's structured data downstream with `templates/extract-json-island.sh <file.html>`.
+
 ## Feature Input
 
 <feature_input> #$ARGUMENTS </feature_input>
@@ -121,7 +136,7 @@ Do not proceed without a clear feature description.
 
 ### Re-read discipline (token budget)
 
-`original-prompt.md` is read canonically ONCE in Phase 1 (Assessment). Phase 1 extracts a `Key Requirements` list and saves it into `plans/<feature-slug>/assessment.md`. After that, Phases 3, 4, and 7 reference the cached Key Requirements list from the assessment brief, NOT the full original-prompt.md.
+`original-prompt.md` is read canonically ONCE in Phase 1 (Assessment). Phase 1 extracts a `Key Requirements` list and saves it into the `keyRequirements` data island of `plans/<feature-slug>/assessment.html`. After that, Phases 3, 4, and 7 reference the cached Key Requirements list from the assessment island (read it with `templates/extract-json-island.sh plans/<feature-slug>/assessment.html`), NOT the full original-prompt.md.
 
 **When to re-read original-prompt.md anyway:**
 
@@ -181,7 +196,7 @@ Routine template changes (adding a column, fixing a label, wiring an existing pa
 1. Invoke the `superpowers:brainstorming` skill BEFORE any pipeline phase
 2. Pass the original prompt as context for the brainstorming session
 3. Wait for the brainstorming process to complete (design doc written, user approved)
-4. Save the brainstorming output to `plans/<feature-slug>/brainstorm.md`
+4. Save the brainstorming output to `plans/<feature-slug>/brainstorm.html` (per **Artifact Format** above; `visualDecisions` island)
 5. Use both the original prompt AND the brainstorming spec as input to Phase 1
 
 This is NOT optional. The brainstorming skill's hard gate ("Do NOT invoke any implementation skill until you have presented a design and the user has approved it") applies to the pipeline. The pipeline IS an implementation skill. "Having a reference pattern to copy" is NOT a reason to skip brainstorming -- the brainstorm explores whether that pattern is the right choice.
@@ -198,7 +213,7 @@ Load the assess skill from `plugins/pipeline/skills/assess/SKILL.md`.
 
 1. Determine the codebase area affected by the feature
 2. Run the pre-plan assessment (code + UX in parallel)
-3. Save the Assessment Brief to `plans/<feature-slug>/assessment.md`
+3. Save the Assessment Brief to `plans/<feature-slug>/assessment.html` (per **Artifact Format** above). The cached Key Requirements go in the `keyRequirements` island.
 4. Present key findings to the user
 
 Mark ledger item 2 as complete.
@@ -215,10 +230,10 @@ You MUST run this phase even if you think you already have enough context. Resea
 
 1. Pass the feature description and Assessment Brief to the research orchestrator
 2. Dispatch parallel research agents across all available sources (ai-memory, RAG, domain plugins, web, codebase)
-3. Save the Research Brief to `plans/<feature-slug>/research.md`
+3. Save the Research Brief to `plans/<feature-slug>/research.html` (per **Artifact Format** above; `findings`/`references` island)
 4. Present the Research Brief summary to the user
 
-**Verification:** The Research Brief file MUST exist on disk before proceeding. Run `ls plans/<feature-slug>/research.md` to confirm.
+**Verification:** The Research Brief file MUST exist on disk before proceeding. Run `ls plans/<feature-slug>/research.html` to confirm.
 
 Mark ledger item 4 as complete.
 
@@ -234,13 +249,13 @@ Create the implementation plan. Two options:
 
 **Option B:** If not available, create the plan directly:
 
-1. Use the cached Key Requirements from `plans/<feature-slug>/assessment.md` (re-read original-prompt.md only if the user gave feedback since Phase 1)
-2. Break the feature into logical implementation steps
+1. Use the cached Key Requirements from the `keyRequirements` island of `plans/<feature-slug>/assessment.html` (re-read original-prompt.md only if the user gave feedback since Phase 1)
+2. Break the feature into logical implementation steps. Each step is a chunk that maps to `prompts/NN-<slug>.md` -- record them in the plan's `chunks` island.
 3. Identify file paths, patterns, and dependencies
 4. Write acceptance criteria for each step
-5. Save to `plans/<feature-slug>/plan.md`
+5. Save to `plans/<feature-slug>/plan.html` (per **Artifact Format** above; `chunks`/`decisions`/`requirementsCoverage` island). For a high-level/epic plan that decomposes into sibling feature dirs, use the epic variant (`subPlans` island).
 
-**Verification:** The plan file MUST exist on disk before proceeding. Run `ls plans/<feature-slug>/plan.md` to confirm.
+**Verification:** The plan file MUST exist on disk before proceeding. Run `ls plans/<feature-slug>/plan.html` to confirm.
 
 **Plan self-review (before presenting):** Re-read your own plan and check:
 
@@ -253,7 +268,7 @@ If any check fails, fix the plan before presenting it.
 
 Mark ledger item 6 as complete.
 
-**GATE (ledger item 7):** You MUST stop here and use AskUserQuestion to ask: "Plan ready at `plans/<feature-slug>/plan.md`. Review it and let me know when to generate execution prompts." Do NOT proceed by generating an answer to your own question.
+**GATE (ledger item 7):** You MUST stop here and use AskUserQuestion to ask: "Plan ready at `plans/<feature-slug>/plan.html` (open it in a browser to review and edit decision tables inline). Let me know when to generate execution prompts." Do NOT proceed by generating an answer to your own question.
 
 Mark item 7 when AskUserQuestion returns the user's response.
 
@@ -261,8 +276,8 @@ Mark item 7 when AskUserQuestion returns the user's response.
 
 Load the promptcraft skill from `plugins/pipeline/skills/promptcraft/SKILL.md`.
 
-1. Use the cached Key Requirements from `plans/<feature-slug>/assessment.md` (re-read original-prompt.md only if the user gave feedback since Phase 1)
-2. Decompose the plan into chunks
+1. Use the cached Key Requirements from the `keyRequirements` island of `plans/<feature-slug>/assessment.html` (re-read original-prompt.md only if the user gave feedback since Phase 1)
+2. Decompose the plan into chunks (read the plan's `chunks` island with `templates/extract-json-island.sh plans/<feature-slug>/plan.html`)
 3. Extract context for each chunk from the Assessment and Research Briefs
 4. Perform overlap analysis
 5. Generate self-contained execution prompts
@@ -273,7 +288,7 @@ Load the promptcraft skill from `plugins/pipeline/skills/promptcraft/SKILL.md`.
 
 Mark ledger item 8 as complete.
 
-**Requirements coverage check (ledger item 9):** Read the cached Key Requirements from `plans/<feature-slug>/assessment.md`. For each requirement, verify at least one chunk's acceptance criteria covers it. Present the coverage map:
+**Requirements coverage check (ledger item 9):** Read the cached Key Requirements from the `keyRequirements` island of `plans/<feature-slug>/assessment.html`. For each requirement, verify at least one chunk's acceptance criteria covers it. Present the coverage map:
 
 ```
 Requirements Coverage:
@@ -366,7 +381,7 @@ If ANY chunk in the manifest was classified as UI or Integration, you MUST visua
 If all chunks were Logic-only, skip to the requirements cross-check.
 
 1. **Discover the design spec.** Check these locations in order:
-   - `plans/<feature-slug>/brainstorm.md`
+   - `plans/<feature-slug>/brainstorm.html` (read the `visualDecisions` island with `templates/extract-json-island.sh`)
    - `docs/superpowers/specs/*.md` (most recently modified)
    - `.superpowers/brainstorm/` (HTML mockups)
    - If none exist, use the original prompt's visual requirements as the baseline.
@@ -402,7 +417,7 @@ Assertions without evidence are findings, not verifications. "Verified: sidebar 
 
 If you cannot provide evidence (no browser tools), you MUST state: "Visual verification incomplete -- no browser tools available. The following requirements could not be visually verified: [list]." This is NOT a passing verification.
 
-**Requirements cross-check (ledger item 13):** Use the cached Key Requirements from `plans/<feature-slug>/assessment.md`. (At this phase, re-read original-prompt.md is justified ONLY if the user has layered feedback on during execution -- otherwise the cache is authoritative.) Verify every Key Requirement was addressed in the final branch. Each entry requires an evidence type:
+**Requirements cross-check (ledger item 13):** Use the cached Key Requirements from the `keyRequirements` island of `plans/<feature-slug>/assessment.html`. (At this phase, re-read original-prompt.md is justified ONLY if the user has layered feedback on during execution -- otherwise the cache is authoritative.) Verify every Key Requirement was addressed in the final branch. Each entry requires an evidence type:
 
 ```text
 Requirements Cross-Check:
@@ -450,7 +465,7 @@ Options:
 **If option 3 (done):** Run full cleanup per the artifact lifecycle policy:
 1. Ensure `plans/<feature-slug>/receipt.md` exists (written by orchestrator Step 5b). If missing, write it now.
 2. Delete Tier 1 + 2 artifacts (if not already cleaned by orchestrator).
-3. Delete Tier 3 artifacts: `rm -f plans/<slug>/original-prompt.md assessment.md research.md plan.md final-requirements-crosscheck.md`
+3. Delete Tier 3 artifacts: `rm -f plans/<slug>/original-prompt.md assessment.html research.html plan.html final-requirements-crosscheck.md`
 4. Only `receipt.md` remains in `plans/<feature-slug>/`.
 5. Report: `Plan directory cleaned. Receipt retained at plans/<slug>/receipt.md.`
 

--- a/plugins/pipeline/references/artifact-lifecycle.md
+++ b/plugins/pipeline/references/artifact-lifecycle.md
@@ -23,11 +23,11 @@ Governs all files that pipeline and dm-review plugins create in downstream repos
 | `screenshots/*.png` | 1 | Phase 7 verification screenshots |
 | `prompts/*.md` | 2 | Chunk execution prompts consumed by orchestrator |
 | `manifest.json` | 2 | Chunk ordering and dependency metadata |
-| `brainstorm.md` | 2 | Design decisions (key choices captured in plan.md) |
-| `original-prompt.md` | 3 | User's verbatim input — ground truth |
-| `assessment.md` | 3 | Current state report with cached Key Requirements |
-| `research.md` | 3 | Findings from research phase |
-| `plan.md` | 3 | Implementation plan |
+| `brainstorm.html` | 2 | Design decisions (HTML + `visualDecisions` island) |
+| `original-prompt.md` | 3 | User's verbatim input — ground truth (markdown) |
+| `assessment.html` | 3 | Current state report (HTML + cached Key Requirements island) |
+| `research.html` | 3 | Findings from research phase (HTML + island) |
+| `plan.html` | 3 | Implementation plan (HTML + `chunks`/`decisions` island) |
 | `final-requirements-crosscheck.md` | 3 | Delivery proof with evidence types |
 | `receipt.md` | 3 | Compact post-cleanup summary (written by Step 5b) |
 
@@ -61,7 +61,7 @@ Governs all files that pipeline and dm-review plugins create in downstream repos
 
 1. Write `plans/<feature-slug>/receipt.md`
 2. Delete all Tier 1 files: `rm -rf plans/<slug>/baselines/ baselines-pre-fix/ baselines-post-fix/ screenshots/`
-3. Delete all Tier 2 files: `rm -rf plans/<slug>/prompts/` and `rm -f plans/<slug>/manifest.json plans/<slug>/brainstorm.md`
+3. Delete all Tier 2 files: `rm -rf plans/<slug>/prompts/` and `rm -f plans/<slug>/manifest.json plans/<slug>/brainstorm.html`
 4. Report: `Artifact cleanup: removed N files, retained M feature-scoped files`
 
 ### On failed pipeline run (Step 5b)

--- a/plugins/pipeline/references/gitignore-template.md
+++ b/plugins/pipeline/references/gitignore-template.md
@@ -12,7 +12,7 @@ plans/*/baselines-post-fix/
 plans/*/screenshots/
 plans/*/prompts/
 plans/*/manifest.json
-plans/*/brainstorm.md
+plans/*/brainstorm.html
 .worktrees/
 
 # dm-review artifacts
@@ -24,10 +24,10 @@ todos/
 
 Feature-scoped files (Tier 3) inside `plans/<feature>/` remain trackable:
 
-- `original-prompt.md` — user's verbatim input
-- `assessment.md` — current state report
-- `research.md` — research findings
-- `plan.md` — implementation plan
+- `original-prompt.md` — user's verbatim input (markdown)
+- `assessment.html` — current state report (HTML + island)
+- `research.html` — research findings (HTML + island)
+- `plan.html` — implementation plan (HTML + island)
 - `final-requirements-crosscheck.md` — delivery proof
 - `receipt.md` — post-cleanup summary
 
@@ -45,7 +45,7 @@ ENTRIES=(
   'plans/*/screenshots/'
   'plans/*/prompts/'
   'plans/*/manifest.json'
-  'plans/*/brainstorm.md'
+  'plans/*/brainstorm.html'
   '.worktrees/'
   '.claude/ux-review/'
   'todos/'

--- a/plugins/pipeline/skills/assess/SKILL.md
+++ b/plugins/pipeline/skills/assess/SKILL.md
@@ -105,7 +105,7 @@ Many codebases ship with dev-time auth bypasses or persona-switching helpers. Di
 
 Protocol:
 
-1. **Auth middleware scan:** grep the project's auth middleware (common locations: `internal/handlers/middleware.go`, `backend/auth/*.go`, `app/Http/Middleware/*.php`, `config/authentication.*`) for keywords: `cookie`, `X-Test-User`, `Bearer`, `session`, `impersonate`. **Extract the header/cookie NAME only. Redact values.** If a matched line contains `=<literal>`, `: "<literal>"`, `Bearer <literal>`, or any hardcoded token, flag the file for manual review and record only the field name in the Assessment Brief. Never copy raw matched lines into `plans/<feature-slug>/assessment.md` -- dev-mode middleware sometimes hardcodes bearer tokens or session secrets that must not propagate downstream.
+1. **Auth middleware scan:** grep the project's auth middleware (common locations: `internal/handlers/middleware.go`, `backend/auth/*.go`, `app/Http/Middleware/*.php`, `config/authentication.*`) for keywords: `cookie`, `X-Test-User`, `Bearer`, `session`, `impersonate`. **Extract the header/cookie NAME only. Redact values.** If a matched line contains `=<literal>`, `: "<literal>"`, `Bearer <literal>`, or any hardcoded token, flag the file for manual review and record only the field name in the Assessment Brief. Never copy raw matched lines into `plans/<feature-slug>/assessment.html` (neither the rendered Test Personas section nor the `testPersonas` data island) -- dev-mode middleware sometimes hardcodes bearer tokens or session secrets that must not propagate downstream.
 2. **Seed data scan:** grep seed files (`seeds/`, `fixtures/`, `db/seed.*`, `internal/fixtures/*/seed.go`) for user/member IDs and role names. Collect 2-3 representative personas per role.
 3. **Test helper scan:** grep `tests/`, `_test.go`, `spec/` for patterns like `loginAs(`, `asUser(`, `setCurrentUser(` to find helper functions that scripts/tests use to switch identity.
 
@@ -144,6 +144,8 @@ If no `tasks/lessons.md` exists, log `prior lessons check: no lessons file -- sk
 
 Combine both reports into a single **Assessment Brief**. When running as part of `/pipeline`, the Assessment Brief also serves as the cached source of truth for the Key Requirements list (extracted from `original-prompt.md` once, referenced many times across phases).
 
+The brief is written as **HTML with a JSON data island**, not markdown -- assemble `templates/base.html` + `templates/sections/assessment.html` per `${CLAUDE_PLUGIN_ROOT}/plugins/pipeline/skills/promptcraft/references/templates/README.md`. The content outline below maps to the section's slots; the `keyRequirements`, `testPersonas`, `recentLessons`, and `baselineScreenshots` arrays also populate the `#pipeline-data` island so later phases read them with `extract-json-island.sh` instead of grepping prose.
+
 ```markdown
 # Assessment: [Area Name]
 
@@ -175,7 +177,7 @@ Combine both reports into a single **Assessment Brief**. When running as part of
 - [What to leave alone]
 ```
 
-Save the brief to `plans/<feature-slug>/assessment.md` in the target project. When running standalone via `/pipeline-assess`, the slug may be the area name instead of a feature slug.
+Save the brief to `plans/<feature-slug>/assessment.html` in the target project (detect host CSS first; on `FALLBACK` inline `templates/baseline.css`). When running standalone via `/pipeline-assess`, the slug may be the area name instead of a feature slug.
 
 ### Phase 4: Handoff
 

--- a/plugins/pipeline/skills/promptcraft/SKILL.md
+++ b/plugins/pipeline/skills/promptcraft/SKILL.md
@@ -9,12 +9,22 @@ Transform a plan into self-contained execution prompts with overlap-aware depend
 
 ## Input
 
-1. **Plan file** -- A markdown plan (from `/workflows:plan`, superpowers writing-plans, or hand-written)
-2. **Original prompt** -- The user's verbatim input saved at `plans/<feature-slug>/original-prompt.md` with extracted Key Requirements
-3. **Research Brief** (optional) -- Output from the research skill
-4. **Assessment Brief** (optional) -- Output from the assess skill
+1. **Plan file** -- A pipeline `plan.html` carrying a `#pipeline-data` JSON island (`chunks`, `decisions`, `requirementsCoverage`). When invoked standalone on a hand-written markdown plan, parse the prose directly; within `/pipeline` the plan is HTML.
+2. **Original prompt** -- The user's verbatim input saved at `plans/<feature-slug>/original-prompt.md` with extracted Key Requirements (stays markdown)
+3. **Research Brief** (optional) -- `research.html` from the research skill
+4. **Assessment Brief** (optional) -- `assessment.html` from the assess skill (cached Key Requirements live in its `keyRequirements` island)
 
 ## Process
+
+### Phase 0: Artifact Format Policy
+
+Pipeline planning artifacts (`assessment`, `research`, `brainstorm`, `plan`) are **HTML carrying a JSON data island**, not markdown. Read their structured data with the island extractor rather than grepping rendered prose:
+
+```bash
+bash "${CLAUDE_PLUGIN_ROOT}/skills/promptcraft/references/templates/extract-json-island.sh" plans/<feature-slug>/plan.html
+```
+
+The plan island's `chunks` array seeds Phase 1 decomposition; each chunk's `n` + `slug` map 1:1 onto the `prompts/NN-<slug>.md` you write in Phase 4 (the assembly-baseplate chunk-prompt convention). The assessment island's `keyRequirements` is the cached requirements source for the Phase 6 coverage check. The execution prompts and `manifest.json` you generate stay **markdown/JSON** -- they are agent-only handoffs, not human-facing artifacts. See `references/templates/README.md`.
 
 ### Phase 1: Plan Decomposition
 
@@ -60,7 +70,7 @@ Read `references/prompt-template.md` for the exact prompt structure.
 
 For UI chunks (those touching `.templ`, `.twig`, `.html`, or `.css` files), check for brainstorm outputs that define the approved visual design:
 
-1. Check `plans/<feature-slug>/brainstorm.md` for visual design decisions
+1. Check `plans/<feature-slug>/brainstorm.html` for visual design decisions -- read the `visualDecisions` island with `references/templates/extract-json-island.sh`
 2. Check `.superpowers/brainstorm/` for HTML mockups (these contain styling decisions as inline styles)
 3. If found, extract a **Visual Reference Summary**:
    - Key styling decisions (which component variants, which tokens, which layout patterns)
@@ -222,7 +232,7 @@ For each chunk, generate a self-contained execution prompt using the template fr
 4. **Testable** -- Clear acceptance criteria the subagent can verify
 5. **Visually specified** (UI chunks) -- Include the Visual Reference Summary from Phase 2.5 and generate both structural AND visual acceptance criteria (see prompt template)
 
-Write each prompt to `plans/<feature-slug>/prompts/<chunk-id>.md`. Prompts are Tier 2 (run-scoped) artifacts -- auto-deleted by the orchestrator's cleanup phase after successful execution.
+Write each prompt to `plans/<feature-slug>/prompts/<chunk-id>.md`, where `<chunk-id>` is the `NN-<slug>` from the plan island's `chunks` (zero-padded, ordered; e.g. `00-preflight`, `01-reader-service`, ... `10-doc-sync`). Prompts stay **markdown** -- they are Tier 2 (run-scoped) agent-only artifacts, auto-deleted by the orchestrator's cleanup phase after successful execution.
 
 ### Phase 5: Manifest Generation
 
@@ -255,7 +265,7 @@ The manifest encodes:
 
 ### Phase 6: Requirements Coverage Check
 
-Re-read `plans/<feature-slug>/original-prompt.md` and verify every Key Requirement is covered by at least one chunk's acceptance criteria. Produce a coverage map:
+Read the cached Key Requirements from the `keyRequirements` island of `plans/<feature-slug>/assessment.html` (`extract-json-island.sh`), re-reading `plans/<feature-slug>/original-prompt.md` only if the cache looks incomplete. Verify every Key Requirement is covered by at least one chunk's acceptance criteria. Produce a coverage map:
 
 ```
 Requirements Coverage:

--- a/plugins/pipeline/skills/promptcraft/references/prompt-template.md
+++ b/plugins/pipeline/skills/promptcraft/references/prompt-template.md
@@ -48,7 +48,7 @@ Load these skills for domain-specific guidance:
 
 [If the brainstorm or design spec produced visual mockups, summarize the key decisions here. Omit this section entirely for non-UI chunks.]
 
-Approved design: [path to brainstorm.md or mockup file]
+Approved design: [path to brainstorm.html or mockup file]
 
 Key visual decisions:
 - [Decision 1: e.g., "Sidebar headings use h4 with font-medium, not h3"]

--- a/plugins/pipeline/skills/promptcraft/references/templates/README.md
+++ b/plugins/pipeline/skills/promptcraft/references/templates/README.md
@@ -1,0 +1,117 @@
+# Pipeline HTML Artifact Templates
+
+Self-contained HTML templates for the four pipeline **planning-phase** artifacts:
+`assessment`, `research`, `brainstorm`, `plan`. Each rendered file is human-facing
+prose plus a machine-readable JSON **data island** that downstream agents read
+instead of grepping markdown. Terminal status reports (dm-review reports, pipeline
+receipts, delivery reports) stay inline/markdown and are **not** templated here.
+
+See `docs/html-artifacts.md` (repo root) for the full rationale and schema.
+
+## Files
+
+```
+base.html                 # shell: head, host-CSS slot, landmarks, dark/print CSS
+sections/                 # one body per artifact kind
+  assessment.html  research.html  brainstorm.html  plan.html
+widgets/
+  decision-table.html     # editable table fragment
+  widget-scripts.js       # copy-back JS — INLINE into {{WIDGET_SCRIPTS}}
+  mockup-frame.html       # sandboxed iframe mockup
+  diagram-mermaid.html    # Mermaid diagram (+ CDN script note)
+data-island.html          # <script type="application/json"> snippet
+baseline.css              # inlined when no host CSS detected
+detect-host-css.sh        # prints a <link> tag or FALLBACK
+extract-json-island.sh    # prints an artifact's island JSON
+```
+
+## How an agent assembles an artifact
+
+1. **Detect host CSS** from the target project root:
+   ```bash
+   HOST_CSS_LINK=$(bash "${CLAUDE_PLUGIN_ROOT}/skills/promptcraft/references/templates/detect-host-css.sh" 2>/dev/null || echo "FALLBACK")
+   ```
+   If the output is `FALLBACK`, set the `{{HOST_CSS_HREF}}` substitution to
+   `<style>` + the contents of `baseline.css` + `</style>`. Otherwise use the
+   emitted `<link>` tag verbatim.
+2. **Fill the section.** Take `sections/<kind>.html` and replace its `{{...}}`
+   content slots with rendered HTML.
+3. **Add widgets where needed.** Splice `decision-table.html` (rows filled) into
+   the section's editable areas. Add `mockup-frame.html` / `diagram-mermaid.html`
+   as needed. If any decision-table is present, inline `widget-scripts.js` into
+   `{{WIDGET_SCRIPTS}}` inside a single `<script defer> ... </script>`.
+4. **Build the island.** Fill `data-island.html`'s `{{ISLAND_JSON}}` with the
+   artifact's schema object (see below), then place it in `{{DATA_ISLAND}}`.
+5. **Substitute base.html** slots and `Write` the final file to
+   `plans/<feature-slug>/<kind>.html`.
+
+> Assembly is mechanical string substitution of the `{{SLOT}}` tokens. Template
+> documentation comments deliberately refer to slots by **bare name** (e.g.
+> `BODY`, not `{{BODY}}`) so a naive global replace can't corrupt the notes or
+> emit a duplicate data island. You may strip the `<!-- ... -->` comments from
+> the final artifact, but it isn't required.
+
+### base.html slots
+
+`{{TITLE}}` `{{ARTIFACT_KIND}}` `{{GENERATED_AT}}` `{{HOST_CSS_HREF}}`
+`{{SIBLING_NAV}}` `{{BODY}}` `{{WIDGET_SCRIPTS}}` `{{DATA_ISLAND}}`
+
+`{{SIBLING_NAV}}` is a `<ul>` of links to the run's other artifacts
+(`assessment.html`, `research.html`, and `prompts/` for a plan) — relative links
+within the same `plans/<feature-slug>/` directory.
+
+## Data island schemas
+
+```jsonc
+// assessment.html
+{ "artifact": "assessment", "slug": "<slug>",
+  "keyRequirements": ["..."], "testPersonas": [{"name","id","role","useFor"}],
+  "recentLessons": ["..."], "baselineScreenshots": [{"route","viewport","path"}] }
+
+// research.html
+{ "artifact": "research", "slug": "<slug>",
+  "findings": ["..."], "references": [{"title","url|path","source"}] }
+
+// brainstorm.html
+{ "artifact": "brainstorm", "slug": "<slug>",
+  "visualDecisions": [{"area","decision","variant|token|treatment","rationale"}] }
+
+// plan.html (feature plan)
+{ "artifact": "plan", "slug": "<slug>",
+  "chunks": [{"n":"01","slug":"reader-service","scope","acceptance","deps":[]}],
+  "decisions": [{"id","decision","rationale","alternatives"}],
+  "requirementsCoverage": [{"requirement","chunk"}] }
+
+// plan.html (epic / high-level plan variant)
+{ "artifact": "plan", "slug": "<slug>",
+  "subPlans": [{"n","slug","featureDir"}],
+  "decisions": [...], "requirementsCoverage": [...] }
+```
+
+`keyRequirements` in `assessment.html` is the cached Key Requirements source the
+pipeline re-reads in Phases 3/4/7. `chunks[].n` + `chunks[].slug` map 1:1 onto
+`prompts/NN-<slug>.md` (the assembly-baseplate chunk-prompt convention).
+
+## Reading the island downstream
+
+```bash
+bash "${CLAUDE_PLUGIN_ROOT}/skills/promptcraft/references/templates/extract-json-island.sh" \
+  plans/<slug>/plan.html | python3 -c 'import json,sys; print(len(json.load(sys.stdin)["chunks"]))'
+```
+
+## Copy-back round-trip
+
+Decision tables render with `contenteditable` cells and a **Copy table as JSON**
+button. The human edits decisions in the browser, clicks Copy (serializes the
+table to island-shaped JSON on the clipboard), and pastes it back to Claude or
+into the artifact's `#pipeline-data` island. Each editable section sets
+`data-island-key="<key>"` and each `<th data-field="...">` names the JSON key; a
+`data-list="true"` header serializes its column as an array.
+
+## Plans directory convention (assembly-baseplate)
+
+Artifacts live in flat sibling feature dirs under `plans/`:
+`plans/<feature-slug>/{assessment,research,brainstorm,plan}.html` alongside
+`prompts/NN-<slug>.md`, `manifest.json`, `original-prompt.md`, and evidence dirs.
+A high-level/epic plan is its own dir whose `prompts/<major>.<minor>-<slug>.md`
+seed sibling feature dirs; its `plan.html` uses the epic variant (`subPlans`).

--- a/plugins/pipeline/skills/promptcraft/references/templates/base.html
+++ b/plugins/pipeline/skills/promptcraft/references/templates/base.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<!--
+  Pipeline planning artifact. Self-contained HTML carrying a JSON data island.
+  Assembled by a pipeline agent from base.html + sections/<kind>.html + widgets/*.
+  Required slots (validate-composition.sh validate_html_templates checks these),
+  written here WITHOUT braces so mechanical string-replace does not hit this note:
+    TITLE  ARTIFACT_KIND  GENERATED_AT  HOST_CSS_HREF
+    SIBLING_NAV  BODY  WIDGET_SCRIPTS  DATA_ISLAND
+  The HOST_CSS_HREF slot is replaced with the output of detect-host-css.sh —
+  either a complete <link rel="stylesheet"> tag, or (on FALLBACK) an inline
+  <style> block holding baseline.css.
+-->
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="color-scheme" content="light dark">
+  <meta name="generator" content="depot pipeline">
+  <meta name="pipeline-artifact" content="{{ARTIFACT_KIND}}">
+  <title>{{TITLE}}</title>
+  {{HOST_CSS_HREF}}
+  <style>
+    /* Minimal host-agnostic chrome. Host CSS above owns typography/color;
+       this only adds layout affordances the host stylesheet won't provide. */
+    .skip-link { position: absolute; left: -9999px; top: 0; }
+    .skip-link:focus { left: 0; padding: 0.5rem 1rem; z-index: 10; }
+    .artifact-main { max-width: 70rem; margin-inline: auto; padding: 1rem; }
+    .artifact-header nav ul { display: flex; flex-wrap: wrap; gap: 0.75rem; list-style: none; padding: 0; }
+    .widget--edit table { border-collapse: collapse; width: 100%; }
+    .widget--edit th, .widget--edit td { border: 1px solid currentColor; padding: 0.375rem 0.5rem; text-align: left; vertical-align: top; }
+    .widget--edit td[contenteditable]:focus { outline: 2px solid Highlight; }
+    .widget__copy { margin: 0.5rem 0; }
+    @media (prefers-color-scheme: dark) {
+      /* Fallback only — applies when host CSS does not define a dark scheme. */
+      html:not([data-theme]) { background: #14161a; color: #e6e7e9; }
+    }
+    @media print {
+      nav, .widget--edit .widget__copy { display: none; }
+      .artifact-main { max-width: none; }
+    }
+  </style>
+</head>
+<body>
+  <a class="skip-link" href="#content">Skip to content</a>
+  <header class="artifact-header">
+    <nav aria-label="Pipeline artifacts">
+      {{SIBLING_NAV}}
+    </nav>
+    <p class="artifact-meta"><span class="artifact-kind">{{ARTIFACT_KIND}}</span> &middot; generated {{GENERATED_AT}}</p>
+  </header>
+  <main id="content" class="artifact-main">
+    {{BODY}}
+  </main>
+  <footer class="artifact-footer">
+    <p>Pipeline planning artifact. Edit decision tables inline, then use the Copy button to round-trip changes back into the data island.</p>
+  </footer>
+  {{DATA_ISLAND}}
+  {{WIDGET_SCRIPTS}}
+</body>
+</html>

--- a/plugins/pipeline/skills/promptcraft/references/templates/baseline.css
+++ b/plugins/pipeline/skills/promptcraft/references/templates/baseline.css
@@ -1,0 +1,31 @@
+/*
+  baseline.css — host-agnostic fallback. Inlined into base.html {{HOST_CSS_HREF}}
+  as a <style> block when detect-host-css.sh returns FALLBACK (no host CSS found).
+  Deliberately minimal: readable typography, sane measure, light/dark via
+  color-scheme. Host stylesheets, when present, replace this entirely.
+*/
+:root {
+  color-scheme: light dark;
+  --measure: 70rem;
+  --pad: 1rem;
+}
+* { box-sizing: border-box; }
+body {
+  margin: 0;
+  font: 1rem/1.6 system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  background: Canvas;
+  color: CanvasText;
+}
+h1, h2, h3 { line-height: 1.2; }
+h1 { font-size: 1.875rem; }
+h2 { font-size: 1.375rem; margin-top: 2rem; }
+h3 { font-size: 1.125rem; }
+a { color: LinkText; }
+code, pre { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
+pre { overflow-x: auto; padding: 0.75rem; border: 1px solid GrayText; border-radius: 4px; }
+table { border-collapse: collapse; }
+th, td { border: 1px solid GrayText; padding: 0.375rem 0.5rem; }
+section { margin-block: 1.5rem; }
+small { color: GrayText; }
+.artifact-meta { color: GrayText; font-size: 0.875rem; }
+button { font: inherit; padding: 0.375rem 0.75rem; cursor: pointer; }

--- a/plugins/pipeline/skills/promptcraft/references/templates/data-island.html
+++ b/plugins/pipeline/skills/promptcraft/references/templates/data-island.html
@@ -1,0 +1,13 @@
+<!--
+  Data island snippet. Substituted into base.html's DATA_ISLAND slot.
+  This is the machine-readable half of a dual-purpose artifact: agents read it
+  via extract-json-island.sh instead of grepping the rendered prose.
+
+  The id MUST be "pipeline-data". The "artifact" key MUST be one of:
+  assessment | research | brainstorm | plan. Keep the JSON in sync with the
+  rendered tables — the decision-table widget's Copy button serializes back to
+  this exact shape.
+-->
+<script type="application/json" id="pipeline-data">
+{{ISLAND_JSON}}
+</script>

--- a/plugins/pipeline/skills/promptcraft/references/templates/detect-host-css.sh
+++ b/plugins/pipeline/skills/promptcraft/references/templates/detect-host-css.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+#
+# detect-host-css.sh: Resolve the target project's compiled stylesheet so a
+# pipeline HTML artifact can <link> to it and render in the project's own skin.
+#
+# WHY THIS EXISTS:
+#   Pipeline planning artifacts (assessment/research/brainstorm/plan) are now
+#   self-contained HTML. To look native they link the host project's CSS rather
+#   than shipping bespoke styles. Each host stack exposes its compiled CSS at a
+#   different path; this encodes the detection ladder in one place.
+#
+# WHAT THIS FIXES:
+#   Without detection every artifact would hardcode a path or ship a generic
+#   stylesheet. The ladder matches the four DM stacks (Assembly, Live Wires,
+#   Tailwind, Craft) plus a manual override, and falls back cleanly otherwise.
+#
+# DEPENDENCIES:
+#   - bash 3.2+ (macOS default)
+#   - POSIX grep, sed, head, cat
+#
+# USAGE:
+#   bash detect-host-css.sh            # run from the target project root ($PWD)
+#   HOST_CSS_LINK=$(bash detect-host-css.sh 2>/dev/null || echo FALLBACK)
+#
+#   Prints exactly one line to stdout: either a complete
+#   <link rel="stylesheet" href="..."> tag, or the literal token FALLBACK
+#   (caller then inlines baseline.css). Diagnostics go to stderr only.
+#
+# SECURITY NOTES:
+#   - PATH is reset to a fixed value to prevent caller-controlled hijack of grep,
+#     sed, cat, head.
+#   - A .dm-review-css override is read as a single trusted line and emitted
+#     verbatim; only the first line is used and surrounding whitespace trimmed.
+
+set -uo pipefail
+
+# SECURITY: fixed PATH so a poisoned caller environment can't hijack our tools.
+PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
+export PATH
+
+emit_link() {
+  printf '<link rel="stylesheet" href="%s">\n' "$1"
+}
+
+# 5. Manual override wins over autodetection when present.
+if [ -f ".dm-review-css" ]; then
+  override=$(head -1 ".dm-review-css" | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')
+  if [ -n "$override" ]; then
+    echo "[detect-host-css] using .dm-review-css override" >&2
+    emit_link "$override"
+    exit 0
+  fi
+fi
+
+# 1. Assembly (Go + Templ): compiled CSS served from internal/assets/css/.
+if [ -f "go.mod" ] && [ -d "internal/assets/css" ]; then
+  echo "[detect-host-css] matched Assembly (go.mod + internal/assets/css/)" >&2
+  emit_link "/static/css/assembly.css"
+  exit 0
+fi
+
+# 2. Live Wires: package.json livewires dep OR the settings layer directory.
+if { [ -f "package.json" ] && grep -q '"livewires"' package.json 2>/dev/null; } \
+   || [ -d "src/css/0_settings" ]; then
+  href="/dist/livewires.css"
+  if [ -f "livewires.config.json" ]; then
+    configured=$(grep -o '"cssPath"[[:space:]]*:[[:space:]]*"[^"]*"' livewires.config.json 2>/dev/null \
+      | head -1 | sed 's/.*:[[:space:]]*"//; s/"$//')
+    [ -n "$configured" ] && href="$configured"
+  fi
+  echo "[detect-host-css] matched Live Wires" >&2
+  emit_link "$href"
+  exit 0
+fi
+
+# 3. Tailwind: a tailwind config plus a built output stylesheet.
+for cfg in tailwind.config.js tailwind.config.ts tailwind.config.cjs tailwind.config.mjs; do
+  if [ -f "$cfg" ] && [ -f "dist/output.css" ]; then
+    echo "[detect-host-css] matched Tailwind ($cfg + dist/output.css)" >&2
+    emit_link "/dist/output.css"
+    exit 0
+  fi
+done
+
+# 4. Craft CMS: general config present, conventional site stylesheet.
+if [ -f "config/general.php" ]; then
+  echo "[detect-host-css] matched Craft CMS (config/general.php)" >&2
+  emit_link "/css/site.css"
+  exit 0
+fi
+
+# 6. Nothing matched — caller inlines baseline.css.
+echo "[detect-host-css] no host CSS detected; FALLBACK" >&2
+echo "FALLBACK"
+exit 0

--- a/plugins/pipeline/skills/promptcraft/references/templates/extract-json-island.sh
+++ b/plugins/pipeline/skills/promptcraft/references/templates/extract-json-island.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+#
+# extract-json-island.sh: Print the JSON data island from a pipeline HTML artifact.
+#
+# WHY THIS EXISTS:
+#   Pipeline planning artifacts are dual-purpose HTML: human-readable prose plus a
+#   <script type="application/json" id="pipeline-data"> island carrying structured
+#   data (keyRequirements, chunks, visualDecisions, findings). Downstream agents
+#   read the island instead of grepping rendered markup, which is brittle.
+#
+# WHAT THIS FIXES:
+#   A single, dependency-light extractor agents can call regardless of whether the
+#   artifact is .html (new) — replaces ad-hoc markdown grepping in promptcraft,
+#   plan-adversary, and the execution-orchestrator.
+#
+# DEPENDENCIES:
+#   - bash 3.2+ (macOS default)
+#   - python3 preferred (robust HTML parsing); POSIX sed/grep fallback otherwise
+#
+# USAGE:
+#   bash extract-json-island.sh <file.html> [island-id]
+#     island-id defaults to "pipeline-data".
+#   Prints the island's JSON to stdout. Exit 0 on success; non-zero (with a
+#   stderr message) when the file or island is missing.
+#
+# SECURITY NOTES:
+#   - PATH is reset to a fixed value to prevent caller-controlled hijack of
+#     python3, grep, sed, cat.
+#   - The file is read read-only; nothing is executed from its contents.
+
+set -uo pipefail
+
+# SECURITY: fixed PATH so a poisoned caller environment can't hijack our tools.
+PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
+export PATH
+
+FILE="${1:-}"
+ISLAND_ID="${2:-pipeline-data}"
+
+if [ -z "$FILE" ]; then
+  echo "ERROR: usage: extract-json-island.sh <file.html> [island-id]" >&2
+  exit 2
+fi
+if [ ! -f "$FILE" ]; then
+  echo "ERROR: file not found: $FILE" >&2
+  exit 1
+fi
+
+if command -v python3 >/dev/null 2>&1; then
+  ISLAND_ID="$ISLAND_ID" python3 - "$FILE" <<'PY'
+import os, sys
+from html.parser import HTMLParser
+
+island_id = os.environ.get("ISLAND_ID", "pipeline-data")
+
+class Island(HTMLParser):
+    def __init__(self):
+        super().__init__()
+        self.capture = False
+        self.found = False
+        self.buf = []
+    def handle_starttag(self, tag, attrs):
+        if tag == "script":
+            a = dict(attrs)
+            if a.get("id") == island_id and a.get("type") == "application/json":
+                self.capture = True
+                self.found = True
+    def handle_endtag(self, tag):
+        if tag == "script" and self.capture:
+            self.capture = False
+    def handle_data(self, data):
+        if self.capture:
+            self.buf.append(data)
+
+with open(sys.argv[1], "r", encoding="utf-8") as fh:
+    parser = Island()
+    parser.feed(fh.read())
+
+if not parser.found:
+    sys.stderr.write("ERROR: no <script id='%s' type='application/json'> island in %s\n" % (island_id, sys.argv[1]))
+    sys.exit(1)
+
+text = "".join(parser.buf).strip()
+# Validate it parses; emit canonical text so callers can pipe to jq/python.
+try:
+    import json
+    json.loads(text)
+except Exception as exc:
+    sys.stderr.write("ERROR: island in %s is not valid JSON: %s\n" % (sys.argv[1], exc))
+    sys.exit(1)
+sys.stdout.write(text + "\n")
+PY
+  exit $?
+fi
+
+# Fallback: no python3. Extract the script block with sed, strip the tags.
+# Matches the opening tag with the requested id on a single line (the convention
+# emitted by data-island.html), through the next </script>.
+island=$(sed -n "/<script[^>]*id=\"$ISLAND_ID\"[^>]*>/,/<\/script>/p" "$FILE" \
+  | sed "s/.*<script[^>]*>//; s/<\/script>.*//")
+if [ -z "$island" ]; then
+  echo "ERROR: no '$ISLAND_ID' island found in $FILE (and python3 unavailable for robust parse)" >&2
+  exit 1
+fi
+printf '%s\n' "$island"
+exit 0

--- a/plugins/pipeline/skills/promptcraft/references/templates/sections/assessment.html
+++ b/plugins/pipeline/skills/promptcraft/references/templates/sections/assessment.html
@@ -1,0 +1,49 @@
+<!--
+  Assessment section body. Fills the base.html BODY slot for kind "assessment".
+  Mirrors the Assessment Brief markdown structure (skills/assess/SKILL.md Phase 3).
+  Island schema: { artifact:"assessment", slug, keyRequirements[], testPersonas[],
+                    recentLessons[], baselineScreenshots[] }
+  keyRequirements IS the cached Key Requirements source the pipeline re-reads in
+  Phases 3/4/7 — keep it complete and verbatim.
+-->
+<h1>Assessment: {{AREA_NAME}}</h1>
+
+<section aria-labelledby="key-requirements">
+  <h2 id="key-requirements">Key Requirements <small>(cached from original-prompt.md)</small></h2>
+  <ol>{{KEY_REQUIREMENTS_LIST}}</ol>
+</section>
+
+<section aria-labelledby="code-state">
+  <h2 id="code-state">Code State</h2>
+  {{CODE_STATE}}
+</section>
+
+<section aria-labelledby="ux-state">
+  <h2 id="ux-state">UX State</h2>
+  {{UX_STATE}}
+</section>
+
+<section aria-labelledby="test-personas">
+  <h2 id="test-personas">Test Personas</h2>
+  {{TEST_PERSONAS}}
+</section>
+
+<section aria-labelledby="recent-lessons">
+  <h2 id="recent-lessons">Recent Lessons That May Apply</h2>
+  {{RECENT_LESSONS}}
+</section>
+
+<section aria-labelledby="baseline-screenshots">
+  <h2 id="baseline-screenshots">Baseline Screenshots</h2>
+  {{BASELINE_SCREENSHOTS}}
+</section>
+
+<section aria-labelledby="key-findings">
+  <h2 id="key-findings">Key Findings</h2>
+  {{KEY_FINDINGS}}
+</section>
+
+<section aria-labelledby="recommendations">
+  <h2 id="recommendations">Recommendations</h2>
+  {{RECOMMENDATIONS}}
+</section>

--- a/plugins/pipeline/skills/promptcraft/references/templates/sections/brainstorm.html
+++ b/plugins/pipeline/skills/promptcraft/references/templates/sections/brainstorm.html
@@ -1,0 +1,32 @@
+<!--
+  Brainstorm section body. Fills the base.html BODY slot for kind "brainstorm".
+  Captures the approved visual design from the Phase 0a brainstorming session.
+  Tier 2 artifact — deleted by the orchestrator on successful run.
+  Island schema: { artifact:"brainstorm", slug, visualDecisions[] }
+  visualDecisions[] items: { area, decision, variant|token|treatment, rationale }
+  — exactly what promptcraft Phase 2.5 and the orchestrator design-spec discovery
+  extract. Use the mockup-frame widget for inline mockups and diagram-mermaid for
+  flows; reference, do not inline, large external mockups.
+-->
+<h1>Brainstorm: {{FEATURE_NAME}}</h1>
+
+<section aria-labelledby="problem">
+  <h2 id="problem">Problem &amp; Intent</h2>
+  {{PROBLEM}}
+</section>
+
+<section aria-labelledby="visual-decisions">
+  <h2 id="visual-decisions">Visual Decisions</h2>
+  <p>Component variants, design tokens, and layout treatments approved in this session. These shape each UI chunk's Visual Acceptance Criteria.</p>
+  {{VISUAL_DECISIONS}}
+</section>
+
+<section aria-labelledby="mockups">
+  <h2 id="mockups">Mockups</h2>
+  {{MOCKUPS}}
+</section>
+
+<section aria-labelledby="open-questions">
+  <h2 id="open-questions">Open Questions / Out of Scope</h2>
+  {{OPEN_QUESTIONS}}
+</section>

--- a/plugins/pipeline/skills/promptcraft/references/templates/sections/plan.html
+++ b/plugins/pipeline/skills/promptcraft/references/templates/sections/plan.html
@@ -1,0 +1,37 @@
+<!--
+  Plan section body. Fills the base.html BODY slot for kind "plan".
+  Layout-aware per the assembly-baseplate plans/ convention:
+    - the base.html SIBLING_NAV slot links assessment.html, research.html, prompts/.
+    - Chunk rows map 1:1 onto prompts/NN-<slug>.md (promptcraft Phase 4 output).
+  Island schema (feature plan):
+    { artifact:"plan", slug,
+      chunks:[{ n:"01", slug:"reader-service", scope, acceptance, deps:[] }],
+      decisions:[{ id, decision, rationale, alternatives }],
+      requirementsCoverage:[{ requirement, chunk }] }
+  Epic-plan variant: replace the chunk table with the sub-plan roadmap and emit
+    "subPlans":[{ n, slug, featureDir }] instead of "chunks".
+  The chunk and decision tables use the decision-table widget (editable + copy-back).
+-->
+<h1>Plan: {{FEATURE_NAME}}</h1>
+
+<section aria-labelledby="overview">
+  <h2 id="overview">Overview</h2>
+  {{OVERVIEW}}
+</section>
+
+<section aria-labelledby="chunks" class="widget--edit" data-island-key="chunks">
+  <h2 id="chunks">Chunk Decomposition</h2>
+  <p>Each row becomes <code>prompts/NN-&lt;slug&gt;.md</code>. Edit cells inline, then Copy to round-trip into the data island.</p>
+  {{CHUNK_TABLE}}
+</section>
+
+<section aria-labelledby="decisions" class="widget--edit" data-island-key="decisions">
+  <h2 id="decisions">Decisions &amp; Tradeoffs</h2>
+  {{DECISION_TABLE}}
+</section>
+
+<section aria-labelledby="coverage">
+  <h2 id="coverage">Requirements Coverage</h2>
+  <p>Maps each cached Key Requirement (from <a href="assessment.html">assessment.html</a>) to the chunk that satisfies it.</p>
+  {{COVERAGE_TABLE}}
+</section>

--- a/plugins/pipeline/skills/promptcraft/references/templates/sections/research.html
+++ b/plugins/pipeline/skills/promptcraft/references/templates/sections/research.html
@@ -1,0 +1,49 @@
+<!--
+  Research section body. Fills the base.html BODY slot for kind "research".
+  Mirrors the Research Brief markdown structure (skills/research/SKILL.md Phase 4).
+  This is the synthesized brief. Facet files (research-codebase/context/design.md)
+  stay as markdown supporting detail and are NOT converted.
+  Island schema: { artifact:"research", slug, findings[], references[] }
+  references[] items: { title, url|path, source }.
+-->
+<h1>Research Brief: {{FEATURE_NAME}}</h1>
+
+<section aria-labelledby="summary">
+  <h2 id="summary">Summary</h2>
+  {{SUMMARY}}
+</section>
+
+<section aria-labelledby="project-context">
+  <h2 id="project-context">Project Context</h2>
+  {{PROJECT_CONTEXT}}
+</section>
+
+<section aria-labelledby="domain-knowledge">
+  <h2 id="domain-knowledge">Domain Knowledge</h2>
+  {{DOMAIN_KNOWLEDGE}}
+</section>
+
+<section aria-labelledby="design-references">
+  <h2 id="design-references">Design References</h2>
+  {{DESIGN_REFERENCES}}
+</section>
+
+<section aria-labelledby="technical-references">
+  <h2 id="technical-references">Technical References</h2>
+  {{TECHNICAL_REFERENCES}}
+</section>
+
+<section aria-labelledby="codebase-patterns">
+  <h2 id="codebase-patterns">Codebase Patterns</h2>
+  {{CODEBASE_PATTERNS}}
+</section>
+
+<section aria-labelledby="constraints-risks">
+  <h2 id="constraints-risks">Constraints and Risks</h2>
+  {{CONSTRAINTS_RISKS}}
+</section>
+
+<section aria-labelledby="key-decisions">
+  <h2 id="key-decisions">Key Decisions Needed</h2>
+  {{KEY_DECISIONS}}
+</section>

--- a/plugins/pipeline/skills/promptcraft/references/templates/widgets/decision-table.html
+++ b/plugins/pipeline/skills/promptcraft/references/templates/widgets/decision-table.html
@@ -1,0 +1,32 @@
+<!--
+  decision-table widget. Editable table whose Copy button serializes rows back to
+  JSON matching the data island schema. Drop one instance per editable section in
+  the body; include widget-scripts.js ONCE via the base.html WIDGET_SCRIPTS slot.
+
+  Contract:
+    - Wrap the table in a section with class "widget--edit" and a
+      data-island-key="<key>" naming the island array this table maps to
+      (e.g. "chunks", "decisions"). The section is provided by the section
+      template; this widget supplies the <table> + Copy button.
+    - Each <th> carries data-field="<jsonKey>" naming the property each column
+      serializes to. Header text is for humans; data-field drives the JSON.
+    - Body cells are contenteditable. A cell may hold a comma-separated list;
+      mark it data-list="true" to serialize as a JSON array.
+  Example header for the plan "chunks" table:
+    n | slug | scope | acceptance | deps(data-list)
+-->
+<table>
+  <thead>
+    <tr>
+      <th data-field="n">NN</th>
+      <th data-field="slug">Slug</th>
+      <th data-field="scope">Scope</th>
+      <th data-field="acceptance">Acceptance</th>
+      <th data-field="deps" data-list="true">Depends on</th>
+    </tr>
+  </thead>
+  <tbody>
+    {{ROWS}}
+  </tbody>
+</table>
+<button type="button" class="widget__copy" data-copy-island>Copy table as JSON</button>

--- a/plugins/pipeline/skills/promptcraft/references/templates/widgets/diagram-mermaid.html
+++ b/plugins/pipeline/skills/promptcraft/references/templates/widgets/diagram-mermaid.html
@@ -1,0 +1,14 @@
+<!--
+  diagram-mermaid widget. Renders a Mermaid diagram (flowchart, sequence, ER).
+  Use in plan.html / research.html for dependency graphs and flows.
+  Slot: MERMAID_SOURCE (raw Mermaid text — do NOT HTML-escape; Mermaid reads
+  the element's textContent).
+  The CDN loader goes into the base.html WIDGET_SCRIPTS slot ONCE per artifact, as two
+  deferred script tags: one with
+    src="https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.min.js"
+  and one inline that calls mermaid.initialize({startOnLoad:true}) on window load.
+  When offline (no CDN), the <pre> degrades to readable diagram source — acceptable.
+-->
+<figure class="diagram">
+  <pre class="mermaid">{{MERMAID_SOURCE}}</pre>
+</figure>

--- a/plugins/pipeline/skills/promptcraft/references/templates/widgets/mockup-frame.html
+++ b/plugins/pipeline/skills/promptcraft/references/templates/widgets/mockup-frame.html
@@ -1,0 +1,13 @@
+<!--
+  mockup-frame widget. Inline visual mockup via a sandboxed iframe srcdoc, so the
+  artifact stays a single self-contained file. Use in brainstorm.html for approved
+  layout treatments. Keep mockups small — reference large external mockups by path
+  in the body rather than embedding them.
+  Slots: MOCKUP_TITLE (caption), MOCKUP_SRCDOC (HTML-escaped markup).
+  sandbox is intentionally empty: no scripts, no same-origin — the mockup renders
+  but cannot execute or reach the parent document.
+-->
+<figure class="mockup-frame">
+  <figcaption>{{MOCKUP_TITLE}}</figcaption>
+  <iframe title="{{MOCKUP_TITLE}}" sandbox loading="lazy" srcdoc="{{MOCKUP_SRCDOC}}" style="width:100%;min-height:18rem;border:1px solid currentColor;"></iframe>
+</figure>

--- a/plugins/pipeline/skills/promptcraft/references/templates/widgets/widget-scripts.js
+++ b/plugins/pipeline/skills/promptcraft/references/templates/widgets/widget-scripts.js
@@ -1,0 +1,70 @@
+// Copy-back round-trip for decision-table widgets.
+// Self-contained HTML artifacts open via file:// — relative <script src> to the
+// templates dir would not resolve next to the artifact. So agents INLINE this
+// file's contents into the base.html WIDGET_SCRIPTS slot inside a
+// <script defer> ... </script> block. Include it once per artifact.
+//
+// Behaviour: each [data-copy-island] button serializes its enclosing
+// .widget--edit table to an array of objects (keyed by each <th data-field>),
+// wraps it under the section's data-island-key, and writes it to the clipboard.
+// The human edits cells in the browser, clicks Copy, and pastes the JSON back to
+// Claude or into the artifact's #pipeline-data island.
+(function () {
+  "use strict";
+
+  function serializeTable(table) {
+    var headers = [].slice.call(table.querySelectorAll("thead th"));
+    var fields = headers.map(function (th) {
+      return { key: th.getAttribute("data-field") || th.textContent.trim(), list: th.getAttribute("data-list") === "true" };
+    });
+    var rows = [].slice.call(table.querySelectorAll("tbody tr"));
+    return rows.map(function (tr) {
+      var cells = [].slice.call(tr.querySelectorAll("td"));
+      var obj = {};
+      fields.forEach(function (f, i) {
+        var raw = cells[i] ? cells[i].textContent.trim() : "";
+        obj[f.key] = f.list
+          ? raw.split(",").map(function (s) { return s.trim(); }).filter(Boolean)
+          : raw;
+      });
+      return obj;
+    });
+  }
+
+  function writeClipboard(text, button) {
+    var done = function () {
+      var prev = button.textContent;
+      button.textContent = "Copied ✓";
+      setTimeout(function () { button.textContent = prev; }, 1500);
+    };
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      navigator.clipboard.writeText(text).then(done, function () { fallbackCopy(text, done); });
+    } else {
+      fallbackCopy(text, done);
+    }
+  }
+
+  function fallbackCopy(text, done) {
+    var ta = document.createElement("textarea");
+    ta.value = text;
+    ta.setAttribute("readonly", "");
+    ta.style.position = "absolute";
+    ta.style.left = "-9999px";
+    document.body.appendChild(ta);
+    ta.select();
+    try { document.execCommand("copy"); done(); } catch (e) { /* no-op */ }
+    document.body.removeChild(ta);
+  }
+
+  document.addEventListener("click", function (event) {
+    var button = event.target.closest("[data-copy-island]");
+    if (!button) return;
+    var section = button.closest(".widget--edit");
+    var table = section && section.querySelector("table");
+    if (!table) return;
+    var key = section.getAttribute("data-island-key") || "rows";
+    var payload = {};
+    payload[key] = serializeTable(table);
+    writeClipboard(JSON.stringify(payload, null, 2), button);
+  });
+})();

--- a/plugins/pipeline/skills/research/SKILL.md
+++ b/plugins/pipeline/skills/research/SKILL.md
@@ -184,7 +184,7 @@ Also loads (see Phase 4 handoff): the promptcraft skill's Phase 3e Stable Anchor
 
 ### Phase 4: Consolidation
 
-Collect results from all agents and produce a **Research Brief**:
+Collect results from all agents and produce a **Research Brief**. Write it as **HTML with a JSON data island**, not markdown -- assemble `templates/base.html` + `templates/sections/research.html` per `${CLAUDE_PLUGIN_ROOT}/plugins/pipeline/skills/promptcraft/references/templates/README.md`. This is the synthesized brief; if research also produced facet notes (`research-codebase.md`, `research-context.md`, `research-design.md`), leave those as markdown supporting detail. The `findings` and `references` arrays populate the `#pipeline-data` island. The content outline below maps to the section's slots:
 
 ```markdown
 # Research Brief: [Feature Name]
@@ -214,7 +214,7 @@ Collect results from all agents and produce a **Research Brief**:
 [Questions that planning will need to answer]
 ```
 
-Save the brief to `plans/research-<feature-slug>.md` in the target project.
+Save the brief to `plans/<feature-slug>/research.html` in the target project (detect host CSS first; on `FALLBACK` inline `templates/baseline.css`).
 
 ### Phase 5: Handoff
 

--- a/tools/validate-composition.sh
+++ b/tools/validate-composition.sh
@@ -448,6 +448,108 @@ check_skill_frontmatter() {
 }
 
 # --------------------------------------------------------------------------
+# Validate the pipeline HTML artifact templates
+#
+# The pipeline emits its four planning artifacts (assessment/research/brainstorm/
+# plan) as self-contained HTML carrying a JSON data island. This checks that the
+# template system is intact: base.html has every substitution slot, the section
+# and widget fragments are structurally sane, and the two bash helpers are
+# executable and syntactically valid.
+#
+# Note: we do NOT use `xmllint --html` here. libxml2's HTML parser is HTML4-era
+# and emits false "Tag header/main/footer invalid" errors on HTML5 semantic
+# elements while still exiting 0 — useless as a gate. We use deterministic
+# structural checks (slot presence, balanced comments/script tags) instead.
+# --------------------------------------------------------------------------
+validate_html_templates() {
+  local any_failed=0
+  local tdir="$PLUGINS_DIR/pipeline/skills/promptcraft/references/templates"
+
+  if [ ! -d "$tdir" ]; then
+    printf "  ${RED}FAIL${RESET}  templates directory missing: %s\n" "${tdir#$REPO_ROOT/}"
+    return 1
+  fi
+
+  # Required files.
+  local required=(
+    "base.html" "data-island.html" "baseline.css" "README.md"
+    "detect-host-css.sh" "extract-json-island.sh"
+    "sections/assessment.html" "sections/research.html"
+    "sections/brainstorm.html" "sections/plan.html"
+    "widgets/decision-table.html" "widgets/widget-scripts.js"
+    "widgets/mockup-frame.html" "widgets/diagram-mermaid.html"
+  )
+  local f
+  for f in "${required[@]}"; do
+    if [ ! -f "$tdir/$f" ]; then
+      printf "  ${RED}FAIL${RESET}  missing template file: %s\n" "$f"
+      any_failed=1
+    fi
+  done
+
+  # base.html must declare every substitution slot.
+  local slot
+  for slot in TITLE ARTIFACT_KIND GENERATED_AT HOST_CSS_HREF SIBLING_NAV BODY WIDGET_SCRIPTS DATA_ISLAND; do
+    if ! grep -qF "{{$slot}}" "$tdir/base.html" 2>/dev/null; then
+      printf "  ${RED}FAIL${RESET}  base.html missing slot {{%s}}\n" "$slot"
+      any_failed=1
+    fi
+  done
+
+  # data-island.html must carry the canonical island id and type.
+  if ! grep -qF 'id="pipeline-data"' "$tdir/data-island.html" 2>/dev/null \
+     || ! grep -qF 'type="application/json"' "$tdir/data-island.html" 2>/dev/null; then
+    printf "  ${RED}FAIL${RESET}  data-island.html missing id=\"pipeline-data\" or type=\"application/json\"\n"
+    any_failed=1
+  fi
+
+  # Structural sanity for every HTML fragment: balanced comments and script tags.
+  while IFS= read -r -d '' htmlf; do
+    local rel="${htmlf#$tdir/}"
+    local open_c close_c open_s close_s
+    open_c=$(grep -o '<!--' "$htmlf" | wc -l | tr -d ' ')
+    close_c=$(grep -o -- '-->' "$htmlf" | wc -l | tr -d ' ')
+    if [ "$open_c" != "$close_c" ]; then
+      printf "  ${RED}FAIL${RESET}  %s: unbalanced HTML comments (%s '<!--' vs %s '-->')\n" "$rel" "$open_c" "$close_c"
+      any_failed=1
+    fi
+    open_s=$(grep -o '<script' "$htmlf" | wc -l | tr -d ' ')
+    close_s=$(grep -o '</script>' "$htmlf" | wc -l | tr -d ' ')
+    if [ "$open_s" != "$close_s" ]; then
+      printf "  ${RED}FAIL${RESET}  %s: unbalanced <script> tags (%s open vs %s close)\n" "$rel" "$open_s" "$close_s"
+      any_failed=1
+    fi
+  done < <(find "$tdir" -name '*.html' -print0 2>/dev/null)
+
+  # Each section must reference the data island so its structured data round-trips.
+  for f in assessment research brainstorm plan; do
+    local secf="$tdir/sections/$f.html"
+    [ -f "$secf" ] || continue
+    if ! grep -qiE "island|pipeline-data" "$secf"; then
+      printf "  ${YELLOW}WARN${RESET}  sections/%s.html does not mention its data island\n" "$f"
+    fi
+  done
+
+  # Helpers: executable bit + syntax.
+  for f in detect-host-css.sh extract-json-island.sh; do
+    [ -f "$tdir/$f" ] || continue
+    if [ ! -x "$tdir/$f" ]; then
+      printf "  ${RED}FAIL${RESET}  %s is not executable (chmod +x)\n" "$f"
+      any_failed=1
+    fi
+    if ! bash -n "$tdir/$f" 2>/dev/null; then
+      printf "  ${RED}FAIL${RESET}  %s has a bash syntax error\n" "$f"
+      any_failed=1
+    fi
+  done
+
+  if [ "$any_failed" -eq 0 ]; then
+    printf "  ${GREEN}OK${RESET}    pipeline HTML templates intact (slots, fragments, helpers)\n"
+  fi
+  return $any_failed
+}
+
+# --------------------------------------------------------------------------
 # Composition checks (the default mode)
 # --------------------------------------------------------------------------
 run_composition_checks() {
@@ -481,6 +583,11 @@ run_composition_checks() {
 
   printf "\n${BOLD}SKILL.md frontmatter integrity:${RESET}\n"
   if ! check_skill_frontmatter; then
+    any_failed=1
+  fi
+
+  printf "\n${BOLD}Pipeline HTML templates:${RESET}\n"
+  if ! validate_html_templates; then
     any_failed=1
   fi
 


### PR DESCRIPTION
## Summary

Converts the pipeline's four **planning-phase** artifacts — `brainstorm`, `assessment`, `research`, `plan` — from markdown to self-contained **HTML carrying a JSON data island**. The HTML links the target project's compiled CSS (so it renders in the project's own skin); the `<script type="application/json" id="pipeline-data">` island is what downstream agents read instead of grepping prose. Humans review the rendered page and can edit decision tables inline with a copy-back-to-clipboard loop.

Motivation: as autonomous runs grew to hours, plans ballooned to ~1000 lines of markdown and humans stopped reading them. A richer, browsable review medium re-engages the human as the compute allocator. Full rationale in `docs/html-artifacts.md`.

## What changed

- **New template system** under `plugins/pipeline/skills/promptcraft/references/templates/`: `base.html` shell, four section bodies, `decision-table`/`mockup-frame`/`diagram-mermaid` widgets + copy-back JS, `data-island.html`, `baseline.css`, plus two bash helpers (`detect-host-css.sh` host-CSS detection ladder, `extract-json-island.sh` island reader) and a README.
- **Dual-purpose handoff preserved**: `commands/pipeline.md`, `skills/assess`, `skills/research`, `skills/promptcraft`, `plan-adversary`, and `execution-orchestrator` now write/read `.html` + island (cached Key Requirements move into the assessment island; brainstorm cleanup + gitignore + lifecycle tiers updated).
- **Layout convention**: plan artifacts follow the assembly-baseplate `plans/` structure — flat feature dirs, chunks mapped 1:1 to `prompts/NN-<slug>.md`, and an epic/roadmap variant (`subPlans`). The pipeline does not auto-generate the epic→sub-plan tree; `plan.html` is layout-aware only.
- **Validation**: `validate_html_templates()` added to `tools/validate-composition.sh` (slot presence, balanced fragments, executable + `bash -n`-clean helpers). `--all` passes.
- **Out of scope (unchanged)**: dm-review reports, pipeline receipts, delivery reports stay inline; `original-prompt.md`, `prompts/*.md`, `manifest.json`, research facet files, and state files stay markdown/JSON. dm-review got only a one-line cross-ref fix (brainstorm spec path → `.html`), with a patch version bump per repo rules.
- Version bumps: pipeline `1.14.0 → 1.15.0`, dm-review `1.30.0 → 1.30.1` (+ marketplace sync + regenerated Codex manifests).

## Test plan

- [x] `./tools/validate-composition.sh --all` passes (evals, deps, composition, version sync, HTML templates, Codex compat).
- [x] All four artifacts assemble from templates to exactly one valid, extractable island with zero leftover slots.
- [x] `detect-host-css.sh` returns the Assembly `<link>` and `FALLBACK` correctly; `extract-json-island.sh` round-trips via python and the sed fallback.
- [ ] Live end-to-end run of `/pipeline` against an Assembly and a Live Wires project to confirm rendered CSS, inline editing, and the copy-back loop in a browser.

https://claude.ai/code/session_01BfH7euFugqdJsy8t3ygGsM

---
_Generated by [Claude Code](https://claude.ai/code/session_01BfH7euFugqdJsy8t3ygGsM)_