### PR TITLE
fix(workflow-authority): anchor broker fixtures to the wall clock

### DIFF
--- a/native/workflow-authority/internal/client/integration_test.go
+++ b/native/workflow-authority/internal/client/integration_test.go
@@ -85,7 +85,11 @@ func TestEndToEndUnixBrokerDispatchAndReplayRejection(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() { _ = os.RemoveAll(root) })
-	now := time.Date(2026, 8, 4, 2, 0, 0, 0, time.UTC)
+	// Anchored to the wall clock: ipc.Server.handle applies the allocation's
+	// ExpiresAt as a real net.Conn deadline, so a frozen calendar date expires
+	// the broker connection once that date passes and the whole end-to-end
+	// dispatch fails with authority_unavailable.
+	now := time.Now().UTC().Truncate(time.Second)
 	owner := uint32(os.Geteuid())
 	peer := authority.Peer{UID: owner, PID: int32(os.Getpid())}
 

--- a/native/workflow-authority/internal/ipc/server_test.go
+++ b/native/workflow-authority/internal/ipc/server_test.go
@@ -90,6 +90,13 @@ func (d *fixtureDispatcher) Dispatch(ctx context.Context, input provider.Dispatc
 	return provider.TerminalResult{}, nil
 }
 
+// fixtureNow anchors fixture allocations to the wall clock. Server.handle
+// applies the allocation's ExpiresAt as a real net.Conn deadline, so a frozen
+// calendar date silently expires every fixture connection once that date
+// passes -- the daemon then closes before writing its hello frame and every
+// assertion below fails with invalid_document.
+func fixtureNow() time.Time { return time.Now().UTC().Truncate(time.Second) }
+
 func fixtureServer(now time.Time, failAt int) (*Server, *fixtureAllocator, *fixtureManager, *fixtureDispatcher) {
 	digest := protocol.Digest([]byte("fixture"))
 	hello := protocol.AuthorityHello{SchemaVersion: 1, Protocol: protocol.Name, Type: protocol.AuthorityHelloType, DaemonBuildSHA256: digest, ScannerBuildSHA256: digest, PolicySHA256: digest, BootID: "boot-01", SessionID: "session-01", Sequence: 1, IssuedAt: now.Format(time.RFC3339), ExpiresAt: now.Add(120 * time.Second).Format(time.RFC3339), PriorChainDigest: protocol.Digest(nil), ConnectionNonceSHA256: digest, Limits: protocol.FrozenAllocationLimits()}
@@ -140,7 +147,7 @@ func writeFixtureRequest(t *testing.T, conn net.Conn, hello protocol.AuthorityHe
 }
 
 func TestServerWritesHelloBeforeCallerBytesAndKeepsResponseOnConnection(t *testing.T) {
-	now := time.Date(2026, 8, 4, 1, 2, 3, 0, time.UTC)
+	now := fixtureNow()
 	server, allocator, _, dispatcher := fixtureServer(now, 0)
 	daemon, client := net.Pipe()
 	done := make(chan struct{})
@@ -170,7 +177,7 @@ func TestServerWritesHelloBeforeCallerBytesAndKeepsResponseOnConnection(t *testi
 }
 
 func TestServerRejectsWrongConsentBeforeDispatch(t *testing.T) {
-	now := time.Date(2026, 8, 4, 1, 2, 3, 0, time.UTC)
+	now := fixtureNow()
 	server, allocator, manager, dispatcher := fixtureServer(now, 0)
 	daemon, client := net.Pipe()
 	done := make(chan struct{})
@@ -191,7 +198,7 @@ func TestServerRejectsWrongConsentBeforeDispatch(t *testing.T) {
 }
 
 func TestServerRejectsAlteredPartBeforeReservation(t *testing.T) {
-	now := time.Date(2026, 8, 4, 1, 2, 3, 0, time.UTC)
+	now := fixtureNow()
 	server, allocator, manager, dispatcher := fixtureServer(now, 0)
 	daemon, client := net.Pipe()
 	done := make(chan struct{})
@@ -227,7 +234,7 @@ func TestServerRejectsAlteredPartBeforeReservation(t *testing.T) {
 }
 
 func TestServerRejectsOversizedPartDeclarationWithoutReadingParts(t *testing.T) {
-	now := time.Date(2026, 8, 4, 1, 2, 3, 0, time.UTC)
+	now := fixtureNow()
 	server, allocator, manager, dispatcher := fixtureServer(now, 0)
 	daemon, client := net.Pipe()
 	done := make(chan struct{})
@@ -260,7 +267,7 @@ func TestServerRejectsOversizedPartDeclarationWithoutReadingParts(t *testing.T) 
 }
 
 func TestServerRejectsUnauthorizedPeerWithoutHello(t *testing.T) {
-	now := time.Date(2026, 8, 4, 1, 2, 3, 0, time.UTC)
+	now := fixtureNow()
 	server, allocator, _, dispatcher := fixtureServer(now, 0)
 	server.Peers = fixturePeers{err: authority.ErrDenied}
 	daemon, client := net.Pipe()
@@ -277,7 +284,7 @@ func TestServerRejectsUnauthorizedPeerWithoutHello(t *testing.T) {
 }
 
 func TestServerRejectsAncillaryDataAndConsumesAllocation(t *testing.T) {
-	now := time.Date(2026, 8, 4, 1, 2, 3, 0, time.UTC)
+	now := fixtureNow()
 	server, allocator, _, dispatcher := fixtureServer(now, 1)
 	daemon, client := net.Pipe()
 	done := make(chan struct{})
@@ -293,7 +300,7 @@ func TestServerRejectsAncillaryDataAndConsumesAllocation(t *testing.T) {
 }
 
 func TestServerEOFConsumesAllocationWithoutDispatch(t *testing.T) {
-	now := time.Date(2026, 8, 4, 1, 2, 3, 0, time.UTC)
+	now := fixtureNow()
 	server, allocator, _, dispatcher := fixtureServer(now, 0)
 	daemon, client := net.Pipe()
 	done := make(chan struct{})
@@ -309,7 +316,7 @@ func TestServerEOFConsumesAllocationWithoutDispatch(t *testing.T) {
 }
 
 func TestServerStaleAllocationIsConsumedBeforeCallerInput(t *testing.T) {
-	now := time.Date(2026, 8, 4, 1, 2, 3, 0, time.UTC)
+	now := fixtureNow()
 	server, allocator, _, dispatcher := fixtureServer(now, 0)
 	server.Clock = func() time.Time { return now.Add(121 * time.Second) }
 	daemon, client := net.Pipe()
@@ -326,7 +333,7 @@ func TestServerStaleAllocationIsConsumedBeforeCallerInput(t *testing.T) {
 }
 
 func TestServerNeverWritesUnsignedSafeErrorAfterDispatcher(t *testing.T) {
-	now := time.Date(2026, 8, 4, 1, 2, 3, 0, time.UTC)
+	now := fixtureNow()
 	server, allocator, _, dispatcher := fixtureServer(now, 0)
 	dispatcher.fail = true
 	daemon, client := net.Pipe()
@@ -355,7 +362,7 @@ func (a fixtureAddr) Network() string { return "fixture" }
 func (a fixtureAddr) String() string  { return string(a) }
 
 func TestServerUnexpectedAcceptFailureShutsDownDependencies(t *testing.T) {
-	now := time.Date(2026, 8, 4, 1, 2, 3, 0, time.UTC)
+	now := fixtureNow()
 	server, allocator, manager, _ := fixtureServer(now, 0)
 	want := errors.New("accept failed")
 	if err := server.Serve(context.Background(), failingListener{err: want}); !errors.Is(err, want) {
@@ -409,7 +416,7 @@ func (d *blockingDispatcher) Dispatch(ctx context.Context, _ provider.DispatchIn
 }
 
 func TestStopCancelsInflightDispatchAndPreventsQueuedProgress(t *testing.T) {
-	now := time.Date(2026, 8, 4, 1, 2, 3, 0, time.UTC)
+	now := fixtureNow()
 	server, allocator, manager, _ := fixtureServer(now, 0)
 	blocking := &blockingDispatcher{entered: make(chan struct{}), cancelled: make(chan struct{})}
 	server.Dispatcher = blocking


### PR DESCRIPTION
## Problem

`./tools/validate-workflow-authority.sh` has been failing on every host since **2026-08-04T01:04:03Z**, independent of any code change. 9 tests fail:

- 8x `invalid_document` in `internal/ipc` (`server_test.go`)
- 1x `authority_unavailable` in `internal/client` (`TestEndToEndUnixBrokerDispatchAndReplayRejection`)

## Root cause

`ipc.Server.handle` applies the allocation's `ExpiresAt` as a **real** `net.Conn` deadline:

```go
// internal/ipc/server.go:183-187
expires, err := time.Parse(time.RFC3339, allocation.Hello.ExpiresAt)
if err != nil || conn.SetDeadline(expires) != nil {
	reason = "allocation_deadline_invalid"
	return
}
```

The `ipc` and `client` fixtures pinned that allocation to a frozen `time.Date(2026, 8, 4, ...)` literal with a 120s TTL. Once that calendar date passed, `SetDeadline` received a time in the past, so every fixture connection was created already-expired -- the daemon closed before writing its hello frame, and the client's first `ReadFrame` returned `invalid_document`.

Confirmed by re-running the identical fixture handshake with a wall-clock-anchored `now`: passes. The fixture date was the only difference.

## Fix

Anchor both fixtures to `time.Now().UTC().Truncate(time.Second)`. Test-only, 2 files.

The other hardcoded fixture dates (`allocator_test.go`, `client_test.go`, `provider_test.go`, `protocol/allocation_test.go`, `authority/run_test.go`) are left alone: none of them bind a real socket deadline, and several assert expiry semantics deliberately (`authorization_expired`, the 2027-01-01 not-yet-expired case).

## Verification

| Gate | Result |
|---|---|
| `./tools/validate-workflow-authority.sh` | PASS, including `-race` and `vet`. Linux/libfido2 production-build lane reports `COVERAGE-GAP` as expected on macOS. |
| `PYTHONPATH=... python3.12 -m unittest discover -s tests -t . -p 'test_*.py'` | OK -- 988 tests, 2 skipped |
| `python3.12 tools/validate-workflow-kernel.py` | PASS |
| `bash tools/validate-composition.sh --all` | PASS |

No plugin version bump: the change is confined to `native/workflow-authority/`, which is not a plugin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NMeHXuvxgzXDxXPs8B7tsG

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Design-Machines-Studio/codesmith/depot/pr/18"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788672930&installation_model_id=428410&pr_number=18&repository=Design-Machines-Studio%2Fdepot&return_to=https%3A%2F%2Fgithub.com%2FDesign-Machines-Studio%2Fdepot%2Fpull%2F18&signature=755fb8bee18ddf5a337b2609160136c18ed33cd6fa970166d7df12eb31a936de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->