### PR TITLE
perf(pipeline): reduce orchestration overhead

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -348,12 +348,12 @@
     {
       "name": "pipeline",
       "source": "./plugins/pipeline",
-      "version": "1.30.0",
+      "version": "1.31.0",
       "author": {
         "name": "Design Machines",
         "url": "https://designmachines.studio"
       },
-      "description": "Autonomous feature development pipeline with assessment, research, prompt generation, adversarial review (ambiguity surfacing), and worktree-based execution with review-fix loops and surgical-change discipline",
+      "description": "Autonomous feature development pipeline with assessment, research, bounded prompt generation, adversarial review, and worktree-based execution with risk-tiered review gates",
       "capabilities_summary": {
         "skills": 4,
         "agents": 2,
@@ -373,12 +373,12 @@
     {
       "name": "workflow-kernel",
       "source": "./plugins/workflow-kernel",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "author": {
         "name": "Design Machines",
         "url": "https://designmachines.studio"
       },
-      "description": "Neutral deterministic run-state, replay, recovery, receipts, and shadow observation for Design Machines workflows.",
+      "description": "Neutral deterministic run-state, replay, recovery, receipts, shadow observation, and active-versus-wait runtime metrics for Design Machines workflows.",
       "capabilities_summary": {
         "skills": 1,
         "agents": 0,

--- a/plugins/pipeline/.claude-plugin/plugin.json
+++ b/plugins/pipeline/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "pipeline",
-  "description": "Autonomous feature development pipeline: assess current state, research context, generate execution prompts with dependency ordering, adversarial review (with ambiguity surfacing), orchestrate concurrent worktree execution with review-fix loops and surgical-change discipline, and deliver clean branches",
-  "version": "1.30.0",
+  "description": "Autonomous feature development pipeline: assess current state, research context, generate bounded execution prompts with dependency ordering, adversarial review, orchestrate worktree execution with risk-tiered review and surgical-change discipline, and deliver clean branches",
+  "version": "1.31.0",
   "author": {
     "name": "Design Machines",
     "url": "https://designmachines.io"
@@ -9,7 +9,7 @@
   "pluginDependencies": {
     "dm-review": ">=1.44.0",
     "ned": ">=1.4.0",
-    "workflow-kernel": ">=0.1.1"
+    "workflow-kernel": ">=0.2.0"
   },
   "optionalPluginDependencies": {
     "design-machines": ">=1.3.0",
@@ -132,7 +132,7 @@
         "id": "execution-orchestrator",
         "name": "Execution Orchestrator",
         "category": "workflow",
-        "description": "Autonomously executes sub-prompts in worktrees with dm-review-loop review-fix loops and zero-deferral policy",
+        "description": "Autonomously executes sub-prompts in worktrees with focused Codex review, sensitive-path escalation, final full review, and zero-deferral policy",
         "tags": [
           "orchestration",
           "worktrees",
@@ -164,7 +164,7 @@
       {
         "id": "pipeline-run",
         "name": "Pipeline Run",
-        "description": "Execute generated prompts in worktrees with review-fix loops",
+        "description": "Execute generated prompts in worktrees with risk-tiered review gates",
         "argumentHint": "[path to manifest.json or prompts directory]"
       },
       {

--- a/plugins/pipeline/.codex-plugin/plugin.json
+++ b/plugins/pipeline/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "pipeline",
-  "version": "1.30.0",
-  "description": "Autonomous feature development pipeline: assess current state, research context, generate execution prompts with dependency ordering, adversarial review (with ambiguity surfacing), orchestrate concurrent worktree execution with review-fix loops and surgical-change discipline, and deliver clean branches",
+  "version": "1.31.0",
+  "description": "Autonomous feature development pipeline: assess current state, research context, generate bounded execution prompts with dependency ordering, adversarial review, orchestrate worktree execution with risk-tiered review and surgical-change discipline, and deliver clean branches",
   "author": {
     "name": "Design Machines",
     "url": "https://designmachines.io"
@@ -119,7 +119,7 @@
         "id": "execution-orchestrator",
         "name": "Execution Orchestrator",
         "category": "workflow",
-        "description": "Autonomously executes sub-prompts in worktrees with dm-review-loop review-fix loops and zero-deferral policy",
+        "description": "Autonomously executes sub-prompts in worktrees with focused Codex review, sensitive-path escalation, final full review, and zero-deferral policy",
         "tags": [
           "orchestration",
           "worktrees",
@@ -151,7 +151,7 @@
       {
         "id": "pipeline-run",
         "name": "Pipeline Run",
-        "description": "Execute generated prompts in worktrees with review-fix loops",
+        "description": "Execute generated prompts in worktrees with risk-tiered review gates",
         "argumentHint": "[path to manifest.json or prompts directory]"
       },
       {
@@ -165,7 +165,7 @@
   "pluginDependencies": {
     "dm-review": ">=1.44.0",
     "ned": ">=1.4.0",
-    "workflow-kernel": ">=0.1.1"
+    "workflow-kernel": ">=0.2.0"
   },
   "optionalPluginDependencies": {
     "design-machines": ">=1.3.0",
@@ -180,8 +180,8 @@
   },
   "interface": {
     "displayName": "Pipeline",
-    "shortDescription": "Autonomous feature development pipeline: assess current state, research context, generate execution prompts with depende",
-    "longDescription": "Autonomous feature development pipeline: assess current state, research context, generate execution prompts with dependency ordering, adversarial review (with ambiguity surfacing), orchestrate concurrent worktree execution with review-fix loops and surgical-change discipline, and deliver clean branches",
+    "shortDescription": "Autonomous feature development pipeline: assess current state, research context, generate bounded execution prompts with",
+    "longDescription": "Autonomous feature development pipeline: assess current state, research context, generate bounded execution prompts with dependency ordering, adversarial review, orchestrate worktree execution with risk-tiered review and surgical-change discipline, and deliver clean branches",
     "developerName": "Design Machines",
     "category": "Developer Tools",
     "capabilities": [

--- a/plugins/pipeline/agents/workflow/execution-orchestrator.md
+++ b/plugins/pipeline/agents/workflow/execution-orchestrator.md
@@ -1,13 +1,13 @@
 ---
 name: execution-orchestrator
-description: Autonomously executes sub-prompts in worktrees with dm-review-loop review-fix loops and zero-deferral policy
+description: Autonomously executes sub-prompts in worktrees with risk-tiered Codex review, final full dm-review, and zero-deferral policy
 model: opus
 tools: Bash, Read, Write, Edit, Glob, Grep, Agent, TodoWrite, Skill
 ---
 
 # Execution Orchestrator
 
-You are the autonomous execution engine for the pipeline plugin. You take a manifest and set of execution prompts, then execute them in worktrees with review-fix loops at each stage.
+You are the autonomous execution engine for the pipeline plugin. You take a manifest and set of execution prompts, then execute them in worktrees with risk-tiered review gates.
 
 ## Output Style
 
@@ -41,25 +41,25 @@ Two rules govern every subagent you spawn:
    - Add a `NOT-COVERED:` entry to the chunk receipt naming the dead agent and what it left unfinished.
    - Continue to the next chunk/lane. A silently missing lane that reads as "done" is the costliest failure; flag it instead.
 
-## CRITICAL: How to Run dm-review (skill, not slash command)
+## CRITICAL: How to Run Review Gates
 
 You are a subagent. **Slash commands like `/dm-review-loop`, `/dm-review-quick`, `/dm-review`, and `/dm-review-fix` are NOT callable from a subagent context** -- they are user-input only. References elsewhere in this document that say "Run /dm-review-quick" mean "execute the review-fix-loop pattern below using the `Skill` tool to invoke the underlying review skill."
 
 You have the `Skill` tool in your whitelist. Use it. Never report "dm-review-loop slash command not callable" -- that means you've misread the instructions. The slash command is a user-facing wrapper; the underlying skill is `dm-review:review` and it IS callable.
 
-### Single-pass review (replaces `/dm-review-quick`)
+### Focused Codex review (ordinary chunks)
 
 ```text
-1. Skill(skill="dm-review:review", args="quick <worktree-path>")
-   -- This dispatches the 5 core review agents (plus ui-standards-reviewer
-      when UI files changed) and writes findings to <worktree-path>/todos/.
-   -- The skill returns a consolidated report.
+1. Run one read-only Codex reviewer against the chunk diff and acceptance
+   criteria. On a Codex host, use one native review subagent. On another host,
+   invoke the configured Codex review command.
 
 2. Read <worktree-path>/todos/*-pending-*.md to enumerate findings.
 
 3. If zero findings: report "Clean" and proceed.
    If findings exist: apply targeted fixes via Edit/Write to the worktree files,
-      then rename each todo file from `-pending-` to `-done-`.
+      rename each todo file from `-pending-` to `-done-`, and run one focused
+      recheck. Stop after two total passes.
 ```
 
 The orchestrator (you) applies the fixes itself using the Edit/Write tools you already have. Do NOT spawn a separate fix subagent for trivial findings -- read the finding, apply the fix to the cited file:line, mark todo done, move on.
@@ -68,12 +68,12 @@ The orchestrator (you) applies the fixes itself using the Edit/Write tools you a
 
 Same as single-pass, but pass `args="full <branch-name>"` to invoke ALL applicable agents (a11y, css, voice, governance, etc. -- everything dm-review's Phase 3 conditional table dispatches).
 
-### Review-fix loop (replaces `/dm-review-loop`)
+### Full review-fix loop (sensitive chunks and final review)
 
 ```text
 prior_signature = null
-for iteration in 1..max_iterations (default 3):
-  Skill(skill="dm-review:review", args="quick <worktree-path>")
+for iteration in 1..max_iterations (default 2):
+  Skill(skill="dm-review:review", args="full <worktree-path>")
 
   pending = ls <worktree-path>/todos/*-pending-*.md
   current_signature = sorted basenames of pending
@@ -95,15 +95,18 @@ for iteration in 1..max_iterations (default 3):
     rename pending -> done
 
   if iteration == max_iterations:
-    Skill(skill="dm-review:review", args="quick <worktree-path>")  -- final verify
+    Skill(skill="dm-review:review", args="full <worktree-path>")  -- final verify
     if pending after final: log each as DEFERRED with explicit justification
 ```
 
 The stalled-convergence check is critical -- without it, the orchestrator can loop wasting tokens on findings that don't auto-resolve.
 
-### Per-chunk review tier (quick by default; escalate sensitive paths)
+### Per-chunk review tier (focused by default; escalate sensitive paths)
 
-Default the per-chunk review gate to **quick** mode -- 5 core agents (+ ui-standards-reviewer for UI files). Full review runs once at the end against the feature branch, not per chunk. This is the token-economy default; do not run full review on every chunk.
+Default the per-chunk review gate to one **focused Codex review** with at most
+one repair/recheck pass. Full dm-review runs once at the end against the feature
+branch, not per ordinary chunk. Do not dispatch the 5-agent quick dm-review
+suite for an ordinary chunk.
 
 **Sensitive-path exception.** Before the per-chunk review, test the chunk's `filesToModify` against the sensitive-path set. If any path matches, run **full** review for that chunk (`args="full <worktree-path>"`) so the Codex-native `security-auditor` and all conditional agents engage, and record `review_tier: full (sensitive path)` in the chunk receipt:
 
@@ -115,7 +118,7 @@ deploy/**                   *.env*
 migrations/** containing seed credentials
 ```
 
-These lanes are never quick-only and are never delegated to OpenRouter (see the OpenRouter routing policy). A chunk that touches auth/federation/secrets and was reviewed quick-only is a run-postmortem miss.
+These lanes are never focused-only and are never delegated to OpenRouter (see the OpenRouter routing policy). A chunk that touches auth/federation/secrets and did not receive full dm-review is a run-postmortem miss.
 
 ### Why this matters for OpenRouter routing
 
@@ -130,7 +133,7 @@ Adapter parity requirements:
 - The current Codex agent is the orchestrator and follows this file as the execution contract.
 - Implementation chunks are dispatched with `multi_agent_v1.spawn_agent` using worker agents after the worktree is created.
 - Worker prompts inline the complete chunk prompt and restrict writes to the chunk worktree.
-- Per-chunk review gates use the dm-review inline protocol from `plugins/dm-review/skills/review/SKILL.md` in quick mode.
+- Ordinary per-chunk review gates use one native focused Codex reviewer. Sensitive chunks use the dm-review inline protocol from `plugins/dm-review/skills/review/SKILL.md` in full mode.
 - The final review gate uses the same dm-review inline protocol in full mode against the feature branch.
 - Zero-deferral, convergence limits, pending/done todo receipts, final requirements cross-check, cleanup, memory capture, and summary reporting remain mandatory.
 
@@ -144,28 +147,31 @@ Not all chunks need the same evaluation depth. Classify each chunk before execut
 
 **UI chunks** (touch `.templ`, `.twig`, `.html`, `.css`, or template files):
 
-- Run the review-fix loop (quick mode, max 3 iterations) per the helper above
+- Run focused Codex review with at most one repair/recheck pass
 - ALSO run Playwright browser evaluation: navigate to the affected route, screenshot, check the page loads and renders correctly, verify interactive elements respond
 - If the project has `tests/ux/` personas, evaluate through at least 2 persona lenses
 
 **Logic chunks** (touch `.go`, `.py`, `.ts`, `.php` handler/service files, migrations):
 
-- Run the review-fix loop (quick mode, max 3 iterations) per the helper above
+- Run focused Codex review with at most one repair/recheck pass
 - No Playwright (no visual output to test)
 
 **Trivial chunks** (touch only config, documentation, `.md`, `.json`, `.yaml`, or non-code files):
 
-- Run a single-pass review (no loop) per the helper above
+- Run a single focused Codex review
 - If zero findings, proceed. If findings, fix and re-run once.
 - Skip the full loop -- it's overhead for non-behavioral changes
 
 **Integration chunks** (wire multiple prior chunks together, touch routes/main):
 
-- Run the review-fix loop (quick mode, max 3 iterations) per the helper above
+- Run focused Codex review with at most one repair/recheck pass, then verify the cross-chunk wiring explicitly
 - Run Playwright browser evaluation on all affected routes
 - This is the highest-risk chunk type -- treat it with full rigor
 
 The manifest's `estimatedComplexity` field and the chunk's `filesToModify` list determine the classification. When in doubt, classify up (treat ambiguous chunks as Logic, not Trivial).
+
+The sensitive-path exception overrides every classification above and requires
+full dm-review with at most two passes.
 
 ## Progress Ledger
 
@@ -209,11 +215,20 @@ FINAL 6. Present summary report
 
 Do NOT mark a step complete until you have actually done it. Do NOT skip steps.
 
+### Wait Measurement
+
+When orchestration truly pauses, timestamp the start and resume and append one
+authoritative `progress` receipt with measured nonnegative `duration_seconds`
+and a `wait_category` of `human_gate`, `external_dependency`, `capacity`, or
+`ci`. Measure the orchestrator-level non-overlapping interval; parallel worker
+waits must not be added separately. Never estimate missing time or relabel
+active implementation, review, validation, or browser work as waiting.
+
 ### Shadow Workflow Kernel Runtime
 
 The Markdown manifest, routing policy, this orchestrator, and emitted receipts remain authoritative. Kernel predictions are observation-only: they do not select ready nodes, advance gates, block or approve merges, change provider fallback, execute cleanup, or convert review outcomes. Run hooks only after the corresponding authoritative action and receipt exist.
 
-Resolve `$WORKFLOW_KERNEL` -- the workflow-kernel launcher script -- once per run, following the single fail-closed resolution contract in the workflow-kernel plugin's `references/runtime-resolution.md` (launcher discovery snippet, repo-vs-cache trust boundaries, semver compatibility, symlink and scope fail-closed rules, and stable exit codes all live there; do not restate them here). Use only the launcher's stable subcommands; inline Python source is forbidden. Keep observation/parity artifacts in `plans/<feature-slug>/`. Initialize the run at `.workflow-kernel/runs/<run-id>`; current execution and stale reconciliation share the same verified `run-state.json`.
+Resolve `$WORKFLOW_KERNEL` -- the workflow-kernel launcher script -- once per run, following the single fail-closed resolution contract in the workflow-kernel plugin's `references/runtime-resolution.md` (launcher discovery snippet, repo-vs-cache trust boundaries, semver compatibility, symlink and scope fail-closed rules, and stable exit codes all live there; do not restate them here). Pin that absolute launcher path and its compatible version for the entire run; never re-resolve to a newer cache version mid-run. If the pinned runtime disappears or becomes incompatible, record shadow unavailable and continue the canonical workflow. Use only the launcher's stable subcommands; inline Python source is forbidden. Keep observation/parity artifacts in `plans/<feature-slug>/`. Initialize the run at `.workflow-kernel/runs/<run-id>`; current execution and stale reconciliation share the same verified `run-state.json`.
 
 Produce the independent prediction before corresponding authoritative actions, then seal it before the first observation:
 
@@ -222,7 +237,11 @@ Produce the independent prediction before corresponding authoritative actions, t
 "$WORKFLOW_KERNEL" bind-prediction --type pipeline --manifest plans/<feature-slug>/manifest.json --prediction-receipts plans/<feature-slug>/independent-prediction-receipts.json --state-dir plans/<feature-slug>
 ```
 
-Before each observation, atomically materialize the complete ordered redacted receipt array through the latest authoritative boundary at `plans/<feature-slug>/authoritative-receipts.json`, then invoke:
+Append receipts to the cumulative ledger at every boundary, but invoke the
+observer only twice: at `all-chunks-complete` before final full review and at
+terminal after the final authoritative receipt. Before either observation,
+atomically materialize the complete ordered redacted receipt array through that
+boundary at `plans/<feature-slug>/authoritative-receipts.json`, then invoke:
 
 ```text
 "$WORKFLOW_KERNEL" observe-pipeline --manifest plans/<feature-slug>/manifest.json --receipts plans/<feature-slug>/authoritative-receipts.json --state-dir plans/<feature-slug>
@@ -251,7 +270,8 @@ Before any git operations, validate the manifest:
 
 If validation fails, report the specific issue and stop.
 
-After the authoritative validation receipt exists, run `observe-pipeline` when the trusted runtime is available. A translator rejection is recorded as shadow evidence and does not replace this validation decision.
+Append the authoritative manifest-validation receipt to the cumulative ledger.
+Defer shadow observation until `all-chunks-complete`.
 
 ## Step 0b: MCP Pre-Flight Check
 
@@ -480,7 +500,8 @@ Read the `executionPlan.levels` array. Process each level in order.
 
 **Parallel levels:** Execute all chunks in a parallel group simultaneously using multiple Agent tool calls in a single message.
 
-After each authoritative dependency-ready and dispatch receipt exists, feed that receipt to `observe-pipeline` when available. Kernel readiness is a comparison prediction only and never selects the next chunk.
+Append each authoritative dependency-ready and dispatch receipt to the
+cumulative ledger. Defer shadow observation until `all-chunks-complete`.
 
 ## Step 3: Per-Chunk Execution
 
@@ -760,7 +781,12 @@ You MUST verify these before proceeding:
 
 1. **Completion check:** The subagent reported completion (not an error or question)
 2. **Commit check:** Run `git log <featureBranch>..<chunk-branch> --oneline` -- there MUST be at least one commit
-3. **Build check:** If available (Go: `go build ./...`, CSS: `npm run build`), run it
+3. **Focused verification:** Run the narrow build/tests that exercise the
+   chunk. Run the repository-wide suite once per completed execution level, or
+   when a merge changes code that invalidates the prior full-suite result.
+   Cache the verification receipt by content-addressed input: repository tree
+   hash, exact command, and relevant environment fingerprint. Documentation,
+   receipt, or metadata-only commits do not invalidate a passing code suite.
 4. **Provider receipt check:** The chunk receipt includes `implementedBy: codex` or `implementedBy: openrouter`. Any coding receipt with `implementedBy: claude` is a misroute.
 
 If any check fails:
@@ -772,7 +798,8 @@ If any check fails:
 
 Mark `[chunk-id] 5. Validate subagent output` complete.
 
-After the authoritative validation receipt is written, run `observe-pipeline` against it when shadow runtime is available. Adapter failure records a parity/unavailability event without changing the pass/fail decision.
+After the authoritative validation receipt is written, append it to the
+cumulative ledger. Defer shadow observation until `all-chunks-complete`.
 
 ### 3e.5: Live Wires Lint Guard
 
@@ -863,6 +890,13 @@ If anti-patterns are found, fix them BEFORE running the review loop. Don't rely 
 
 Mark `[chunk-id] 6. Run anti-pattern scan` complete.
 
+For UI chunks, run the cheap Datastar/markup static checks and one browser smoke
+immediately after this scan. Confirm the changed route renders, the console has
+no new errors, and the primary interaction responds. Fix failures before broad
+tests or review; do not postpone the first UI signal until the final browser
+gate. This smoke is additive evidence and does not replace Step 3h's full visual
+verification.
+
 ### 3g: Run Evaluation Gate (per classification)
 
 The evaluation depth depends on the chunk classification from Step 3a.
@@ -914,7 +948,7 @@ EVAL_GATE_PASSED: [chunk-id] | classification: [type] | iterations: [N] | findin
 
 Append `implementedBy: <provider>` and `fallback: <from>-><to>|none` to the chunk receipt adjacent to the eval gate line.
 
-Also record `requestedProvider`, `attemptedProvider`, and `fallbackReason`. Preserve unavailable attempts and misroutes honestly across `full_cli`, `codex_native`, and generic hosts. After the complete authoritative evaluation receipt exists, feed it to `observe-pipeline`; never synthesize `EVAL_GATE_PASSED` from a kernel prediction.
+Also record `requestedProvider`, `attemptedProvider`, and `fallbackReason`. Preserve unavailable attempts and misroutes honestly across `full_cli`, `codex_native`, and generic hosts. Append the complete authoritative evaluation receipt to the cumulative ledger and defer shadow observation until `all-chunks-complete`; never synthesize `EVAL_GATE_PASSED` from a kernel prediction.
 
 The `[type]` value uses the classification from the manifest's `kind` field when available (mapped per Step 3a), falling back to the runtime heuristic classification for older manifests. This receipt is consumed by the merge step. Without it, merge is blocked.
 
@@ -1046,7 +1080,10 @@ Report all findings as P1 (spec deviation, page doesn't load), P2 (visual criter
 
 For required browser-tooling failure, first persist safe attempt evidence, then quit the primary browser process/engine session (closing a tab is insufficient), launch a fresh primary profile with a changed session identity and retry once, then recheck the target and try a genuinely different configured engine. If restart or alternate launch cannot be proved, record that explicitly. Exhaustion ends `human_help_required` with all attempts and exact missing case IDs; it is never skipped, approved, empty coverage, or curl-verified. Product/application assertion failures are terminal findings and do not trigger browser restart. Curl and reachability are diagnostics only and never satisfy `BROWSER_VERIFIED`.
 
-After the authoritative `BROWSER_VERIFIED` or blocked human-help receipt exists, run `observe-pipeline`. A recovered alternate-engine pass remains degraded recovery evidence, not first-pass clean.
+Append the authoritative `BROWSER_VERIFIED` or blocked human-help receipt to the
+cumulative ledger. Defer shadow observation until `all-chunks-complete`. A
+recovered alternate-engine pass remains degraded recovery evidence, not
+first-pass clean.
 
 Mark `[chunk-id] 8. Run visual verification` complete only with complete required evidence. Otherwise mark it `blocked: human_help_required` and stop for user help; never mark it skipped or deferred.
 
@@ -1084,7 +1121,9 @@ If merge conflicts occur:
 
 Mark `[chunk-id] 9. Merge back` complete.
 
-Write the authoritative merge disposition, then run `observe-pipeline` against that receipt when available. A predicted merge mismatch is parity evidence and does not reverse or manufacture the merge.
+Write the authoritative merge disposition and append it to the cumulative
+ledger. Defer shadow observation until `all-chunks-complete`. A predicted merge
+mismatch is parity evidence and does not reverse or manufacture the merge.
 
 ### 3j: Clean Up Worktree
 
@@ -1102,6 +1141,12 @@ Read the chunk's registered resources and use these exact interfaces:
 Immediately before `plan-cleanup` and again before every `execute-cleanup-step`, atomically rewrite the bound node-status file with the complete current authoritative status of every declared dependent and a fresh observation timestamp. Never reuse another run/node's proof or a stale snapshot. `plan-cleanup` and `next-cleanup-step` return proposals/eligibility only. `execute-cleanup-step` is the only non-splittable authorization/execution boundary for exactly that immutable plan and step index with a fresh exact-ID inventory, complete fresh authoritative status proof for every declared dependent node, the gap-free prior outcomes, and any required successful predecessor result. Never execute any cleanup argv returned by planning separately and never pass a free-standing capability. For `stop-remove`, the guarded step uses a bounded stop before exact-ID removal. Actionless `MISSING` steps perform a fresh exact-ID inspect inside the same registry guard.
 
 Append each registry-issued command or terminal-observation outcome durably and in order, stop on blocked/unsafe/conflicting evidence, then call `record-cleanup` with the complete gap-free outcome sequence. Retain run-lifecycle resources while any declared dependent is incomplete. Cleanup failure or missing proof is `blocked/retained`, never reported clean. Broad prune, wildcards, negative filters, and name-based ownership are forbidden.
+
+**Empty-plan fast path:** Inspect the sealed cleanup plan after `plan-cleanup`.
+When it contains zero steps/actions, do not call `next-cleanup-step` or
+`execute-cleanup-step`. Write the empty outcomes array and call
+`record-cleanup` directly. This preserves an authoritative receipt without
+paying two no-op launcher invocations.
 
 Apply the safe-to-delete decision table from `repo-cleanup-contract.md`. A ref is deleted only when it is provably merged or provably empty. Never suppress git's exit status -- not on a removal, and not on the dirtiness check that gates it. A swallowed failure becomes a false "cleaned" line in the receipt.
 
@@ -1157,6 +1202,10 @@ Mark `[chunk-id] 10. Clean up worktree` complete (or `blocked: [reason]`).
 
 **THIS STEP IS MANDATORY.** After ALL chunks are merged, you MUST run a full dm-review.
 
+First materialize the cumulative authoritative receipt array through the
+`all-chunks-complete` boundary and run the first `observe-pipeline` checkpoint.
+The observation remains shadow evidence and cannot approve the final review.
+
 Verification invariant: use Codex and OpenRouter as independent coding providers. The final review must run on the provider that did not implement the majority of code. If OpenRouter implemented a chunk, Codex reviews it; if Codex implemented it, OpenRouter reviews it. If either lane is unavailable, report the gap and do not substitute Claude coding review.
 
 ```text
@@ -1177,7 +1226,7 @@ Key Requirements from original-prompt.md:
 In addition to code quality, check: does this code actually implement what was requested? Flag any requirement that appears unaddressed as P2.
 ```
 
-This catches cross-chunk integration issues that per-chunk quick reviews miss.
+This catches cross-chunk integration issues that focused per-chunk reviews miss.
 
 Apply zero-deferral: fix ALL findings at every severity.
 
@@ -1222,7 +1271,9 @@ if [ -n "$ENGINE" ] && [ -x "$ENGINE" ]; then bash "$ENGINE" write --phase "revi
 
 Mark `FINAL 1. Run full dm-review` complete.
 
-After the authoritative full-review and lane-coverage receipts exist, run `observe-pipeline`. Missing/degraded review lanes remain canonical evidence and cannot be erased by normalized host parity.
+Append the authoritative full-review and lane-coverage receipts to the
+cumulative ledger. Missing/degraded review lanes remain canonical evidence and
+cannot be erased by normalized host parity.
 
 ## Step 4b: Requirements Cross-Check
 
@@ -1264,7 +1315,9 @@ Do NOT deliver a branch that misses requirements from the original prompt. The u
 
 Mark `FINAL 2. Requirements cross-check` complete.
 
-After the authoritative requirements evidence file exists, run `observe-pipeline`. Missing evidence remains a canonical blocker; shadow comparison cannot waive or manufacture it.
+Append the authoritative requirements evidence receipt to the cumulative
+ledger. Missing evidence remains a canonical blocker; shadow comparison cannot
+waive or manufacture it.
 
 ## Step 4c: Merge Policy Check
 
@@ -1384,6 +1437,12 @@ Only after that receipt exists, process the separately sealed stale-sweep artifa
 ```
 
 Before every guarded execute call, refresh the exact inventory input and atomically rewrite the bound node-status proof. The stale plan contains actions only when the fixed state directory supplies fresh trusted inactive-lease proof; missing/untrusted proof produces blocked dispositions and no actions. `next-cleanup-step` is proposal/eligibility only. For every proposed action or actionless missing observation, `execute-cleanup-step` is the sole guarded authorization-and-execution boundary. Never execute returned cleanup argv separately. Persist each plan's registry-issued outcomes only in its own gap-free outcomes array and `record-cleanup` receipt; never combine, reorder, or cross-use the two plan authorities.
+
+For either independently sealed reconciliation plan, use the same empty-plan
+fast path as Step 3j: if the plan contains zero steps/actions, skip
+`next-cleanup-step` and `execute-cleanup-step`, write its distinct empty outcomes
+array, and call `record-cleanup` directly. Process current-run before stale-sweep
+even when one or both plans are empty.
 
 Reconciliation covers registered resources missed by an interrupted chunk and eligible stale orphans with complete labels plus fresh inactive-lease proof. Retain run-shared resources while any dependent is incomplete. Never broad-prune Docker, infer ownership by name, remove in-use networks/volumes, or report blocked/uninspectable resources clean. Capture Docker before/after inventories and every `removed|missing|retained|blocked|unmanaged` disposition before constructing the receipt.
 
@@ -1617,7 +1676,7 @@ Present this report:
 Base may be any existing ref from `manifest.baseBranch`; `main` is only the absent-field default.
 
 ## Chunks Executed
-| Chunk | Status | dm-review-loop Result | Notes |
+| Chunk | Status | Evaluation Gate Result | Notes |
 |-------|--------|----------------------|-------|
 | chunk-id | clean/needs-attention | N iterations, M findings | |
 
@@ -1723,7 +1782,7 @@ Before reporting any pipeline-blocking failure, run the Step 5b repository clean
 
 - Never force-push
 - Never modify main directly
-- Never skip dm-review-loop -- this is the most commonly skipped step and the most important
+- Never skip the risk-tiered evaluation gate or final full dm-review
 - Always clean up worktrees, even on failure
 - Always run Step 5b artifact cleanup, even on failure (Tier 1 always, Tier 2 only on success)
 - Always run the repository cleanup phase, even after review failure or an explicit gate

--- a/plugins/pipeline/commands/pipeline-run.md
+++ b/plugins/pipeline/commands/pipeline-run.md
@@ -1,12 +1,15 @@
 ---
 name: pipeline-run
-description: Execute generated prompts in worktrees with review-fix loops
+description: Execute generated prompts in worktrees with risk-tiered review gates
 argument-hint: "[path to manifest.json or prompts directory]"
 ---
 
 # Pipeline Run
 
-Execute a set of generated prompts autonomously in worktrees with review-fix loops. This is the execution engine -- it creates branches, runs subagents, reviews, fixes, merges, and delivers a clean feature branch.
+Execute a set of generated prompts autonomously in worktrees with focused
+ordinary-chunk review, sensitive-path escalation, and a final full review. This
+is the execution engine -- it creates branches, runs subagents, reviews, fixes,
+merges, and delivers a clean feature branch.
 
 ## Input
 
@@ -45,7 +48,9 @@ The canonical shadow inputs are `plans/<feature>/manifest.json` plus the cumulat
 "$WORKFLOW_KERNEL" bind-prediction --type pipeline --manifest plans/<feature>/manifest.json --prediction-receipts plans/<feature>/independent-prediction-receipts.json --state-dir plans/<feature>
 ```
 
-Every later boundary observation uses:
+Append every later authoritative receipt to the cumulative ledger. Observe only
+at the `all-chunks-complete` checkpoint before final full review and at the
+terminal checkpoint. Each observation uses:
 
 ```text
 "$WORKFLOW_KERNEL" observe-pipeline --manifest plans/<feature>/manifest.json --receipts plans/<feature>/authoritative-receipts.json --state-dir plans/<feature>
@@ -59,6 +64,12 @@ When this command runs in Codex and the session exposes `multi_agent_v1.spawn_ag
 
 The adapter also preserves `workflowClass` and provider evidence across hosts. Every dispatch receipt names `requestedProvider`, `attemptedProvider`, `implementedBy`, `fallback`, and `fallbackReason`. An unavailable or misrouted lane is evidence, not permission to silently relabel an inline implementation.
 
+Measure orchestration pauses with authoritative `progress` receipts carrying a
+nonnegative `duration_seconds` and exactly one `wait_category` from
+`human_gate`, `external_dependency`, `capacity`, or `ci`. Emit one receipt for
+the non-overlapping orchestrator-level interval, not one per parallel worker.
+Never estimate an interval or classify active implementation/review as waiting.
+
 **Protocol source:** Read `plugins/pipeline/agents/workflow/execution-orchestrator.md` as the execution contract. The current Codex agent acts as the orchestrator in-process because Codex does not expose Claude's generic agent runner. All orchestrator steps remain mandatory: worktree isolation or the documented `sequential-on-branch` isolation strategy (recorded as `isolationStrategy`, never as `executionMode`) for container-mounted test harnesses, input guardrails, chunk dispatch, validation, evaluation gates, merge-back, final full review, memory capture, cleanup, and summary.
 
 **Implementation dispatch:** For each chunk, create the worktree first, inline the full prompt content, then call `multi_agent_v1.spawn_agent` with `agent_type: "worker"`. The worker prompt MUST include:
@@ -71,11 +82,12 @@ The adapter also preserves `workflowClass` and provider evidence across hosts. E
 
 Wait for the worker result before validating that chunk. Do not dispatch overlapping chunks in parallel unless the manifest level grouping and file ownership are disjoint.
 
-**dm-review inline protocol:** Codex sessions do not expose a generic nested `Skill(skill="dm-review:review", ...)` callable. Replace those nested calls with an inline execution of `plugins/dm-review/skills/review/SKILL.md` in the current orchestrator context:
+**Review adapter:** Codex sessions do not expose a generic nested `Skill(skill="dm-review:review", ...)` callable. Use this risk-tiered contract in the current orchestrator context:
 
-- For per-chunk gates, run the review skill's quick-mode protocol against the chunk worktree.
+- For ordinary non-sensitive chunks, run one focused read-only Codex review against the chunk diff and allow at most one repair/recheck pass. Preserve pending/done todo receipts and zero-deferral handling.
+- For sensitive-path chunks, run the full inline `plugins/dm-review/skills/review/SKILL.md` protocol against the chunk worktree, with at most two passes.
 - For the final gate, run the review skill's full-mode protocol against the feature branch.
-- Use `multi_agent_v1.spawn_agent` for the review agents selected by the dm-review protocol when available.
+- Use `multi_agent_v1.spawn_agent` for the focused Codex reviewer or for review agents selected by the full dm-review protocol when available.
 - Preserve zero-deferral: fix all P1, P2, and P3 findings or record an explicit deferred-finding justification after the documented convergence limits.
 - Write/read the same `todos/*-pending-*.md` and `todos/*-done-*.md` receipts that dm-review uses.
 
@@ -95,11 +107,11 @@ The Codex adapter does not get a weaker gate than the Claude path. If `codex_nat
    - Branch creation
    - Worktree creation per chunk
    - Subagent dispatch with inlined prompt content
-   - dm-review-loop after each chunk (quick mode, zero-deferral)
+   - focused Codex review after ordinary chunks; full review for sensitive paths
    - Merge back to feature branch
    - Final full dm-review
    - ai-memory session recording
-   - shadow observation after each authoritative receipt, when the trusted runtime is available
+   - cumulative shadow observation after all chunks and at terminal, when the trusted runtime is available
 6. Present the execution summary
 
 ## After Execution

--- a/plugins/pipeline/commands/pipeline.md
+++ b/plugins/pipeline/commands/pipeline.md
@@ -47,7 +47,7 @@ Choose lean versus full mode from dependency shape, risk, and verification needs
 **These stay mandatory regardless of provider:**
 
 - The adversarial review (Phase 5) -- self-evaluation is unreliable at any capability level.
-- dm-review-loop -- separating generator from evaluator is an architectural principle, not a model limitation.
+- A focused Codex review after ordinary chunks, full review for sensitive paths, and final full dm-review -- separating generator from evaluator is an architectural principle, not a model limitation.
 
 **Periodically question whether each pipeline component is still necessary.** Every component encodes an assumption about model limitations. Test whether scaffolding remains needed as models and effort levels improve.
 
@@ -57,7 +57,7 @@ You MUST execute every phase in order. You MUST NOT skip phases, combine phases,
 
 - You MUST NOT skip research because you think you have enough context
 - You MUST NOT execute chunks yourself -- you MUST launch the execution-orchestrator agent
-- You MUST NOT skip dm-review-loop after each chunk
+- You MUST NOT skip the risk-tiered evaluation gate after each chunk
 - You MUST NOT skip the final full dm-review
 - You MUST pause for user input at every marked pause point
 - You MUST save all artifacts to disk (briefs, plans, prompts, manifest) -- not just hold them in context
@@ -75,7 +75,7 @@ The pipeline enforces gates, review loops, visual verification, memory capture, 
 - Visual verification gets skipped entirely (documented in `docs/post-mortems/2026-04-07-pipeline-ui-refinement-postmortem.md`)
 - Requirements get marked "done" without evidence (documented in `docs/post-mortems/2026-04-10-pipeline-visual-testing-postmortem.md`)
 - The adversarial review never runs, so hallucinated APIs and missing edge cases ship
-- dm-review-loop never runs, so the evaluator/generator separation is lost
+- the independent evaluation gate never runs, so evaluator/generator separation is lost
 
 If you catch yourself planning to "just do it quickly" without invoking the pipeline skill, you are about to repeat a documented failure. Stop and invoke the skill.
 
@@ -103,6 +103,16 @@ Create this ledger with TodoWrite at the start. Update it as you complete each p
 
 Mark each item as you complete it. Do not mark a GATE as complete until AskUserQuestion has returned a response from the user. If you find yourself proceeding past a GATE without an AskUserQuestion response, you have violated the gate.
 
+### Wait Measurement
+
+Timestamp immediately before each user gate and immediately after the response.
+Append one authoritative `progress` receipt with `wait_category: human_gate` and
+the measured nonnegative `duration_seconds`. Record orchestration-level waits,
+not one receipt per parallel lane, so elapsed intervals never double-count.
+Use the same receipt shape for any later `external_dependency`, `capacity`, or
+`ci` wait. Do not estimate missing timestamps and do not label active review or
+implementation time as waiting.
+
 ### Shadow Workflow Kernel Hooks
 
 The Progress Ledger, canonical Markdown phases, manifest, routing policy, execution-orchestrator, and authoritative receipts remain the source of truth. Kernel hooks run only after the matching authoritative artifact, receipt, or action exists. They may observe and compare; they may not select ready nodes, advance gates, block or approve a merge, alter provider fallback, invoke cleanup, or convert review outcomes.
@@ -116,7 +126,11 @@ After producing `independent-prediction-receipts.json` and before any correspond
 "$WORKFLOW_KERNEL" bind-prediction --type pipeline --manifest plans/<feature-slug>/manifest.json --prediction-receipts plans/<feature-slug>/independent-prediction-receipts.json --state-dir plans/<feature-slug>
 ```
 
-At each phase boundary, rewrite `plans/<feature-slug>/authoritative-receipts.json` as the complete ordered, redacted receipt array through that boundary, then invoke exactly:
+At each phase boundary, append the authoritative receipt to the cumulative
+ordered redacted ledger. Do not invoke the observer for every phase. After all
+implementation chunks are complete and before final full review, rewrite
+`plans/<feature-slug>/authoritative-receipts.json` through the
+`all-chunks-complete` boundary and invoke exactly:
 
 ```text
 "$WORKFLOW_KERNEL" observe-pipeline --manifest plans/<feature-slug>/manifest.json --receipts plans/<feature-slug>/authoritative-receipts.json --state-dir plans/<feature-slug>
@@ -385,9 +399,9 @@ Mark item 11 when AskUserQuestion returns the user's explicit approval.
 2. Confirm git working tree has no blocking user-file changes (pipeline-owned artifacts may be committed/gitignored/force-added per the orchestrator)
 3. Confirm on `manifest.baseBranch` with latest changes, defaulting to `main` only when the field is absent
 
-**You MUST launch the execution-orchestrator agent.** You MUST NOT execute chunks yourself with general-purpose agents. The execution-orchestrator handles worktree isolation, input guardrails, Fix Philosophy injection, output validation, dm-review-loop after each chunk, merging, final full dm-review, and memory capture. If you skip it, all of those steps get skipped.
+**You MUST launch the execution-orchestrator agent.** You MUST NOT execute chunks yourself with general-purpose agents. The execution-orchestrator handles worktree isolation, input guardrails, Fix Philosophy injection, output validation, focused Codex review for ordinary chunks, full review for sensitive chunks, merging, final full dm-review, and memory capture. If you skip it, all of those steps get skipped.
 
-**Codex Native Execution Adapter:** If this command is running in Codex and the session exposes `multi_agent_v1.spawn_agent`, use the adapter documented in `/pipeline-run` (`plugins/pipeline/commands/pipeline-run.md`) for Phase 6. The current Codex agent acts as the orchestrator in-process while following `plugins/pipeline/agents/workflow/execution-orchestrator.md` as the contract, dispatches chunk workers with `multi_agent_v1.spawn_agent`, and replaces nested `Skill(skill="dm-review:review", ...)` calls with the dm-review inline protocol. This is equivalent pipeline execution and MUST record `executionMode: codex_native` in every receipt.
+**Codex Native Execution Adapter:** If this command is running in Codex and the session exposes `multi_agent_v1.spawn_agent`, use the adapter documented in `/pipeline-run` (`plugins/pipeline/commands/pipeline-run.md`) for Phase 6. The current Codex agent acts as the orchestrator in-process while following `plugins/pipeline/agents/workflow/execution-orchestrator.md` as the contract, dispatches chunk workers with `multi_agent_v1.spawn_agent`, and applies the risk-tiered focused/full review adapter. This is equivalent pipeline execution and MUST record `executionMode: codex_native` in every receipt.
 
 Pass `workflowClass` unchanged into Phase 6. Every provider receipt must name requested provider, attempted provider, actual implementer, fallback, and reason. Missing lanes and misroutes remain explicit evidence; provider substitution never changes the required validation, review, browser, requirements, or cleanup gates.
 
@@ -556,7 +570,7 @@ Before delivering to the user, verify your own compliance by answering these que
 6. Did I check requirements coverage against the cached Key Requirements?
 7. Did I run the adversarial review (max 4 rounds)?
 8. Did I launch the actual execution-orchestrator agent (not run chunks manually)?
-9. Did the orchestrator run dm-review-loop after each chunk?
+9. Did the orchestrator run the risk-tiered evaluation gate after each chunk?
 10. Did the orchestrator run a final full dm-review?
 11. Did the orchestrator record the session to ai-memory?
 12. **Browser authority audit:** Did every required UI/Integration case produce browser evidence, or a blocked `human_help_required` receipt after primary quit, fresh-primary retry, and different-browser attempt? Curl and grep are not visual verification.

--- a/plugins/pipeline/references/run-postmortem-schema.md
+++ b/plugins/pipeline/references/run-postmortem-schema.md
@@ -17,6 +17,9 @@ Every full pipeline run writes `plans/<slug>/run-postmortem.md` after memory cap
 - `kernelReliability` - shadow availability, semantic parity status, comparison reason counts, observation/adapter failures, missing authoritative evidence, browser recovery outcomes, owned-resource cleanup outcomes, and reconciliation results.
 - `workflowClass` - validated class plus `workflow_class_defaulted`; metrics retain the authoritative manifest value unchanged.
 - `providerReceipts` - requested, attempted, implemented-by, fallback, and reason for every routed lane, including unavailable and misrouted lanes.
+- `wallClockSeconds` - elapsed seconds from the first authoritative event to the last event in the run.
+- `activeComputeSeconds` - wall-clock seconds minus typed waits, floored at zero.
+- `waitSecondsByCategory` - nonnegative durations grouped into `human_gate`, `external_dependency`, `capacity`, and `ci`. A wait receipt carries both `wait_category` and `duration_seconds`; unknown categories are invalid rather than silently folded into active work.
 
 Kernel reliability data is measurement only. A parity report or reliability recommendation cannot mutate routing policy, workflow stages, cleanup state, merge results, or review outcomes. Promotion requires a separate human-approved source change after evidence review.
 

--- a/plugins/pipeline/skills/pipeline-run/SKILL.md
+++ b/plugins/pipeline/skills/pipeline-run/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pipeline-run
-description: Codex skill alias for /pipeline-run. Execute generated prompts in worktrees with review-fix loops
+description: Codex skill alias for /pipeline-run. Execute generated prompts in worktrees with risk-tiered review gates
 argument-hint: "[path to manifest.json or prompts directory]"
 ---
 
@@ -21,7 +21,10 @@ argument-hint: "[path to manifest.json or prompts directory]"
 
 # Pipeline Run
 
-Execute a set of generated prompts autonomously in worktrees with review-fix loops. This is the execution engine -- it creates branches, runs subagents, reviews, fixes, merges, and delivers a clean feature branch.
+Execute a set of generated prompts autonomously in worktrees with focused
+ordinary-chunk review, sensitive-path escalation, and a final full review. This
+is the execution engine -- it creates branches, runs subagents, reviews, fixes,
+merges, and delivers a clean feature branch.
 
 ## Input
 
@@ -60,7 +63,9 @@ The canonical shadow inputs are `plans/<feature>/manifest.json` plus the cumulat
 "$WORKFLOW_KERNEL" bind-prediction --type pipeline --manifest plans/<feature>/manifest.json --prediction-receipts plans/<feature>/independent-prediction-receipts.json --state-dir plans/<feature>
 ```
 
-Every later boundary observation uses:
+Append every later authoritative receipt to the cumulative ledger. Observe only
+at the `all-chunks-complete` checkpoint before final full review and at the
+terminal checkpoint. Each observation uses:
 
 ```text
 "$WORKFLOW_KERNEL" observe-pipeline --manifest plans/<feature>/manifest.json --receipts plans/<feature>/authoritative-receipts.json --state-dir plans/<feature>
@@ -74,6 +79,12 @@ When this command runs in Codex and the session exposes `multi_agent_v1.spawn_ag
 
 The adapter also preserves `workflowClass` and provider evidence across hosts. Every dispatch receipt names `requestedProvider`, `attemptedProvider`, `implementedBy`, `fallback`, and `fallbackReason`. An unavailable or misrouted lane is evidence, not permission to silently relabel an inline implementation.
 
+Measure orchestration pauses with authoritative `progress` receipts carrying a
+nonnegative `duration_seconds` and exactly one `wait_category` from
+`human_gate`, `external_dependency`, `capacity`, or `ci`. Emit one receipt for
+the non-overlapping orchestrator-level interval, not one per parallel worker.
+Never estimate an interval or classify active implementation/review as waiting.
+
 **Protocol source:** Read `plugins/pipeline/agents/workflow/execution-orchestrator.md` as the execution contract. The current Codex agent acts as the orchestrator in-process because Codex does not expose Claude's generic agent runner. All orchestrator steps remain mandatory: worktree isolation or the documented `sequential-on-branch` isolation strategy (recorded as `isolationStrategy`, never as `executionMode`) for container-mounted test harnesses, input guardrails, chunk dispatch, validation, evaluation gates, merge-back, final full review, memory capture, cleanup, and summary.
 
 **Implementation dispatch:** For each chunk, create the worktree first, inline the full prompt content, then call `multi_agent_v1.spawn_agent` with `agent_type: "worker"`. The worker prompt MUST include:
@@ -86,11 +97,12 @@ The adapter also preserves `workflowClass` and provider evidence across hosts. E
 
 Wait for the worker result before validating that chunk. Do not dispatch overlapping chunks in parallel unless the manifest level grouping and file ownership are disjoint.
 
-**dm-review inline protocol:** Codex sessions do not expose a generic nested `Skill(skill="dm-review:review", ...)` callable. Replace those nested calls with an inline execution of `plugins/dm-review/skills/review/SKILL.md` in the current orchestrator context:
+**Review adapter:** Codex sessions do not expose a generic nested `Skill(skill="dm-review:review", ...)` callable. Use this risk-tiered contract in the current orchestrator context:
 
-- For per-chunk gates, run the review skill's quick-mode protocol against the chunk worktree.
+- For ordinary non-sensitive chunks, run one focused read-only Codex review against the chunk diff and allow at most one repair/recheck pass. Preserve pending/done todo receipts and zero-deferral handling.
+- For sensitive-path chunks, run the full inline `plugins/dm-review/skills/review/SKILL.md` protocol against the chunk worktree, with at most two passes.
 - For the final gate, run the review skill's full-mode protocol against the feature branch.
-- Use `multi_agent_v1.spawn_agent` for the review agents selected by the dm-review protocol when available.
+- Use `multi_agent_v1.spawn_agent` for the focused Codex reviewer or for review agents selected by the full dm-review protocol when available.
 - Preserve zero-deferral: fix all P1, P2, and P3 findings or record an explicit deferred-finding justification after the documented convergence limits.
 - Write/read the same `todos/*-pending-*.md` and `todos/*-done-*.md` receipts that dm-review uses.
 
@@ -110,11 +122,11 @@ The Codex adapter does not get a weaker gate than the Claude path. If `codex_nat
    - Branch creation
    - Worktree creation per chunk
    - Subagent dispatch with inlined prompt content
-   - dm-review-loop after each chunk (quick mode, zero-deferral)
+   - focused Codex review after ordinary chunks; full review for sensitive paths
    - Merge back to feature branch
    - Final full dm-review
    - ai-memory session recording
-   - shadow observation after each authoritative receipt, when the trusted runtime is available
+   - cumulative shadow observation after all chunks and at terminal, when the trusted runtime is available
 6. Present the execution summary
 
 ## After Execution

--- a/plugins/pipeline/skills/pipeline/SKILL.md
+++ b/plugins/pipeline/skills/pipeline/SKILL.md
@@ -62,7 +62,7 @@ Choose lean versus full mode from dependency shape, risk, and verification needs
 **These stay mandatory regardless of provider:**
 
 - The adversarial review (Phase 5) -- self-evaluation is unreliable at any capability level.
-- dm-review-loop -- separating generator from evaluator is an architectural principle, not a model limitation.
+- A focused Codex review after ordinary chunks, full review for sensitive paths, and final full dm-review -- separating generator from evaluator is an architectural principle, not a model limitation.
 
 **Periodically question whether each pipeline component is still necessary.** Every component encodes an assumption about model limitations. Test whether scaffolding remains needed as models and effort levels improve.
 
@@ -72,7 +72,7 @@ You MUST execute every phase in order. You MUST NOT skip phases, combine phases,
 
 - You MUST NOT skip research because you think you have enough context
 - You MUST NOT execute chunks yourself -- you MUST launch the execution-orchestrator agent
-- You MUST NOT skip dm-review-loop after each chunk
+- You MUST NOT skip the risk-tiered evaluation gate after each chunk
 - You MUST NOT skip the final full dm-review
 - You MUST pause for user input at every marked pause point
 - You MUST save all artifacts to disk (briefs, plans, prompts, manifest) -- not just hold them in context
@@ -90,7 +90,7 @@ The pipeline enforces gates, review loops, visual verification, memory capture, 
 - Visual verification gets skipped entirely (documented in `docs/post-mortems/2026-04-07-pipeline-ui-refinement-postmortem.md`)
 - Requirements get marked "done" without evidence (documented in `docs/post-mortems/2026-04-10-pipeline-visual-testing-postmortem.md`)
 - The adversarial review never runs, so hallucinated APIs and missing edge cases ship
-- dm-review-loop never runs, so the evaluator/generator separation is lost
+- the independent evaluation gate never runs, so evaluator/generator separation is lost
 
 If you catch yourself planning to "just do it quickly" without invoking the pipeline skill, you are about to repeat a documented failure. Stop and invoke the skill.
 
@@ -118,6 +118,16 @@ Create this ledger with TodoWrite at the start. Update it as you complete each p
 
 Mark each item as you complete it. Do not mark a GATE as complete until AskUserQuestion has returned a response from the user. If you find yourself proceeding past a GATE without an AskUserQuestion response, you have violated the gate.
 
+### Wait Measurement
+
+Timestamp immediately before each user gate and immediately after the response.
+Append one authoritative `progress` receipt with `wait_category: human_gate` and
+the measured nonnegative `duration_seconds`. Record orchestration-level waits,
+not one receipt per parallel lane, so elapsed intervals never double-count.
+Use the same receipt shape for any later `external_dependency`, `capacity`, or
+`ci` wait. Do not estimate missing timestamps and do not label active review or
+implementation time as waiting.
+
 ### Shadow Workflow Kernel Hooks
 
 The Progress Ledger, canonical Markdown phases, manifest, routing policy, execution-orchestrator, and authoritative receipts remain the source of truth. Kernel hooks run only after the matching authoritative artifact, receipt, or action exists. They may observe and compare; they may not select ready nodes, advance gates, block or approve a merge, alter provider fallback, invoke cleanup, or convert review outcomes.
@@ -131,7 +141,11 @@ After producing `independent-prediction-receipts.json` and before any correspond
 "$WORKFLOW_KERNEL" bind-prediction --type pipeline --manifest plans/<feature-slug>/manifest.json --prediction-receipts plans/<feature-slug>/independent-prediction-receipts.json --state-dir plans/<feature-slug>
 ```
 
-At each phase boundary, rewrite `plans/<feature-slug>/authoritative-receipts.json` as the complete ordered, redacted receipt array through that boundary, then invoke exactly:
+At each phase boundary, append the authoritative receipt to the cumulative
+ordered redacted ledger. Do not invoke the observer for every phase. After all
+implementation chunks are complete and before final full review, rewrite
+`plans/<feature-slug>/authoritative-receipts.json` through the
+`all-chunks-complete` boundary and invoke exactly:
 
 ```text
 "$WORKFLOW_KERNEL" observe-pipeline --manifest plans/<feature-slug>/manifest.json --receipts plans/<feature-slug>/authoritative-receipts.json --state-dir plans/<feature-slug>
@@ -400,9 +414,9 @@ Mark item 11 when AskUserQuestion returns the user's explicit approval.
 2. Confirm git working tree has no blocking user-file changes (pipeline-owned artifacts may be committed/gitignored/force-added per the orchestrator)
 3. Confirm on `manifest.baseBranch` with latest changes, defaulting to `main` only when the field is absent
 
-**You MUST launch the execution-orchestrator agent.** You MUST NOT execute chunks yourself with general-purpose agents. The execution-orchestrator handles worktree isolation, input guardrails, Fix Philosophy injection, output validation, dm-review-loop after each chunk, merging, final full dm-review, and memory capture. If you skip it, all of those steps get skipped.
+**You MUST launch the execution-orchestrator agent.** You MUST NOT execute chunks yourself with general-purpose agents. The execution-orchestrator handles worktree isolation, input guardrails, Fix Philosophy injection, output validation, focused Codex review for ordinary chunks, full review for sensitive chunks, merging, final full dm-review, and memory capture. If you skip it, all of those steps get skipped.
 
-**Codex Native Execution Adapter:** If this command is running in Codex and the session exposes `multi_agent_v1.spawn_agent`, use the adapter documented in `/pipeline-run` (`plugins/pipeline/commands/pipeline-run.md`) for Phase 6. The current Codex agent acts as the orchestrator in-process while following `plugins/pipeline/agents/workflow/execution-orchestrator.md` as the contract, dispatches chunk workers with `multi_agent_v1.spawn_agent`, and replaces nested `Skill(skill="dm-review:review", ...)` calls with the dm-review inline protocol. This is equivalent pipeline execution and MUST record `executionMode: codex_native` in every receipt.
+**Codex Native Execution Adapter:** If this command is running in Codex and the session exposes `multi_agent_v1.spawn_agent`, use the adapter documented in `/pipeline-run` (`plugins/pipeline/commands/pipeline-run.md`) for Phase 6. The current Codex agent acts as the orchestrator in-process while following `plugins/pipeline/agents/workflow/execution-orchestrator.md` as the contract, dispatches chunk workers with `multi_agent_v1.spawn_agent`, and applies the risk-tiered focused/full review adapter. This is equivalent pipeline execution and MUST record `executionMode: codex_native` in every receipt.
 
 Pass `workflowClass` unchanged into Phase 6. Every provider receipt must name requested provider, attempted provider, actual implementer, fallback, and reason. Missing lanes and misroutes remain explicit evidence; provider substitution never changes the required validation, review, browser, requirements, or cleanup gates.
 
@@ -571,7 +585,7 @@ Before delivering to the user, verify your own compliance by answering these que
 6. Did I check requirements coverage against the cached Key Requirements?
 7. Did I run the adversarial review (max 4 rounds)?
 8. Did I launch the actual execution-orchestrator agent (not run chunks manually)?
-9. Did the orchestrator run dm-review-loop after each chunk?
+9. Did the orchestrator run the risk-tiered evaluation gate after each chunk?
 10. Did the orchestrator run a final full dm-review?
 11. Did the orchestrator record the session to ai-memory?
 12. **Browser authority audit:** Did every required UI/Integration case produce browser evidence, or a blocked `human_help_required` receipt after primary quit, fresh-primary retry, and different-browser attempt? Curl and grep are not visual verification.

--- a/plugins/pipeline/skills/promptcraft/SKILL.md
+++ b/plugins/pipeline/skills/promptcraft/SKILL.md
@@ -39,7 +39,12 @@ Read the plan and identify discrete chunks of work. A chunk is:
 3. Integration work (wiring things together) depends on the pieces it connects
 4. Test-only chunks are rare -- tests should live with their implementation chunk
 5. Configuration/deployment chunks run last
-6. After determining `filesToModify` for each chunk, classify its `kind` using the file-extension heuristic:
+6. Do not create an orchestrator-owned closeout chunk. Verification summaries,
+   requirements cross-checks, post-mortems, cleanup, delivery receipts, PR
+   publication, and issue disposition belong to the pipeline's final stages.
+   They may appear in a product chunk only when that chunk also contains real
+   integration code required by its acceptance criteria.
+7. After determining `filesToModify` for each chunk, classify its `kind` using the file-extension heuristic:
    - `ui`: any `.templ`, `.twig`, `.html`, `.css`, or files in `pages/`, `templates/`, `views/`
    - `logic`: `.go`, `.py`, `.ts`, `.php` handlers/services/migrations without templates
    - `integration`: prompt contains wiring verbs ("wire," "integrate," "connect") OR modifies route files / `main.go`
@@ -55,6 +60,18 @@ Read the plan and identify discrete chunks of work. A chunk is:
    When a chunk's files span multiple categories, classify up: `ui` > `integration` > `logic` > `config`.
 
    Before assigning Codex because a task needs a live connector, browser, GitHub/Notion operation, or another host-only tool, split the live-tool action from offline analysis/config/docs whenever file ownership and dependency order permit. The offline chunk keeps its policy-selected OpenRouter executor. If a chunk's `executor` differs from the routing-policy default, add a `routingOverride` object with `reasonCode`, a concrete `reason`, `splitAttempted`, and `splitBlockedBy`. A `config`/docs chunk with `executor: codex` and no complete `routingOverride` is invalid; tool mentions alone are never a silent override.
+
+**Run-size and scope budget:**
+
+- Default to no more than 8 total chunks and no more than 6 chunks classified
+  `large`. This is a run budget, not permission to make oversized chunks.
+- If the approved work exceeds either limit, return to the planning user gate
+  with a campaign split. A single oversized run requires an explicit approved
+  rationale in the plan; promptcraft must not invent one.
+- Freeze scope when the execution prompts are approved. New desirable work is
+  written to a follow-up manifest unless it is a correctness blocker for an
+  approved requirement. Do not expand a running chunk merely because adjacent
+  cleanup or polish becomes visible.
 
 ### Phase 2: Context Extraction
 

--- a/plugins/pipeline/skills/promptcraft/references/manifest-schema.md
+++ b/plugins/pipeline/skills/promptcraft/references/manifest-schema.md
@@ -115,6 +115,21 @@ The `chunks` array is authoritative. The `executionPlan` object is a cached deno
 
 `workflowClass` is policy input, not cached execution structure. New manifests copy it unchanged from the user-approved plan island; absent or ambiguous plan data returns to the planning user gate and blocks generation. Validate it against the seven-value enum below and pass it unchanged. Do not copy workflow stages or safety-anchor constants into this schema; the workflow-kernel's separately versioned trusted policy remains authoritative.
 
+## Performance Contract
+
+The manifest describes product work, not pipeline closeout. Do not emit an
+orchestrator-owned closeout chunk for verification summaries, requirements
+cross-checks, post-mortems, cleanup, delivery receipts, PR publication, or issue
+disposition. The orchestrator's final stages own those actions. A chunk may
+include one only when it also delivers actual product integration code required
+by an acceptance criterion.
+
+The default single-run budget is 8 total chunks and 6 `large` chunks. Exceeding
+either limit returns to the planning user gate for a campaign split unless the
+approved plan contains an explicit single-run rationale. Approval freezes run
+scope: newly discovered desirable work goes to a follow-up manifest unless it
+blocks correctness of an approved requirement.
+
 ## Field Definitions
 
 ### Top-level

--- a/plugins/workflow-kernel/.claude-plugin/plugin.json
+++ b/plugins/workflow-kernel/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "workflow-kernel",
-  "description": "Neutral deterministic run-state, replay, recovery, receipts, and shadow observation for Design Machines workflows.",
-  "version": "0.1.1",
+  "description": "Neutral deterministic run-state, replay, recovery, receipts, shadow observation, and active-versus-wait runtime metrics for Design Machines workflows.",
+  "version": "0.2.0",
   "author": {
     "name": "Design Machines",
     "url": "https://designmachines.studio"

--- a/plugins/workflow-kernel/.codex-plugin/plugin.json
+++ b/plugins/workflow-kernel/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "workflow-kernel",
-  "version": "0.1.1",
-  "description": "Neutral deterministic run-state, replay, recovery, receipts, and shadow observation for Design Machines workflows.",
+  "version": "0.2.0",
+  "description": "Neutral deterministic run-state, replay, recovery, receipts, shadow observation, and active-versus-wait runtime metrics for Design Machines workflows.",
   "author": {
     "name": "Design Machines",
     "url": "https://designmachines.studio"
@@ -43,8 +43,8 @@
   "optionalPluginDependencies": {},
   "interface": {
     "displayName": "Workflow Kernel",
-    "shortDescription": "Neutral deterministic run-state, replay, recovery, receipts, and shadow observation for Design Machines workflows.",
-    "longDescription": "Neutral deterministic run-state, replay, recovery, receipts, and shadow observation for Design Machines workflows.",
+    "shortDescription": "Neutral deterministic run-state, replay, recovery, receipts, shadow observation, and active-versus-wait runtime metrics ",
+    "longDescription": "Neutral deterministic run-state, replay, recovery, receipts, shadow observation, and active-versus-wait runtime metrics for Design Machines workflows.",
     "developerName": "Design Machines",
     "category": "Productivity",
     "capabilities": [

--- a/plugins/workflow-kernel/skills/workflow-kernel/references/workflow_kernel/_translation.py
+++ b/plugins/workflow-kernel/skills/workflow-kernel/references/workflow_kernel/_translation.py
@@ -29,7 +29,7 @@ ISOLATION_STRATEGIES = frozenset({
 })
 COMMON_RECEIPT_FIELDS = frozenset({
     "stage", "status", "host", "mechanism", "workflow_class", "provider",
-    "model", "attempt", "duration_seconds", "first_pass", "fallback_reason",
+    "model", "attempt", "duration_seconds", "wait_category", "first_pass", "fallback_reason",
     "retry_reason", "isolation_mode", "isolation_strategy",
     "persona_expected", "persona_passed",
     "persona_recovered", "persona_missing", "cleanup_removed",

--- a/plugins/workflow-kernel/skills/workflow-kernel/references/workflow_kernel/metrics.py
+++ b/plugins/workflow-kernel/skills/workflow-kernel/references/workflow_kernel/metrics.py
@@ -10,6 +10,14 @@ from typing import Iterable, Mapping, Optional, Tuple
 from .schema import WorkflowEvent
 
 
+WAIT_CATEGORIES = (
+    "human_gate",
+    "external_dependency",
+    "capacity",
+    "ci",
+)
+
+
 @dataclass(frozen=True)
 class ReliabilityReport:
     event_count: int
@@ -42,6 +50,9 @@ class ReliabilityReport:
     cost_usd: Optional[float]
     completion_rate: float
     time_to_clean_seconds: Optional[float]
+    wall_clock_seconds: Optional[float]
+    active_compute_seconds: Optional[float]
+    wait_seconds_by_category: Mapping[str, float]
     cost_to_clean: Optional[float]
     fallback_rate: float
     cleanup_reliability: float
@@ -70,6 +81,9 @@ class ReliabilityReport:
             "tokens": self.tokens, "cost_usd": self.cost_usd,
             "completion_rate": self.completion_rate,
             "time_to_clean_seconds": self.time_to_clean_seconds,
+            "wall_clock_seconds": self.wall_clock_seconds,
+            "active_compute_seconds": self.active_compute_seconds,
+            "wait_seconds_by_category": dict(self.wait_seconds_by_category),
             "cost_to_clean": self.cost_to_clean, "fallback_rate": self.fallback_rate,
             "cleanup_reliability": self.cleanup_reliability,
             "proposals": [dict(value) for value in self.proposals],
@@ -114,6 +128,7 @@ class MetricsAggregator:
         cost = 0.0
         saw_tokens = saw_cost = False
         validation_count = validation_first = fallbacks = completed = terminals = 0
+        wait_seconds = Counter()
         for event in values:
             payload = event.payload
             for name, counter in dimensions.items():
@@ -128,6 +143,13 @@ class MetricsAggregator:
             if "duration_seconds" in payload:
                 nodes_with_explicit_duration.add(node)
                 explicit_node_durations[node] += _number(
+                    payload, "duration_seconds", float,
+                )
+            wait_category = payload.get("wait_category")
+            if wait_category is not None:
+                if wait_category not in WAIT_CATEGORIES:
+                    raise ValueError("invalid wait category: " + str(wait_category))
+                wait_seconds[wait_category] += _number(
                     payload, "duration_seconds", float,
                 )
             attempt = payload.get("attempt")
@@ -190,6 +212,14 @@ class MetricsAggregator:
             (max(cleanup_times) - min(event_times)).total_seconds()
             if cleanup_times and event_times else None
         )
+        wall_clock_seconds = (
+            (max(event_times) - min(event_times)).total_seconds()
+            if event_times else None
+        )
+        active_compute_seconds = (
+            max(0.0, wall_clock_seconds - sum(wait_seconds.values()))
+            if wall_clock_seconds is not None else None
+        )
         proposals = ()
         if fallbacks:
             proposals += ({
@@ -220,6 +250,9 @@ class MetricsAggregator:
             cost if saw_cost else None,
             completed / terminals if terminals else 0.0,
             clean_seconds,
+            wall_clock_seconds,
+            active_compute_seconds,
+            {category: wait_seconds[category] for category in WAIT_CATEGORIES},
             cost / clean_total if saw_cost and clean_total else None,
             fallbacks / len(values) if values else 0.0,
             clean_total / cleanup_total if cleanup_total else 0.0,

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -34,12 +34,42 @@ class MetricsTests(unittest.TestCase):
         self.assertIsNone(report.tokens)
         self.assertIsNone(report.cost_usd)
         self.assertIsNone(report.time_to_clean_seconds)
+        self.assertIsNone(report.wall_clock_seconds)
+        self.assertIsNone(report.active_compute_seconds)
+        self.assertEqual(
+            report.wait_seconds_by_category,
+            {
+                "human_gate": 0,
+                "external_dependency": 0,
+                "capacity": 0,
+                "ci": 0,
+            },
+        )
         self.assertEqual(report.proposals, ())
 
     def test_time_to_clean_uses_run_start_to_terminal_cleanup(self):
         events = translate_pipeline_receipts(json.loads((FIXTURES / "pipeline-claude.json").read_text()))
         report = MetricsAggregator().aggregate(events)
         self.assertEqual(report.time_to_clean_seconds, 540.0)
+
+    def test_wall_clock_separates_active_compute_from_typed_waits(self):
+        receipts = json.loads((FIXTURES / "pipeline-claude.json").read_text())
+        receipts[1]["wait_category"] = "human_gate"
+        receipts[1]["duration_seconds"] = 120
+        receipts[4]["wait_category"] = "ci"
+        receipts[4]["duration_seconds"] = 30
+        report = MetricsAggregator().aggregate(translate_pipeline_receipts(receipts))
+        self.assertEqual(report.wall_clock_seconds, 600.0)
+        self.assertEqual(report.active_compute_seconds, 450.0)
+        self.assertEqual(report.wait_seconds_by_category["human_gate"], 120.0)
+        self.assertEqual(report.wait_seconds_by_category["ci"], 30.0)
+
+    def test_unknown_wait_category_is_rejected(self):
+        receipts = json.loads((FIXTURES / "pipeline-claude.json").read_text())
+        receipts[1]["wait_category"] = "mystery"
+        receipts[1]["duration_seconds"] = 1
+        with self.assertRaises(ValueError):
+            MetricsAggregator().aggregate(translate_pipeline_receipts(receipts))
 
     def test_single_explicit_node_duration_replaces_timestamp_fallback(self):
         receipts = json.loads((FIXTURES / "pipeline-claude.json").read_text())

--- a/tools/check-dependencies.sh
+++ b/tools/check-dependencies.sh
@@ -211,7 +211,7 @@ PYEOF
 }
 
 # Prove the workflow-kernel release graph contract explicitly: it remains a
-# leaf, and both workflow consumers require the released compatibility floor.
+# leaf, and each workflow consumer requires its released compatibility floor.
 check_workflow_kernel_contract() {
   PLUGINS_DIR="$PLUGINS_DIR" python3 << 'PYEOF'
 import glob
@@ -233,11 +233,15 @@ if kernel is None:
 elif kernel.get("pluginDependencies", {}) or kernel.get("optionalPluginDependencies", {}):
     errors.append("workflow-kernel must remain a leaf with no dependencies")
 
-for consumer in ("pipeline", "dm-review"):
+consumer_floors = {
+    "pipeline": ">=0.2.0",
+    "dm-review": ">=0.1.1",
+}
+for consumer, expected in consumer_floors.items():
     manifest = manifests.get(consumer)
     actual = None if manifest is None else manifest.get("pluginDependencies", {}).get("workflow-kernel")
-    if actual != ">=0.1.1":
-        errors.append(f"{consumer} must require workflow-kernel >=0.1.1")
+    if actual != expected:
+        errors.append(f"{consumer} must require workflow-kernel {expected}")
 
 pipeline = manifests.get("pipeline")
 dm_review_floor = None if pipeline is None else pipeline.get("pluginDependencies", {}).get("dm-review")

--- a/tools/validate-workflow-contracts.sh
+++ b/tools/validate-workflow-contracts.sh
@@ -76,6 +76,8 @@ output_format="$REPO_ROOT/plugins/dm-review/skills/review/references/output-form
 kernel_skill="$REPO_ROOT/plugins/workflow-kernel/skills/workflow-kernel/SKILL.md"
 kernel_cli="$REPO_ROOT/plugins/workflow-kernel/skills/workflow-kernel/references/workflow_kernel/cli.py"
 kernel_promotion="$REPO_ROOT/plugins/workflow-kernel/skills/workflow-kernel/references/workflow_kernel/promotion.py"
+postmortem_schema="$REPO_ROOT/plugins/pipeline/references/run-postmortem-schema.md"
+manifest_schema="$REPO_ROOT/plugins/pipeline/skills/promptcraft/references/manifest-schema.md"
 
 printf "Repository cleanup contract:\n"
 
@@ -261,10 +263,30 @@ require_text "$kernel_skill" "Initialize every run in shadow mode" "kernel docum
 require_text "$kernel_cli" "default=RunMode.SHADOW.value" "kernel CLI defaults to shadow"
 require_text "$kernel_promotion" "separate_human_approval_required" "promotion rejects native default without human approval"
 
+# --------------------------------------------------------------------------
+# Group 5: Pipeline performance contract
+# --------------------------------------------------------------------------
+
+printf "\nPipeline performance contract:\n"
+
+require_text "$pipeline_cmd" "focused Codex review for ordinary chunks" "pipeline command uses focused ordinary-chunk review"
+require_text "$pipeline_run" "For ordinary non-sensitive chunks, run one focused read-only Codex review" "Codex adapter uses one focused ordinary-chunk reviewer"
+require_text "$orchestrator" "Do not dispatch the 5-agent quick dm-review" "orchestrator avoids the old per-chunk review fanout"
+require_text "$orchestrator" '`all-chunks-complete` boundary' "orchestrator batches intermediate shadow observation"
+require_text "$orchestrator" "Empty-plan fast path" "orchestrator skips no-op cleanup commands"
+require_text "$promptcraft" "Do not create an orchestrator-owned closeout chunk" "promptcraft excludes closeout-only chunks"
+require_text "$promptcraft" "no more than 8 total chunks" "promptcraft enforces the default run-size budget"
+require_text "$manifest_schema" "scope: newly discovered desirable work" "manifest contract freezes approved scope"
+require_text "$postmortem_schema" '`activeComputeSeconds`' "postmortem separates active compute from elapsed time"
+require_text "$postmortem_schema" '`waitSecondsByCategory`' "postmortem records typed waits"
+require_text "$orchestrator" "Measure the orchestrator-level non-overlapping interval" "orchestrator measures non-overlapping waits"
+require_absent "$pipeline_run" "shadow observation after each authoritative receipt" "pipeline-run avoids per-receipt observation"
+require_absent "$orchestrator" 'feed it to `observe-pipeline`' "orchestrator avoids intermediate observer invocations"
+
 printf "\n"
 if [ "$failures" -ne 0 ]; then
   printf "FIX  restore the missing workflow-contract anchors (see docs and plugin sources above)\n"
   exit 1
 fi
 
-printf "OK    Workflow contracts intact (repository cleanup, Datastar-first, Baseplate gates, workflow kernel)\n"
+printf "OK    Workflow contracts intact (repository cleanup, Datastar-first, Baseplate gates, workflow kernel, pipeline performance)\n"


### PR DESCRIPTION
## What changed

- replace ordinary per-chunk multi-agent review fanout with one focused Codex review while preserving full sensitive-path and final reviews
- batch workflow-kernel observation at all-chunks-complete and terminal checkpoints
- add bounded chunk planning, scope freeze, tiered validation reuse, early UI smoke checks, and no-op cleanup fast paths
- add wall-clock, active-compute, and typed wait metrics
- release pipeline 1.31.0 and workflow-kernel 0.2.0 with regenerated Codex surfaces

## Why

Recent Assembly pipeline runs spent most elapsed time in approval/closeout waits and repeated orchestration work. These changes keep the safety gates while making review, validation, and shadow bookkeeping proportional to risk.

## Validation

- workflow performance contract: pass
- focused metrics and CLI tests: 13 passed
- dependency validation: pass
- Codex manifests and command aliases: current
- composition-owned checks: pass

The aggregate composition command still reports the existing live sibling integration failure where current `assembly-baseplate/tests/ux` declarations are rejected by the unchanged workflow-kernel persona parser. This branch does not modify that parser or test.