### PR TITLE
feat(pipeline): add native_judgment as last-resort coding rung

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -350,7 +350,7 @@
     {
       "name": "pipeline",
       "source": "./plugins/pipeline",
-      "version": "1.40.0",
+      "version": "1.41.0",
       "author": {
         "name": "Design Machines",
         "url": "https://designmachines.studio"

--- a/plugins/pipeline/.claude-plugin/plugin.json
+++ b/plugins/pipeline/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "pipeline",
   "description": "Autonomous feature development pipeline with executable tiered verification, exact receipt reuse, approved decision-depth profiles, bounded feedback, browser recovery, risk-tiered review, and isolated execution",
-  "version": "1.40.0",
+  "version": "1.41.0",
   "author": {
     "name": "Design Machines",
     "url": "https://designmachines.io"

--- a/plugins/pipeline/.codex-plugin/plugin.json
+++ b/plugins/pipeline/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pipeline",
-  "version": "1.40.0",
+  "version": "1.41.0",
   "description": "Autonomous feature development pipeline with executable tiered verification, exact receipt reuse, approved decision-depth profiles, bounded feedback, browser recovery, risk-tiered review, and isolated execution",
   "author": {
     "name": "Design Machines",

--- a/plugins/pipeline/references/model-cascade.json
+++ b/plugins/pipeline/references/model-cascade.json
@@ -3,7 +3,7 @@
   "routing_policy": "routing-policy.json",
 
   "class_from_kind": {
-    "_comment": "Coding kind -> cascade class. Config/docs go OpenRouter-primary; logic, ui, and integration go Codex-primary. Claude is non-coding-only and appears in no executable coding class.",
+    "_comment": "Coding kind -> cascade class. Config/docs go OpenRouter-primary; logic, ui, and integration go Codex-primary. Claude native is a LAST-RESORT coding rung below both external rails (see policy._comment_native_fallback).",
     "logic": "codex", "config": "openrouter", "docs": "openrouter", "ui": "codex", "integration": "codex"
   },
 
@@ -32,14 +32,14 @@
 
   "cascades": {
     "codex": {
-      "_comment": "Primary executor = Codex for logic, UI, and integration. When Codex caps, descend through agentic and wrapper OpenRouter models; Claude has no coding rung.",
+      "_comment": "Primary executor = Codex for logic, UI, and integration. When Codex caps, descend through agentic OpenRouter, then the native judgment rung, then wrapper models.",
       "quality_floor": 70,
-      "ladder": ["premium_sub", "openrouter_exec", "frontier_api", "cheap_api"]
+      "ladder": ["premium_sub", "openrouter_exec", "native_judgment", "frontier_api", "cheap_api"]
     },
     "openrouter": {
-      "_comment": "Primary executor = OpenRouter for config/docs/mechanical logic. Codex is the trusted coding fallback; Claude has no coding rung.",
+      "_comment": "Primary executor = OpenRouter for config/docs/mechanical logic. Codex is the trusted coding fallback, then the native judgment rung, then wrapper models.",
       "quality_floor": 70,
-      "ladder": ["openrouter_exec", "premium_sub", "frontier_api", "cheap_api"]
+      "ladder": ["openrouter_exec", "premium_sub", "native_judgment", "frontier_api", "cheap_api"]
     }
   },
 
@@ -49,8 +49,9 @@
     "reentry": "highest_quality",
     "_comment_reentry": "When an exhausted sub rail's resets_at passes it re-enters at its original ladder position (flat-rate and free again -- prefer quality).",
     "on_cap_error": ["airlift_checkpoint", "mark_exhausted_until_resets_at", "descend"],
-    "_comment_subscriptions": "Coding rails: Codex Pro 20x is the active flat-rate workhorse, with a named 5x profile; OpenRouter carries external agentic and mechanical work. Claude Pro is reserved for non-coding tasks and is absent from coding cascades.",
-    "_comment_fable": "Fable 5 keeps its quality score for research and non-coding comparison only. Claude is outside the executable coding graph, so availability never adds Fable or Opus to a coding ladder.",
+    "_comment_subscriptions": "Coding rails: Codex Pro 20x is the active flat-rate workhorse, with a named 5x profile; OpenRouter carries external agentic and mechanical work. Claude Pro sits below both as the native last-resort coding rung.",
+    "_comment_fable": "Fable 5 keeps its quality score for research, judgment, and review lanes. Opus heads the native_judgment coding rung; Fable is routed explicitly for adversarial plan review rather than by ladder descent.",
+    "_comment_native_fallback": "2026-08-08 user directive (Trav): user judgment overrides written routing policy. native_judgment is an executable coding rung, placed BELOW premium_sub and openrouter_exec in every class so it fires only when both external rails are unavailable. Rationale: the automated OpenRouter rail fails closed on hosts without /usr/local/bin/workflow-authority, so a capped Codex sub previously produced a total execution deadlock (2026-08-08 zero-chunk BLOCKED run). Every dispatch on this rung is a target variance and must be receipted (routing-policy targets.enforcement.varianceReceiptRequired). Revisit when the broker lands (R3) and the interim macOS authorization retires.",
     "_comment_native_host_constraint": "GPT-5.6 Sol is native Codex only and remains the preferred coding head. Terra and Luna OpenRouter calls are explicit policy-routed review/direct workloads rather than replacements in the host fallback ladder. Claude aliases retained in harness-profile native_judgment are native Claude compatibility metadata for explicit non-coding workflows and are referenced by no coding cascade.",
     "privacy": "DEMOTED (2026-07-18, user directive): model selection priority is Quality > Price > Speed > Provider privacy. OPENROUTER_ZDR is OPT-IN, never a default pin -- Chinese first-party hosting (Moonshot/DeepSeek/Z.AI) is acceptable by default. Set OPENROUTER_ZDR=1 per-call only for genuinely sensitive material (client code under NDA, credentials-adjacent diffs); when set, a model with no eligible ZDR provider (e.g. moonshotai/kimi-k3 pre-weights) is a per-model failure and the ladder walks on.",
     "_comment_headroom_unknown": "usage-probe state 'unknown' is treated as HAS-headroom: dispatch plus reactive cap detection is preferred over falsely skipping a healthy Codex or OpenRouter rail.",

--- a/tools/validate-routing-economics.sh
+++ b/tools/validate-routing-economics.sh
@@ -289,7 +289,21 @@ require_text "$orchestrator" "Claude JSONL delta" "postmortem measures Claude JS
 require_text "$orchestrator" "AWAITING APPROVAL" "postmortem recommendations are proposal-only"
 require_text "$model_cascade" '"openrouter"' "model cascade defines OpenRouter class"
 if [ -f "$model_cascade" ] && [ -f "$harness" ]; then
-  jq -e '(.cascades | has("claude") | not) and ([.cascades[].ladder[]] | index("native_judgment") | not)' "$model_cascade" >/dev/null || { printf "  FAIL  coding cascades exclude Claude-native ladders\n"; failures=1; }
+  # 2026-08-08 user directive: native_judgment is an executable LAST-RESORT coding rung.
+  # Claude must still never be a cascade class of its own, and where the native rung is
+  # present it must rank below premium_sub and openrouter_exec so both external rails are
+  # tried first. This replaces the former absolute exclusion.
+  jq -e '.cascades | has("claude") | not' "$model_cascade" >/dev/null || { printf "  FAIL  no Claude-native cascade class\n"; failures=1; }
+  jq -e '
+    [.cascades[]
+      | .ladder as $l
+      | select($l | index("native_judgment"))
+      | ($l | index("native_judgment")) as $n
+      | (($l | index("premium_sub")) // -1) as $p
+      | (($l | index("openrouter_exec")) // -1) as $o
+      | ($n > $p and $n > $o)]
+    | all
+  ' "$model_cascade" >/dev/null || { printf "  FAIL  native_judgment ranks below premium_sub and openrouter_exec in every cascade\n"; failures=1; }
   jq -e '
     [.hosts[].roles | to_entries[]
       | select(.value.kind == "wrapper" or .value.kind == "openrouter_exec")
@@ -300,8 +314,9 @@ if [ -f "$model_cascade" ] && [ -f "$harness" ]; then
   jq -e '
     [.quality_rank | keys[] | select(test("^(openai|anthropic)/"))] | length == 0
   ' "$model_cascade" >/dev/null || { printf "  FAIL  model cascade excludes OpenRouter-prefixed native-vendor identities\n"; failures=1; }
-  if ! jq -e '.hosts.generic.roles.native_judgment.kind == "none"' "$harness" >/dev/null ||
-     ! jq -e '([.cascades[].ladder[]] | index("native_judgment") | not)' "$model_cascade" >/dev/null; then
+  # Generic (non-Claude, non-Codex) harnesses still have NO native vendor rail: the native
+  # rung must resolve to "none" there rather than being silently mapped onto OpenRouter.
+  if ! jq -e '.hosts.generic.roles.native_judgment.kind == "none"' "$harness" >/dev/null; then
     printf "  FAIL  generic/native-vendor intent is unavailable rather than mapped to OpenRouter\n"
     failures=1
   fi


### PR DESCRIPTION
## Why

Both external coding rails can be unavailable at the same time on a macOS host, and the result today is a **total execution deadlock** rather than a degraded run:

- **Codex** caps on the ChatGPT subscription (`You've hit your usage limit`).
- **Every automated OpenRouter rung** — `openrouter_exec`, `frontier_api`, `cheap_api`, `bulk_api` — fails closed in `cascade-dispatch.sh`'s `openrouter_allowed()` gate, which requires `/usr/local/bin/workflow-authority`. That binary is absent on hosts awaiting the R3 broker landing.

Result before this change, verified with a real (non-dry) dispatch and a healthy OpenRouter probe:

```
cascade-dispatch: ladder exhausted for class 'openrouter' on host 'claude-code' (floor 70)
```

This is the condition behind the 2026-08-08 zero-chunk BLOCKED run.

Note: `--dry-run` returns success from `openrouter_allowed()` unconditionally, so dry-runs report a healthy ladder that real dispatches refuse. Test with real dispatches.

## What

`native_judgment` becomes an executable coding rung, positioned **strictly below** `premium_sub` and `openrouter_exec` in both cascade classes. Both external rails are always attempted first; the native rung fires only as a last resort.

No security boundary is touched. The `openrouter_allowed()` disclosure gate is left exactly as-is — authorizing that rail is R3 chunk 00's job, with its own receipts.

The dispatcher already emits `requestedProvider` / `actualImplementer` / `fallback` / `fallbackReason` on the exit-64 directive, so target variance stays receipted with no further change:

```json
{ "dispatch": "native", "model": "opus", "role": "native_judgment",
  "requestedProvider": "openrouter", "requestedModel": "z-ai/glm-5.2",
  "actualImplementer": "claude", "actualModel": "opus",
  "fallback": true, "fallbackReason": "openrouter-unavailable-or-below-floor" }
```

## Validator changes

The former absolute exclusion is replaced with an **ordering invariant**, not removed:

- `native_judgment`, where present in a ladder, must rank below `premium_sub` and `openrouter_exec`.
- Claude still cannot be a cascade class of its own.
- Generic harnesses still resolve the native rung to `"none"` rather than mapping it onto OpenRouter.

Negative-tested — promoting `native_judgment` to the head of a ladder fails:

```
FAIL  native_judgment ranks below premium_sub and openrouter_exec in every cascade
```

## Verification

- `./tools/validate-composition.sh --all` — **PASS: All validators passed** (includes the workflow-kernel unittest suite, 13 kernel checks, Codex shim sync).
- Codex shims regenerated; pipeline bumped 1.40.0 -> 1.41.0, mirrored in `marketplace.json`.

## Authorization

User directive 2026-08-08: user judgment overrides written routing policy. Revisit when the R3 broker lands and interim macOS authorization retires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012GzXwSt8Cp3Mv2Vv8m2nPz

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Design-Machines-Studio/codesmith/depot/pr/20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788740846&installation_model_id=428410&pr_number=20&repository=Design-Machines-Studio%2Fdepot&return_to=https%3A%2F%2Fgithub.com%2FDesign-Machines-Studio%2Fdepot%2Fpull%2F20&signature=e4cbc222ab3415cd59c0602165367e411fbbff4c6283d9db477d5486fa661950"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->