### PR TITLE
Refresh OpenRouter model portfolio and recommendation matrix

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -425,7 +425,7 @@
     {
       "name": "openrouter",
       "source": "./plugins/openrouter",
-      "version": "1.11.4",
+      "version": "1.11.5",
       "author": {
         "name": "Design Machines",
         "url": "https://designmachines.studio"

--- a/docs/openrouter-model-matrix-refreshes/2026-08-12.json
+++ b/docs/openrouter-model-matrix-refreshes/2026-08-12.json
@@ -1,0 +1,158 @@
+{
+  "schema_version": 1,
+  "observedAt": "2026-08-11T22:42:37Z",
+  "expiresAt": "2026-08-11T22:57:37Z",
+  "observation_date_utc": "2026-08-11",
+  "matrix_snapshot_date": "2026-08-12",
+  "authority": "The matrix recommends, routing policy decides, receipts record.",
+  "sources": [
+    {"url": "https://openrouter.ai/api/v1/models", "observed_on": "2026-08-11", "kind": "official_catalog"},
+    {"url": "https://developers.openai.com/api/docs/guides/latest-model", "observed_on": "2026-08-12", "kind": "official_native_guidance"},
+    {"url": "https://developers.openai.com/api/docs/models", "observed_on": "2026-08-12", "kind": "official_native_catalog"},
+    {"url": "https://developers.openai.com/api/docs/models/gpt-5.6-sol", "observed_on": "2026-08-12", "kind": "official_native_model"},
+    {"url": "https://developers.openai.com/api/docs/models/gpt-5.6-terra", "observed_on": "2026-08-12", "kind": "official_native_model"},
+    {"url": "https://developers.openai.com/api/docs/models/gpt-5.6-luna", "observed_on": "2026-08-12", "kind": "official_native_model"},
+    {"url": "https://www.anthropic.com/claude/fable", "observed_on": "2026-08-12", "kind": "official_native_model"},
+    {"url": "https://www.anthropic.com/webinars/building-on-the-claude-platform-claude-fable-5-and-model-orchestration-patterns", "observed_on": "2026-08-12", "kind": "official_orchestration_guidance"},
+    {"url": "https://artificialanalysis.ai/models/kimi-k3", "observed_on": "2026-08-12", "kind": "independent_evaluation"},
+    {"url": "https://artificialanalysis.ai/models/deepseek-v4-flash", "observed_on": "2026-08-12", "kind": "independent_evaluation"},
+    {"url": "https://artificialanalysis.ai/models/grok-4-5", "observed_on": "2026-08-12", "kind": "independent_evaluation"},
+    {"url": "https://artificialanalysis.ai/articles/grok-4-5-brings-spacexai-to-the-the-intelligence-frontier", "observed_on": "2026-08-12", "kind": "independent_coding_agent_evaluation"},
+    {"url": "https://artificialanalysis.ai/models/glm-5-2/", "observed_on": "2026-08-12", "kind": "independent_evaluation"}
+  ],
+  "local_sources": [
+    "ai-memory:DepotMetrics",
+    "ai-memory:DepotPlugin:dm-review",
+    "ai-memory:Assembly Fixture Jig",
+    "docs/pipeline-receipts/r1-review-burn-cuts.md",
+    "docs/pipeline-receipts/rail-exhaustion-ask-gate.md",
+    "docs/pipeline-receipts/rail-exhaustion-ask-gate-postmortem.md"
+  ],
+  "inventory": {
+    "reviewed_slug_list": [
+      "moonshotai/kimi-k3",
+      "openai/gpt-5.6-terra",
+      "x-ai/grok-4.5",
+      "z-ai/glm-5.2",
+      "meta/muse-spark-1.1",
+      "openai/gpt-5.6-luna",
+      "google/gemini-3.5-flash",
+      "deepseek/deepseek-v4-pro",
+      "minimax/minimax-m3",
+      "deepseek/deepseek-v4-flash",
+      "qwen/qwen3-coder"
+    ],
+    "changed": [
+      "all routed entries: snapshot, availability, top-provider limits, tool/reasoning support, and recommendation metadata",
+      "z-ai/glm-5.2: price/cache/context",
+      "deepseek/deepseek-v4-pro: price/cache/context",
+      "deepseek/deepseek-v4-flash: resolved identity, price/cache/context, superseded status",
+      "qwen/qwen3-coder: context corrected from misleading 1M to 262144",
+      "x-ai/grok-4.5, meta/muse-spark-1.1, openai/gpt-5.6-luna, google/gemini-3.5-flash, minimax/minimax-m3: cache pricing added",
+      "current independent intelligence, effort, and evaluated-output evidence for Kimi K3, DeepSeek V4 Flash 0731, Grok 4.5, and GLM-5.2"
+    ],
+    "unchanged": [
+      "all 11 previously routed slugs remain catalog-available",
+      "moonshotai/kimi-k3 base price and context",
+      "openai/gpt-5.6-terra base price and context",
+      "openai/gpt-5.6-luna base price and context",
+      "x-ai/grok-4.5 base input/output price and context",
+      "meta/muse-spark-1.1 base input/output price and context",
+      "google/gemini-3.5-flash base input/output price and context",
+      "minimax/minimax-m3 base input/output price and model/top-provider context"
+    ],
+    "new_candidate": ["deepseek/deepseek-v4-flash-0731"],
+    "unavailable": [],
+    "aliased": ["~deepseek/deepseek-v4-flash-latest"],
+    "superseded": ["deepseek/deepseek-v4-flash resolves to DeepSeek V4 Flash 0423 and is superseded for new recommendations by deepseek/deepseek-v4-flash-0731"],
+    "stale": [
+      "all retained Artificial Analysis v4.1 coding and agentic scores",
+      "all Artificial Analysis v4.1 evidence for models not re-evaluated on model-specific current pages",
+      "the routed DeepSeek V4 Flash 0423 quality record"
+    ]
+  },
+  "catalog_evidence": {
+    "moonshotai/kimi-k3": {"name": "MoonshotAI: Kimi K3", "available": true, "created": 1784215858, "pricing": {"prompt": "0.000003", "completion": "0.000015", "input_cache_read": "0.0000003"}, "context_length": 1048576, "top_provider": {"context_length": 1048576, "max_completion_tokens": null, "is_moderated": false}, "modality": "text+image+video->text", "tools": true, "reasoning": true},
+    "openai/gpt-5.6-terra": {"name": "OpenAI: GPT-5.6 Terra", "available": true, "created": 1783590857, "pricing": {"prompt": "0.000001", "completion": "0.000006", "input_cache_read": "0.0000001", "input_cache_write": "0.00000125", "overrides": [{"min_prompt_tokens": 272000, "prompt": "0.000002", "completion": "0.000009", "input_cache_read": "0.0000002", "input_cache_write": "0.0000025"}]}, "context_length": 1050000, "top_provider": {"context_length": 1050000, "max_completion_tokens": 128000, "is_moderated": true}, "modality": "text+image+file->text", "tools": true, "reasoning": true},
+    "x-ai/grok-4.5": {"name": "SpaceXAI: Grok 4.5", "available": true, "created": 1783523154, "pricing": {"prompt": "0.000002", "completion": "0.000006", "input_cache_read": "0.0000003", "overrides": [{"min_prompt_tokens": 200000, "prompt": "0.000004", "completion": "0.000012", "input_cache_read": "0.0000006"}]}, "context_length": 500000, "top_provider": {"context_length": 500000, "max_completion_tokens": null, "is_moderated": false}, "modality": "text+image+file->text", "tools": true, "reasoning": true},
+    "z-ai/glm-5.2": {"name": "Z.ai: GLM 5.2", "available": true, "created": 1781631930, "pricing": {"prompt": "0.000000392", "completion": "0.000001232", "input_cache_read": "0.0000000728"}, "context_length": 1048576, "top_provider": {"context_length": 1048576, "max_completion_tokens": 131072, "is_moderated": false}, "modality": "text->text", "tools": true, "reasoning": true, "parallel_tool_calls": true},
+    "meta/muse-spark-1.1": {"name": "Meta: Muse Spark 1.1", "available": true, "created": 1784215741, "pricing": {"prompt": "0.00000125", "completion": "0.00000425", "input_cache_read": "0.00000015"}, "context_length": 1048576, "top_provider": {"context_length": 1048576, "max_completion_tokens": null, "is_moderated": true}, "modality": "text+image+file+audio+video->text", "tools": true, "reasoning": true},
+    "openai/gpt-5.6-luna": {"name": "OpenAI: GPT-5.6 Luna", "available": true, "created": 1783590864, "pricing": {"prompt": "0.0000001", "completion": "0.0000006", "input_cache_read": "0.00000001", "input_cache_write": "0.000000125", "overrides": [{"min_prompt_tokens": 272000, "prompt": "0.0000002", "completion": "0.0000009", "input_cache_read": "0.00000002", "input_cache_write": "0.00000025"}]}, "context_length": 1050000, "top_provider": {"context_length": 1050000, "max_completion_tokens": 128000, "is_moderated": true}, "modality": "text+image+file->text", "tools": true, "reasoning": true},
+    "google/gemini-3.5-flash": {"name": "Google: Gemini 3.5 Flash", "available": true, "created": 1779193800, "pricing": {"prompt": "0.0000015", "completion": "0.000009", "input_cache_read": "0.00000015", "input_cache_write": "0.0000000833333333333333"}, "context_length": 1048576, "top_provider": {"context_length": 1048576, "max_completion_tokens": 65536, "is_moderated": false}, "modality": "text+image+file+audio+video->text", "tools": true, "reasoning": true},
+    "deepseek/deepseek-v4-pro": {"name": "DeepSeek: DeepSeek V4 Pro", "available": true, "created": 1777000679, "pricing": {"prompt": "0.00000063168", "completion": "0.00000126336", "input_cache_read": "0.000000053298"}, "context_length": 1048576, "top_provider": {"context_length": 1048576, "max_completion_tokens": 393216, "is_moderated": false}, "modality": "text->text", "tools": true, "reasoning": true},
+    "minimax/minimax-m3": {"name": "MiniMax: MiniMax M3", "available": true, "created": 1780245374, "pricing": {"prompt": "0.0000003", "completion": "0.0000012", "input_cache_read": "0.00000006"}, "context_length": 1048576, "top_provider": {"context_length": 524288, "max_completion_tokens": 512000, "is_moderated": false}, "modality": "text+image+video->text", "tools": true, "reasoning": true},
+    "deepseek/deepseek-v4-flash": {"name": "DeepSeek: DeepSeek V4 Flash 0423", "available": true, "created": 1777000666, "pricing": {"prompt": "0.00000014", "completion": "0.00000028", "input_cache_read": "0.000000028"}, "context_length": 1048576, "top_provider": {"context_length": 1048576, "max_completion_tokens": 393216, "is_moderated": false}, "modality": "text->text", "tools": true, "reasoning": true},
+    "deepseek/deepseek-v4-flash-0731": {"name": "DeepSeek: DeepSeek V4 Flash 0731", "available": true, "created": 1785478908, "pricing": {"prompt": "0.00000008", "completion": "0.00000018", "input_cache_read": "0.000000016"}, "context_length": 1048576, "top_provider": {"context_length": 1048576, "max_completion_tokens": 384000, "is_moderated": false}, "modality": "text->text", "tools": true, "reasoning": true, "parallel_tool_calls": true},
+    "qwen/qwen3-coder": {"name": "Qwen: Qwen3 Coder 480B A35B", "available": true, "created": 1753230546, "pricing": {"prompt": "0.0000003", "completion": "0.000001", "input_cache_read": "0.0000001"}, "context_length": 262144, "top_provider": {"context_length": 262144, "max_completion_tokens": 65536, "is_moderated": false}, "modality": "text->text", "tools": true, "reasoning": false},
+    "~deepseek/deepseek-v4-flash-latest": {"name": "DeepSeek V4 Flash Latest", "available": true, "created": 1785606009, "pricing": {"prompt": "0.000000072", "completion": "0.000000144", "input_cache_read": "0.0000000144"}, "context_length": 1048576, "top_provider": {"context_length": 262144, "max_completion_tokens": 262144, "is_moderated": false}, "modality": "text->text", "tools": true, "reasoning": true, "parallel_tool_calls": true, "identity_policy": "do not route; non-durable alias"}
+  },
+  "quality_evidence": {
+    "source_version": "Artificial Analysis Intelligence Index v4.1.1",
+    "benchmark_components": ["GDPval-AA v2", "tau3-Banking", "Terminal-Bench v2.1", "SciCode", "Humanity's Last Exam", "GPQA Diamond", "CritPt", "AA-Omniscience", "AA-LCR"],
+    "models": {
+      "moonshotai/kimi-k3": {"status": "current-intelligence-only", "exact_variant": "Kimi K3 (max)", "effort": "max", "intelligence": 60, "coding": {"value": 76.2, "status": "stale-v4.1"}, "agentic": {"value": 50.1, "status": "stale-v4.1"}, "evaluated_output_tokens_m": 130, "speed_tokens_per_second": 42.5, "evaluation_cost_usd": 2425.11, "price_basis": "Kimi first-party API, not OpenRouter catalog"},
+      "deepseek/deepseek-v4-flash-0731": {"status": "current-intelligence-only", "exact_variant": "DeepSeek V4 Flash 0731 (reasoning, max effort)", "effort": "max", "intelligence": 52, "coding": null, "agentic": null, "evaluated_output_tokens_m": 210, "speed_tokens_per_second": 128.0, "price_basis": "DeepSeek first-party API, not OpenRouter catalog"},
+      "x-ai/grok-4.5": {"status": "current-intelligence-and-separate-coding-agent-evidence", "exact_variant": "Grok 4.5 (high)", "effort": "high", "intelligence": 56, "coding": {"score": 76, "exact_variant": "Grok 4.5 in Grok Build", "source_version": "Artificial Analysis Coding Agent Index reported 2026-07-08; DeepSWE, Terminal-Bench v2, SWE-Atlas QnA", "average_tokens_m": 1.9, "cost_status": "source conflict: summary says $2.59/task; detail says $2.49/task; neither canonicalized"}, "agentic": null, "evaluated_output_tokens_m": 60, "speed_tokens_per_second": 56.8, "evaluation_cost_usd": 579.21, "price_basis": "SpaceXAI first-party API, not OpenRouter catalog"},
+      "z-ai/glm-5.2": {"status": "current-intelligence-only", "exact_variant": "GLM-5.2 (max)", "effort": "max", "intelligence": 53, "coding": {"value": 68.8, "status": "stale-v4.1"}, "agentic": {"value": 43.1, "status": "stale-v4.1"}, "evaluated_output_tokens_m": 140, "speed_tokens_per_second": 132.0, "evaluation_cost_usd": 723.74, "price_basis": "median across providers, not OpenRouter catalog"}
+    },
+    "caveat": "Current model pages did not expose complete comparable coding and agentic index values in retrievable page content. Old fields remain explicitly stale rather than restamped."
+  },
+  "local_operator_evidence": [
+    {"model": "moonshotai/kimi-k3", "claim": "Effective at consequential focused security review.", "evidence": "2026-08-08 rail-exhaustion run: Kimi independently found the self-authorization P1 and additional fail-closed/cross-family policy defects."},
+    {"model": "moonshotai/kimi-k3", "claim": "Verbose and materially costly for broad routine review.", "evidence": "R1 review receipts show successful Kimi lanes around 16,625-25,773 tokens and $0.21065-$0.31859; the rail-exhaustion security lanes emitted 8,587 and 9,913 completion tokens at $0.1393479 and $0.16611795."},
+    {"model": "moonshotai/kimi-k3", "claim": "Large payload reliability needs bounding.", "evidence": "Two Kimi requests on 107KB and 271KB payloads ended incomplete_stream with no output; one security recheck also required a recorded retry."},
+    {"model": "z-ai/glm-5.2", "claim": "Can complete a mechanical lane but should not retain a default seat.", "evidence": "A 2026-08-08 mechanical review completed with 12,923 completion tokens at $0.0651352; repeated operator experience says GLM-5.2 needs too much handholding in this harness."},
+    {"model": "deepseek/deepseek-v4-flash-0731", "claim": "No local evidence yet.", "evidence": "Older DeepSeek V4 lanes had wrapper failures, hallucinated nonexistent paths, and false-positive test findings; those are not attributed to the 0731 refresh."},
+    {"model": "x-ai/grok-4.5", "claim": "No local Depot/Assembly execution receipt found.", "evidence": "Recommendation remains provisional and benchmark-led."},
+    {"model": "openai/gpt-5.6-sol", "claim": "Strong code-aware reviewer and hard-problem fallback, with overbuilding risk.", "evidence": "Depot review records identify the native Codex 5.6 Sol lane as strongest in hard reviews; operator instruction requires explicit simplicity and ergonomics checks."}
+  ],
+  "native_subscription_evidence": {
+    "openai": {
+      "models": {
+        "gpt-5.6-sol": {"role": "frontier complex reasoning and coding", "context_tokens": 1050000, "api_equivalent_usd_per_m": {"input": 5.0, "cached_input": 0.5, "output": 30.0}},
+        "gpt-5.6-terra": {"role": "balance intelligence and cost", "context_tokens": 1050000, "api_equivalent_usd_per_m": {"input": 2.0, "cached_input": 0.2, "output": 12.0}},
+        "gpt-5.6-luna": {"role": "cost-sensitive high-volume work", "context_tokens": 1050000, "api_equivalent_usd_per_m": {"input": 0.2, "cached_input": 0.02, "output": 1.2}}
+      },
+      "pricing_note": "Planning equivalents only; not measured subscription spend. API prices rise for prompts above 272K input tokens.",
+      "effort_guidance": "Preserve the current effort as baseline and compare one level lower. Medium is balanced, low is latency-sensitive, high/xhigh require measured gain, and max is reserved for the hardest quality-first tasks."
+    },
+    "anthropic": {
+      "model": "Claude Fable 5",
+      "boundary": "native subscription only; never add an anthropic/* OpenRouter slug",
+      "advisor_pattern": "Fable sets strategy while a smaller cheaper model performs bounded work",
+      "depot_mapping": "non-coding strategy checkpoint only; do not duplicate full code review"
+    }
+  },
+  "native_api_equivalent_cost": {
+    "status": "changed",
+    "changes": [
+      "refreshed Sol evidence date and replaced OpenRouter page with official OpenAI source; price unchanged at $5/$30 and $0.50 cached input",
+      "removed Terra and Luna native aliases because their OpenRouter prices differ from official native API equivalents and the existing schema cannot represent both without conflation"
+    ],
+    "preserved": ["schema_version 1", "four input bytes per token estimate", "observation-only and never billed subscription spend semantics"]
+  },
+  "proposed_workload_matrix": {
+    "moonshotai/kimi-k3": {"use": "focused security and difficult independent review", "avoid": "implementation or fixing its own findings", "supervision": "bounded output then cheaper executor handoff plus independent sign-off", "confidence": "high-security-medium-other"},
+    "deepseek/deepseek-v4-flash-0731": {"use": "default candidate for bounded low-cost execution", "avoid": "broad autonomous or security-critical work", "supervision": "Codex 5.6 scope/correctness/simplicity review", "confidence": "medium-provisional"},
+    "x-ai/grok-4.5": {"use": "more demanding bounded execution or escalation", "avoid": "unbounded work and >200K prompts without cost review", "supervision": "Codex 5.6 changed-surface review", "confidence": "medium-low-provisional"},
+    "z-ai/glm-5.2": {"use": "experimental last fallback or proven narrow exception", "avoid": "default seats", "supervision": "strong native supervision and explicit acceptance criteria", "confidence": "low-default"},
+    "fable-5-native": {"use": "non-coding strategy/advisor checkpoint", "avoid": "OpenRouter, implementation, duplicated full review", "supervision": "operator/Codex reduces advice to a small brief", "confidence": "high-boundary"},
+    "gpt-5.6-sol-native": {"use": "code-aware supervisor/reviewer and hard fallback", "avoid": "automatic full-task replay and habitual maximum effort", "supervision": "it is the supervisor; operator owns consequential authorization", "confidence": "high"}
+  },
+  "effort_recommendations": [
+    {"native_model_task": "Luna or Terra / mechanical verification and scoped work", "default": "low", "escalation_trigger": "named acceptance criterion missed"},
+    {"native_model_task": "Sol / ordinary code-aware supervision and review", "default": "medium", "escalation_trigger": "cross-component ambiguity, meaningful consequence, or failed medium attempt"},
+    {"native_model_task": "Sol / consequential security", "default": "high", "escalation_trigger": "unresolved attack path or failed high-effort verification; then xhigh"},
+    {"native_model_task": "Sol / hardest quality-first fallback", "default": "xhigh", "escalation_trigger": "failed xhigh or named high-consequence uncertainty; then max"},
+    {"native_model_task": "Fable 5 / non-coding advisor", "default": "lowest native setting adequate to frame direction", "escalation_trigger": "named strategic uncertainty remains unresolved"}
+  ],
+  "executable_routing_recommendations": [
+    "In chunk 00c, evaluate replacing the undated DeepSeek execution rung with deepseek/deepseek-v4-flash-0731 after local bounded-task trials.",
+    "Evaluate DeepSeek V4 Flash 0731 as bounded execution head and Grok 4.5 as demanding bounded escalation.",
+    "Remove Kimi K3 from implementation and self-fix positions; retain focused security review with output bounds and cheaper executor handoff.",
+    "Demote GLM-5.2 from default seats to experimental last fallback unless a narrow local task class earns an exception.",
+    "Keep Fable 5 native-only for non-coding strategy and Codex 5.6 native for code-aware supervision with measured effort escalation."
+  ],
+  "executable_routing_changed": false,
+  "executable_routing_statement": "No routing-policy value, model-cascade order, harness profile, agent card, executor default, authorization rule, provider gate, or executable routing identity was changed in this refresh."
+}

--- a/docs/openrouter-model-matrix-refreshes/2026-08-12.json
+++ b/docs/openrouter-model-matrix-refreshes/2026-08-12.json
@@ -127,7 +127,7 @@
     "status": "changed",
     "changes": [
       "refreshed Sol evidence date and replaced OpenRouter page with official OpenAI source; price unchanged at $5/$30 and $0.50 cached input",
-      "removed Terra and Luna native aliases because their OpenRouter prices differ from official native API equivalents and the existing schema cannot represent both without conflation"
+      "preserved Terra at $2/$12 and $0.20 cached input and Luna at $0.20/$1.20 and $0.02 cached input through distinct native-only aliases and model identities, keeping official native API-equivalent costs separate from cheaper OpenRouter catalog prices"
     ],
     "preserved": ["schema_version 1", "four input bytes per token estimate", "observation-only and never billed subscription spend semantics"]
   },

--- a/plugins/openrouter/.claude-plugin/plugin.json
+++ b/plugins/openrouter/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "openrouter",
   "description": "OpenRouter provider plugin with exact-digest direct interactive use, broker-pending automated routing, Kimi K3-led security and bulk analysis, Terra quality fallback, Luna economical mechanical routing, and an optional official MCP control plane.",
-  "version": "1.11.4",
+  "version": "1.11.5",
   "author": {
     "name": "Design Machines",
     "url": "https://designmachines.studio"

--- a/plugins/openrouter/.codex-plugin/plugin.json
+++ b/plugins/openrouter/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "openrouter",
-  "version": "1.11.4",
+  "version": "1.11.5",
   "description": "OpenRouter provider plugin with exact-digest direct interactive use, broker-pending automated routing, Kimi K3-led security and bulk analysis, Terra quality fallback, Luna economical mechanical routing, and an optional official MCP control plane.",
   "author": {
     "name": "Design Machines",

--- a/plugins/openrouter/skills/openrouter-delegate/references/model-matrix.json
+++ b/plugins/openrouter/skills/openrouter-delegate/references/model-matrix.json
@@ -7,7 +7,9 @@
     "snapshot_date": "2026-08-12",
     "input_bytes_per_token_estimate": 4,
     "aliases": {
-      "gpt-5.6-sol": "openai/gpt-5.6-sol"
+      "gpt-5.6-sol": "openai/gpt-5.6-sol",
+      "gpt-5.6-terra": "openai/gpt-5.6-terra-native-api-equivalent",
+      "gpt-5.6-luna": "openai/gpt-5.6-luna-native-api-equivalent"
     },
     "models": [
       {
@@ -18,6 +20,24 @@
         "snapshot_date": "2026-08-12",
         "pricing_basis": "API-equivalent planning estimate; never billed subscription spend",
         "sources": ["https://developers.openai.com/api/docs/models/gpt-5.6-sol"]
+      },
+      {
+        "slug": "openai/gpt-5.6-terra-native-api-equivalent",
+        "input_usd_per_m": 2.0,
+        "output_usd_per_m": 12.0,
+        "cache_read_usd_per_m": 0.2,
+        "snapshot_date": "2026-08-12",
+        "pricing_basis": "API-equivalent planning estimate; never billed subscription spend",
+        "sources": ["https://developers.openai.com/api/docs/models/gpt-5.6-terra"]
+      },
+      {
+        "slug": "openai/gpt-5.6-luna-native-api-equivalent",
+        "input_usd_per_m": 0.2,
+        "output_usd_per_m": 1.2,
+        "cache_read_usd_per_m": 0.02,
+        "snapshot_date": "2026-08-12",
+        "pricing_basis": "API-equivalent planning estimate; never billed subscription spend",
+        "sources": ["https://developers.openai.com/api/docs/models/gpt-5.6-luna"]
       }
     ]
   },

--- a/plugins/openrouter/skills/openrouter-delegate/references/model-matrix.json
+++ b/plugins/openrouter/skills/openrouter-delegate/references/model-matrix.json
@@ -1,15 +1,13 @@
 {
   "_comment": "CANONICAL machine-readable OpenRouter model matrix. This file is the data source of truth for the Available Models table in model-selection.md: on any disagreement between the prose table and this JSON, the JSON wins. Consumers are pinned to it by tools/validate-openrouter-cascade.sh, which rejects (a) a quality_rank in plugins/pipeline/references/model-cascade.json that disagrees with or is missing from this file, (b) a routing-policy.json agentType model or fallbackModel slug that is absent here, and (c) a snapshot_date that diverges from the prose snapshot date. Routing scope is the OpenRouter rail only: native Codex identities and native Claude aliases are absent from routing models. native_api_equivalent_cost is observation-only pricing evidence and never routing authority. anthropic/* routing slugs are rejected by openrouter-wrapper.sh before network contact and must never be added to routing models.",
   "schema_version": 1,
-  "snapshot_date": "2026-08-03",
+  "snapshot_date": "2026-08-12",
   "native_api_equivalent_cost": {
     "schema_version": 1,
-    "snapshot_date": "2026-08-09",
+    "snapshot_date": "2026-08-12",
     "input_bytes_per_token_estimate": 4,
     "aliases": {
-      "gpt-5.6-sol": "openai/gpt-5.6-sol",
-      "gpt-5.6-terra": "openai/gpt-5.6-terra",
-      "gpt-5.6-luna": "openai/gpt-5.6-luna"
+      "gpt-5.6-sol": "openai/gpt-5.6-sol"
     },
     "models": [
       {
@@ -17,9 +15,9 @@
         "input_usd_per_m": 5.0,
         "output_usd_per_m": 30.0,
         "cache_read_usd_per_m": 0.5,
-        "snapshot_date": "2026-08-09",
+        "snapshot_date": "2026-08-12",
         "pricing_basis": "API-equivalent planning estimate; never billed subscription spend",
-        "sources": ["https://openrouter.ai/openai/gpt-5.6-sol/"]
+        "sources": ["https://developers.openai.com/api/docs/models/gpt-5.6-sol"]
       }
     ]
   },
@@ -83,42 +81,64 @@
     {
       "slug": "moonshotai/kimi-k3",
       "name": "Kimi K3",
+      "catalog_status": "available",
+      "recommendation_status": "review-only",
+      "catalog_name": "MoonshotAI: Kimi K3",
       "input_usd_per_m": 3.0,
       "output_usd_per_m": 15.0,
       "cache_read_usd_per_m": 0.3,
       "context_tokens": 1048576,
+      "top_provider_context_tokens": 1048576,
+      "top_provider_max_completion_tokens": null,
+      "supports_tools": true,
+      "supports_reasoning": true,
       "quality_rank": 97,
       "aa_scores": {
-        "intelligence": 57.1,
+        "intelligence": 60.0,
         "coding": 76.2,
         "agentic": 50.1,
         "source": "artificial-analysis",
-        "source_version": "v4.1"
+        "source_version": "v4.1.1",
+        "exact_variant": "Kimi K3 (max)",
+        "effort": "max",
+        "observed_on": "2026-08-12",
+        "metric_status": {"intelligence": "current", "coding": "stale-v4.1", "agentic": "stale-v4.1"},
+        "evaluated_output_tokens_m": 130
       },
-      "role": "Quality-first security and bulk-analysis head; reasoning efforts low/high/max.",
-      "snapshot_date": "2026-08-03",
+      "role": "Review-only, focused security first. Never implement or fix its own findings; bound output and hand accepted findings to a cheaper executor. Strong quality evidence, but high output price, slower generation, and observed verbosity make broad default use uneconomic.",
+      "snapshot_date": "2026-08-12",
       "sources": [
         "https://openrouter.ai/moonshotai/kimi-k3",
-        "https://artificialanalysis.ai/models"
+        "https://artificialanalysis.ai/models/kimi-k3"
       ]
     },
     {
       "slug": "openai/gpt-5.6-terra",
       "name": "GPT-5.6 Terra",
+      "catalog_status": "available",
+      "recommendation_status": "quality-backup",
+      "catalog_name": "OpenAI: GPT-5.6 Terra",
       "input_usd_per_m": 1.0,
       "output_usd_per_m": 6.0,
       "cache_read_usd_per_m": 0.1,
+      "cache_write_usd_per_m": 1.25,
       "context_tokens": 1050000,
+      "top_provider_context_tokens": 1050000,
+      "top_provider_max_completion_tokens": 128000,
+      "supports_tools": true,
+      "supports_reasoning": true,
+      "pricing_overrides": [{"min_prompt_tokens": 272000, "input_usd_per_m": 2.0, "output_usd_per_m": 9.0, "cache_read_usd_per_m": 0.2, "cache_write_usd_per_m": 2.5}],
       "quality_rank": 94,
       "aa_scores": {
         "intelligence": 55.0,
         "coding": 76.7,
         "agentic": 47.4,
         "source": "artificial-analysis",
-        "source_version": "v4.1"
+        "source_version": "v4.1",
+        "evidence_status": "stale"
       },
-      "role": "High-quality OpenRouter backup; reasoning none through max.",
-      "snapshot_date": "2026-08-03",
+      "role": "OpenRouter quality backup for bounded analysis when cheaper candidates are insufficient; avoid routine mechanical work. Use code-aware native Codex supervision and measured effort escalation; long prompts above 272K trigger higher catalog pricing.",
+      "snapshot_date": "2026-08-12",
       "sources": [
         "https://openrouter.ai/openai/gpt-5.6-terra",
         "https://artificialanalysis.ai/models"
@@ -127,64 +147,102 @@
     {
       "slug": "x-ai/grok-4.5",
       "name": "Grok 4.5",
+      "catalog_status": "available",
+      "recommendation_status": "provisional-bounded-execution",
+      "catalog_name": "SpaceXAI: Grok 4.5",
       "input_usd_per_m": 2.0,
       "output_usd_per_m": 6.0,
-      "cache_read_usd_per_m": null,
+      "cache_read_usd_per_m": 0.3,
       "context_tokens": 500000,
+      "top_provider_context_tokens": 500000,
+      "top_provider_max_completion_tokens": null,
+      "supports_tools": true,
+      "supports_reasoning": true,
+      "pricing_overrides": [{"min_prompt_tokens": 200000, "input_usd_per_m": 4.0, "output_usd_per_m": 12.0, "cache_read_usd_per_m": 0.6}],
       "quality_rank": 93,
       "aa_scores": {
-        "intelligence": 54.0,
-        "coding": null,
+        "intelligence": 56.0,
+        "coding": 76.0,
         "agentic": null,
         "source": "artificial-analysis",
-        "source_version": "v4.1"
+        "source_version": "v4.1.1",
+        "exact_variant": "Grok 4.5 (high)",
+        "effort": "high",
+        "observed_on": "2026-08-12",
+        "metric_status": {"intelligence": "current", "coding": "current-separate-coding-agent-index", "agentic": "unavailable"},
+        "evaluated_output_tokens_m": 60,
+        "coding_exact_variant": "Grok 4.5 in Grok Build",
+        "coding_source_version": "Artificial Analysis Coding Agent Index reported 2026-07-08; DeepSWE, Terminal-Bench v2, SWE-Atlas QnA",
+        "coding_average_tokens_m": 1.9,
+        "coding_cost_note": "The source summary reports $2.59/task while its detailed section reports $2.49/task; neither value is canonicalized here."
       },
-      "role": "Near-frontier value fallback.",
-      "snapshot_date": "2026-08-03",
+      "role": "Provisional candidate for demanding bounded execution or escalation after a cheaper worker fails. Avoid unbounded large-context work: context is 500K and price doubles above 200K prompt tokens. Require Codex 5.6 scope, correctness, and simplicity review until local Assembly evidence exists.",
+      "snapshot_date": "2026-08-12",
       "sources": [
         "https://openrouter.ai/x-ai/grok-4.5",
-        "https://artificialanalysis.ai/models"
+        "https://artificialanalysis.ai/models/grok-4-5",
+        "https://artificialanalysis.ai/articles/grok-4-5-brings-spacexai-to-the-the-intelligence-frontier"
       ]
     },
     {
       "slug": "z-ai/glm-5.2",
       "name": "GLM-5.2",
-      "input_usd_per_m": 1.19,
-      "output_usd_per_m": 3.74,
-      "cache_read_usd_per_m": null,
-      "context_tokens": 1000000,
+      "catalog_status": "available",
+      "recommendation_status": "experimental-last-fallback",
+      "catalog_name": "Z.ai: GLM 5.2",
+      "input_usd_per_m": 0.392,
+      "output_usd_per_m": 1.232,
+      "cache_read_usd_per_m": 0.0728,
+      "context_tokens": 1048576,
+      "top_provider_context_tokens": 1048576,
+      "top_provider_max_completion_tokens": 131072,
+      "supports_tools": true,
+      "supports_reasoning": true,
       "quality_rank": 90,
       "aa_scores": {
-        "intelligence": 51.1,
+        "intelligence": 53.0,
         "coding": 68.8,
         "agentic": 43.1,
         "source": "artificial-analysis",
-        "source_version": "v4.1"
+        "source_version": "v4.1.1",
+        "exact_variant": "GLM-5.2 (max)",
+        "effort": "max",
+        "observed_on": "2026-08-12",
+        "metric_status": {"intelligence": "current", "coding": "stale-v4.1", "agentic": "stale-v4.1"},
+        "evaluated_output_tokens_m": 140
       },
-      "role": "Third-party mechanical and security-capacity fallback; catalog price shown, lower-cost endpoints exist.",
-      "snapshot_date": "2026-08-03",
+      "role": "Experimental or last fallback only unless a narrow local task class earns a seat. Repeated Depot/Assembly experience required too much handholding; independent max-effort scores do not overrule that. Use only with strong native supervision and bounded acceptance criteria.",
+      "snapshot_date": "2026-08-12",
       "sources": [
         "https://openrouter.ai/z-ai/glm-5.2",
-        "https://artificialanalysis.ai/models"
+        "https://artificialanalysis.ai/models/glm-5-2/"
       ]
     },
     {
       "slug": "meta/muse-spark-1.1",
       "name": "Muse Spark 1.1",
+      "catalog_status": "available",
+      "recommendation_status": "specialist-fallback",
+      "catalog_name": "Meta: Muse Spark 1.1",
       "input_usd_per_m": 1.25,
       "output_usd_per_m": 4.25,
-      "cache_read_usd_per_m": null,
-      "context_tokens": 1000000,
+      "cache_read_usd_per_m": 0.15,
+      "context_tokens": 1048576,
+      "top_provider_context_tokens": 1048576,
+      "top_provider_max_completion_tokens": null,
+      "supports_tools": true,
+      "supports_reasoning": true,
       "quality_rank": 90,
       "aa_scores": {
         "intelligence": 51.0,
         "coding": null,
         "agentic": null,
         "source": "artificial-analysis",
-        "source_version": "v4.1"
+        "source_version": "v4.1",
+        "evidence_status": "stale"
       },
       "role": "Multimodal frontier value; the current wrapper is text-only.",
-      "snapshot_date": "2026-08-03",
+      "snapshot_date": "2026-08-12",
       "sources": [
         "https://openrouter.ai/meta/muse-spark-1.1",
         "https://artificialanalysis.ai/models"
@@ -193,20 +251,30 @@
     {
       "slug": "openai/gpt-5.6-luna",
       "name": "GPT-5.6 Luna",
+      "catalog_status": "available",
+      "recommendation_status": "economical-mechanical",
+      "catalog_name": "OpenAI: GPT-5.6 Luna",
       "input_usd_per_m": 0.1,
       "output_usd_per_m": 0.6,
       "cache_read_usd_per_m": 0.01,
+      "cache_write_usd_per_m": 0.125,
       "context_tokens": 1050000,
+      "top_provider_context_tokens": 1050000,
+      "top_provider_max_completion_tokens": 128000,
+      "supports_tools": true,
+      "supports_reasoning": true,
+      "pricing_overrides": [{"min_prompt_tokens": 272000, "input_usd_per_m": 0.2, "output_usd_per_m": 0.9, "cache_read_usd_per_m": 0.02, "cache_write_usd_per_m": 0.25}],
       "quality_rank": 90,
       "aa_scores": {
         "intelligence": 51.2,
         "coding": 71.4,
         "agentic": 45.6,
         "source": "artificial-analysis",
-        "source_version": "v4.1"
+        "source_version": "v4.1",
+        "evidence_status": "stale"
       },
       "role": "Low-cost mechanical and config/doc work; reasoning none through max.",
-      "snapshot_date": "2026-08-03",
+      "snapshot_date": "2026-08-12",
       "sources": [
         "https://openrouter.ai/openai/gpt-5.6-luna",
         "https://artificialanalysis.ai/models"
@@ -215,20 +283,29 @@
     {
       "slug": "google/gemini-3.5-flash",
       "name": "Gemini 3.5 Flash",
+      "catalog_status": "available",
+      "recommendation_status": "specialist-fallback",
+      "catalog_name": "Google: Gemini 3.5 Flash",
       "input_usd_per_m": 1.5,
       "output_usd_per_m": 9.0,
-      "cache_read_usd_per_m": null,
-      "context_tokens": 1000000,
+      "cache_read_usd_per_m": 0.15,
+      "cache_write_usd_per_m": 0.0833333333333,
+      "context_tokens": 1048576,
+      "top_provider_context_tokens": 1048576,
+      "top_provider_max_completion_tokens": 65536,
+      "supports_tools": true,
+      "supports_reasoning": true,
       "quality_rank": 89,
       "aa_scores": {
         "intelligence": 50.0,
         "coding": null,
         "agentic": null,
         "source": "artificial-analysis",
-        "source_version": "v4.1"
+        "source_version": "v4.1",
+        "evidence_status": "stale"
       },
       "role": "Multimodal frontier tail; the current wrapper is text-only.",
-      "snapshot_date": "2026-08-03",
+      "snapshot_date": "2026-08-12",
       "sources": [
         "https://openrouter.ai/google/gemini-3.5-flash",
         "https://artificialanalysis.ai/models"
@@ -237,20 +314,28 @@
     {
       "slug": "deepseek/deepseek-v4-pro",
       "name": "DeepSeek V4 Pro",
-      "input_usd_per_m": 0.435,
-      "output_usd_per_m": 0.87,
-      "cache_read_usd_per_m": null,
-      "context_tokens": 1000000,
+      "catalog_status": "available",
+      "recommendation_status": "legacy-cheap-fallback",
+      "catalog_name": "DeepSeek: DeepSeek V4 Pro",
+      "input_usd_per_m": 0.63168,
+      "output_usd_per_m": 1.26336,
+      "cache_read_usd_per_m": 0.053298,
+      "context_tokens": 1048576,
+      "top_provider_context_tokens": 1048576,
+      "top_provider_max_completion_tokens": 393216,
+      "supports_tools": true,
+      "supports_reasoning": true,
       "quality_rank": 83,
       "aa_scores": {
         "intelligence": 44.0,
         "coding": null,
         "agentic": null,
         "source": "artificial-analysis",
-        "source_version": "v4.1"
+        "source_version": "v4.1",
+        "evidence_status": "stale"
       },
       "role": "Cheap code-analysis fallback through OpenRouter.",
-      "snapshot_date": "2026-08-03",
+      "snapshot_date": "2026-08-12",
       "sources": [
         "https://openrouter.ai/deepseek/deepseek-v4-pro",
         "https://artificialanalysis.ai/models"
@@ -259,20 +344,28 @@
     {
       "slug": "minimax/minimax-m3",
       "name": "MiniMax-M3",
+      "catalog_status": "available",
+      "recommendation_status": "capacity-fallback",
+      "catalog_name": "MiniMax: MiniMax M3",
       "input_usd_per_m": 0.3,
       "output_usd_per_m": 1.2,
-      "cache_read_usd_per_m": null,
-      "context_tokens": 1000000,
+      "cache_read_usd_per_m": 0.06,
+      "context_tokens": 1048576,
+      "top_provider_context_tokens": 524288,
+      "top_provider_max_completion_tokens": 512000,
+      "supports_tools": true,
+      "supports_reasoning": true,
       "quality_rank": 83,
       "aa_scores": {
         "intelligence": 44.0,
         "coding": null,
         "agentic": null,
         "source": "artificial-analysis",
-        "source_version": "v4.1"
+        "source_version": "v4.1",
+        "evidence_status": "stale"
       },
       "role": "Multimodal cost workhorse; model context is 1M but the top endpoint serves about 524K.",
-      "snapshot_date": "2026-08-03",
+      "snapshot_date": "2026-08-12",
       "sources": [
         "https://openrouter.ai/minimax/minimax-m3",
         "https://artificialanalysis.ai/models"
@@ -281,36 +374,86 @@
     {
       "slug": "deepseek/deepseek-v4-flash",
       "name": "DeepSeek V4 Flash",
-      "input_usd_per_m": 0.098,
-      "output_usd_per_m": 0.196,
-      "cache_read_usd_per_m": null,
-      "context_tokens": 1000000,
+      "catalog_status": "available",
+      "recommendation_status": "superseded-routed-identity",
+      "catalog_name": "DeepSeek: DeepSeek V4 Flash 0423",
+      "input_usd_per_m": 0.14,
+      "output_usd_per_m": 0.28,
+      "cache_read_usd_per_m": 0.028,
+      "context_tokens": 1048576,
+      "top_provider_context_tokens": 1048576,
+      "top_provider_max_completion_tokens": 393216,
+      "supports_tools": true,
+      "supports_reasoning": true,
       "quality_rank": 78,
       "aa_scores": {
         "intelligence": 40.0,
         "coding": null,
         "agentic": null,
         "source": "artificial-analysis",
-        "source_version": "v4.1"
+        "source_version": "v4.1",
+        "exact_variant": "DeepSeek V4 Flash 0423 (reasoning, max effort)",
+        "evidence_status": "stale-superseded"
       },
-      "role": "Cheapest mechanical checks.",
-      "snapshot_date": "2026-08-03",
+      "role": "Legacy routed identity only. The catalog resolves this slug to the 0423 release; do not treat it as the refreshed execution candidate or silently mutate executable routing.",
+      "snapshot_date": "2026-08-12",
       "sources": [
         "https://openrouter.ai/deepseek/deepseek-v4-flash",
         "https://artificialanalysis.ai/models"
       ]
     },
     {
+      "slug": "deepseek/deepseek-v4-flash-0731",
+      "name": "DeepSeek V4 Flash 0731",
+      "catalog_status": "available",
+      "recommendation_status": "recommendation-only-default-execution-candidate",
+      "catalog_name": "DeepSeek: DeepSeek V4 Flash 0731",
+      "input_usd_per_m": 0.08,
+      "output_usd_per_m": 0.18,
+      "cache_read_usd_per_m": 0.016,
+      "context_tokens": 1048576,
+      "top_provider_context_tokens": 1048576,
+      "top_provider_max_completion_tokens": 384000,
+      "supports_tools": true,
+      "supports_reasoning": true,
+      "quality_rank": null,
+      "aa_scores": {
+        "intelligence": 52.0,
+        "coding": null,
+        "agentic": null,
+        "source": "artificial-analysis",
+        "source_version": "v4.1.1",
+        "exact_variant": "DeepSeek V4 Flash 0731 (reasoning, max effort)",
+        "effort": "max",
+        "observed_on": "2026-08-12",
+        "metric_status": {"intelligence": "current", "coding": "unavailable", "agentic": "unavailable"},
+        "evaluated_output_tokens_m": 210
+      },
+      "role": "Provisional default candidate for bounded low-cost execution, especially scoped config, docs, and mechanical code changes. Avoid broad autonomous work and treat low token price cautiously because the max-effort evaluation was very verbose. Require Codex 5.6 scope, correctness, and unnecessary-complexity review; confidence is medium pending local 0731 task evidence.",
+      "snapshot_date": "2026-08-12",
+      "sources": [
+        "https://openrouter.ai/deepseek/deepseek-v4-flash-0731",
+        "https://artificialanalysis.ai/models/deepseek-v4-flash"
+      ]
+    },
+    {
       "slug": "qwen/qwen3-coder",
       "name": "Qwen3 Coder",
+      "catalog_status": "available",
+      "recommendation_status": "final-bulk-fallback",
+      "catalog_name": "Qwen: Qwen3 Coder 480B A35B",
       "input_usd_per_m": 0.3,
       "output_usd_per_m": 1.0,
-      "cache_read_usd_per_m": null,
-      "context_tokens": 1000000,
+      "cache_read_usd_per_m": 0.1,
+      "context_tokens": 262144,
+      "top_provider_context_tokens": 262144,
+      "top_provider_max_completion_tokens": 65536,
+      "supports_tools": true,
+      "supports_reasoning": false,
       "quality_rank": 72,
       "aa_scores": null,
-      "role": "Lower-quality final bulk fallback; model context is 1M but the top endpoint serves about 262K, so validate endpoint capacity before very large prompts.",
-      "snapshot_date": "2026-08-03",
+      "role": "Lower-confidence final fallback for bounded code tasks. Avoid large-context work: both catalog and top-provider context are 262,144 tokens. Require native code review and use only after stronger economical candidates are unavailable.",
+      "snapshot_date": "2026-08-12",
       "sources": [
         "https://openrouter.ai/qwen/qwen3-coder"
       ]

--- a/plugins/openrouter/skills/openrouter-delegate/references/model-selection.md
+++ b/plugins/openrouter/skills/openrouter-delegate/references/model-selection.md
@@ -10,24 +10,30 @@ Decision tables for the three distinct routing systems that use these model name
 
 ## Available Models
 
-Prices below are a checked-in planning snapshot from 2026-08-03, in USD per
+Prices below are a checked-in planning snapshot from 2026-08-12, in USD per
 million input/output tokens; they are not current telemetry. Before a paid or
 policy-changing run, obtain a live MCP receipt with `observedAt` and `expiresAt`
 no more than 15 minutes apart and use it only before expiry.
 
 | Slug | Name | Input / output | Context | Quality and role |
 |------|------|----------------|---------|------------------|
-| `moonshotai/kimi-k3` | Kimi K3 | $3 / $15; $0.30 cache read | 1,048,576 | AA intelligence 57.1 / coding 76.2 / agentic 50.1; quality-first security and bulk-analysis head; reasoning efforts low/high/max |
-| `openai/gpt-5.6-terra` | GPT-5.6 Terra | $1 / $6; $0.10 cache read | 1,050,000 | AA intelligence 55.0 / coding 76.7 / agentic 47.4; high-quality OpenRouter backup; reasoning none through max |
-| `openai/gpt-5.6-luna` | GPT-5.6 Luna | $0.10 / $0.60; $0.01 cache read | 1,050,000 | AA intelligence 51.2 / coding 71.4 / agentic 45.6; low-cost mechanical and config/doc work; reasoning none through max |
-| `x-ai/grok-4.5` | Grok 4.5 | $2 / $6 | 500K | AA 54; near-frontier value fallback |
-| `z-ai/glm-5.2` | GLM-5.2 | catalog $1.19 / $3.74; lower-cost endpoints exist | 1M | AA intelligence 51.1 / coding 68.8 / agentic 43.1; third-party mechanical and security-capacity fallback |
-| `meta/muse-spark-1.1` | Muse Spark 1.1 | $1.25 / $4.25 | 1M | AA 51; multimodal frontier value |
-| `google/gemini-3.5-flash` | Gemini 3.5 Flash | $1.50 / $9 | 1M | AA 50; multimodal frontier tail |
-| `deepseek/deepseek-v4-pro` | DeepSeek V4 Pro | $0.435 / $0.87 | 1M | AA 44; cheap code-analysis fallback through OpenRouter |
-| `minimax/minimax-m3` | MiniMax-M3 | $0.30 / $1.20 | 1M model; top endpoint about 524K | AA 44; multimodal cost workhorse |
-| `deepseek/deepseek-v4-flash` | DeepSeek V4 Flash | $0.098 / $0.196 | 1M | AA 40; cheapest mechanical checks |
-| `qwen/qwen3-coder` | Qwen3 Coder | $0.30 / $1 | 1M model; top endpoint about 262K | Lower-quality final bulk fallback; validate endpoint capacity before very large prompts |
+| `moonshotai/kimi-k3` | Kimi K3 | $3 / $15; $0.30 cache read | 1,048,576 | AA v4.1.1 intelligence 60 at max; 130M evaluated output tokens; review-only, focused security first |
+| `openai/gpt-5.6-terra` | GPT-5.6 Terra | $1 / $6; $0.10 cache read, $1.25 cache write | 1,050,000 | OpenRouter quality backup; old AA v4.1 quality fields are stale |
+| `openai/gpt-5.6-luna` | GPT-5.6 Luna | $0.10 / $0.60; $0.01 cache read, $0.125 cache write | 1,050,000 | Economical mechanical/config/doc worker; old AA v4.1 quality fields are stale |
+| `x-ai/grok-4.5` | Grok 4.5 | $2 / $6; $0.30 cache read | 500K | AA v4.1.1 intelligence 56 at high; Coding Agent Index 76 in Grok Build with 1.9M average tokens; demanding bounded-execution candidate |
+| `z-ai/glm-5.2` | GLM-5.2 | $0.392 / $1.232; $0.0728 cache read | 1,048,576 | AA v4.1.1 intelligence 53 at max; 140M evaluated output tokens; experimental/last fallback after poor local ergonomics |
+| `meta/muse-spark-1.1` | Muse Spark 1.1 | $1.25 / $4.25; $0.15 cache read | 1,048,576 | Specialist multimodal fallback; old AA v4.1 evidence is stale and the wrapper remains text-only |
+| `google/gemini-3.5-flash` | Gemini 3.5 Flash | $1.50 / $9; $0.15 cache read, $0.0833 cache write | 1,048,576 | Specialist multimodal fallback; old AA v4.1 evidence is stale and the wrapper remains text-only |
+| `deepseek/deepseek-v4-pro` | DeepSeek V4 Pro | $0.63168 / $1.26336; $0.053298 cache read | 1,048,576 | Legacy cheap fallback; old AA v4.1 evidence is stale |
+| `minimax/minimax-m3` | MiniMax-M3 | $0.30 / $1.20; $0.06 cache read | 1,048,576 model; top provider 524,288 | Capacity fallback; old AA v4.1 evidence is stale |
+| `deepseek/deepseek-v4-flash` | DeepSeek V4 Flash 0423 | $0.14 / $0.28; $0.028 cache read | 1,048,576 | Superseded routed identity; it is not the current 0731 release |
+| `deepseek/deepseek-v4-flash-0731` | DeepSeek V4 Flash 0731 | $0.08 / $0.18; $0.016 cache read | 1,048,576 | Recommendation-only; AA v4.1.1 intelligence 52 at max and 210M evaluated output tokens; provisional default bounded-execution candidate |
+| `qwen/qwen3-coder` | Qwen3 Coder | $0.30 / $1; $0.10 cache read | 262,144 | Lower-confidence final fallback; prior 1M description was misleading |
+
+OpenRouter returned every routed slug as available at `2026-08-11T22:42:37Z`.
+The dated DeepSeek 0731 slug is also available. The `~deepseek/...-latest`
+catalog identity is an alias with only 262,144 tokens at its top provider and is
+not durable enough for executable routing or reproducible evaluation.
 
 **Data source of truth:** the machine-readable
 [`model-matrix.json`](model-matrix.json) is the canonical form of this table --
@@ -104,6 +110,51 @@ matrix never re-routes anything on its own; a routing change is a separate,
 deliberate edit to `model-cascade.json`, `harness-profile.json`, or
 `routing-policy.json`.
 
+## Recommended workload matrix
+
+These are recommendations for the next routing-policy review, not the current
+executable order. Assembly is the calibration target: small internal,
+self-hosted Go applications for roughly 4-50 co-op members, maintained by two
+developers. A future supervisor checks worker scope, correctness, and
+unnecessary complexity; it does not re-run the entire worker task by default.
+
+| Model | Use | Avoid | Cost, latency, and context caveats | Required supervision | Confidence |
+|-------|-----|-------|------------------------------------|----------------------|------------|
+| Kimi K3 | Focused security review and difficult independent review | Implementation, fixing its own findings, routine bulk review | $15/M output; AA max used 130M output tokens and measured 42.5 tok/s | Bound files/questions/output, then hand accepted findings to a cheaper executor; independent code-aware sign-off remains | High for focused security; medium elsewhere |
+| DeepSeek V4 Flash 0731 | Default candidate for bounded low-cost config, docs, and mechanical code execution | Broad autonomous changes, architecture, or security sign-off | Very low catalog price, 1M context, but AA max used 210M output tokens; cheap tokens do not guarantee cheap tasks | Codex 5.6 checks scope, correctness, tests, and overbuilding | Medium; no local 0731 task receipts yet |
+| Grok 4.5 | More demanding bounded execution and escalation after a cheaper worker fails | Very large prompts, unbounded implementation, or unsupervised security work | 500K context; catalog price doubles above 200K prompt tokens; Grok Build scored 76 on the AA Coding Agent Index with 1.9M average tokens | Codex 5.6 reviews the changed surface and simplest adequate design | Medium-low pending local Assembly evidence |
+| GLM-5.2 | Experimental last fallback or a narrow task class proven locally | Default implementation, security, or tasks needing iterative judgment | Attractive catalog price and 1M context, but AA max used 140M output tokens | Strong native supervisor, explicit acceptance criteria, and stop after repeated correction | Low for default use; medium only for a proven narrow exception |
+| GPT-5.6 Terra via OpenRouter | Bounded quality backup when cheap candidates fail | Routine mechanical work and very large prompts without a cost check | 1.05M context; catalog price rises above 272K prompt tokens | Native Codex checks provider/model provenance and the resulting diff | Medium |
+| GPT-5.6 Luna via OpenRouter | High-volume mechanical, config, and documentation work | Architecture, ambiguous integration, and consequential security decisions | Lowest OpenRouter GPT-5.6 price; price rises above 272K prompt tokens | Scope and test review by Codex; escalate model only after a demonstrated miss | Medium |
+| DeepSeek V4 Flash 0423 | Preserve only while executable policy still references the exact slug | Treating it as the refreshed model or choosing it for new work | Superseded identity despite continued availability; 1M context | Existing routing receipts must record the exact returned model | High identity confidence; low recommendation confidence |
+| DeepSeek V4 Pro | Legacy cheap fallback for bounded analysis | Default execution while 0731 remains untested locally | Price rose from the prior snapshot; old quality evidence is stale | Native code review | Low-medium |
+| MiniMax-M3 | Capacity fallback for bounded text work | Prompts that assume full model context at the selected endpoint | Model advertises 1M, top provider exposes 524,288 | Native code review and endpoint-capacity check | Low-medium |
+| Qwen3 Coder | Final fallback for small, explicit code tasks | Bulk/large-context work or reasoning-heavy changes | Catalog and top-provider context are both 262,144; no catalog reasoning support | Full changed-surface code review | Low |
+| Muse Spark 1.1 | Specialist fallback when its modality becomes usable | Assuming multimodal support through the current text-only wrapper | 1M context; current quality evidence is stale | Native review and modality-path verification | Low |
+| Gemini 3.5 Flash | Specialist fallback when its modality becomes usable | Routine text work at its output price or assuming wrapper file support | 1M context, 65,536 top-provider max completion; current quality evidence is stale | Native review and modality-path verification | Low |
+| Fable 5, native subscription only | Non-coding strategy/advisor checkpoint: set direction and delegate bounded work | OpenRouter routing, implementation by default, or duplicating a full code review | Subscription use is not measured API spend; frontier model can add ceremony to small apps | Operator or Codex turns advice into a small execution brief | High for advisor boundary; medium task-by-task |
+| Codex 5.6 Sol, native | Code-aware supervisor/reviewer and hard-problem fallback | Automatically redoing the worker task or using maximum effort by habit | 1.05M context; API-equivalent planning price is $5/$30, not subscription spend | Review scope, correctness, tests, performance, ergonomics, and unnecessary complexity | High |
+
+The local evidence outranks generic benchmarks for this harness. Kimi found
+consequential security defects, but successful review lanes commonly emitted
+roughly 8K-25K completion tokens and cost about $0.14-$0.32 each; large streamed
+payloads also failed before output. GLM completed a mechanical lane, but the
+operator's repeated Depot/Assembly experience is that it needs too much
+handholding. Older DeepSeek lanes have produced wrapper failures, nonexistent
+paths, and false positives; those observations do not establish quality for the
+new 0731 variant. There is no local Grok 4.5 or DeepSeek 0731 execution receipt,
+so both recommendations remain provisional.
+
+Artificial Analysis v4.1.1 currently reports intelligence 60 for Kimi K3
+`max`, 52 for DeepSeek V4 Flash 0731 `max`, 56 for Grok 4.5 `high`, and 53 for
+GLM-5.2 `max`. A separate July 8 Coding Agent Index report scores Grok 4.5 in
+the Grok Build harness at 76 using 1.9M average tokens; that source conflicts
+with itself on per-task cost ($2.59 in its summary and $2.49 in detail), so this
+matrix does not canonicalize either cost. Its price and speed figures are first-party or median-provider
+observations, not OpenRouter catalog prices. Older matrix coding and agentic
+fields are retained as stale because the current pages did not expose complete,
+comparable values for those exact evaluated variants.
+
 ## Native Codex execution
 
 Native Codex models run through the Codex host or `codex-companion`; they are not OpenRouter requests and retain `implementedBy: codex` provenance.
@@ -114,7 +165,53 @@ Native Codex models run through the Codex host or `codex-companion`; they are no
 | Claude Code | `premium_sub` via `codex-companion` | GPT-5.6 Sol (representative; Codex selects its configured native model) |
 | Generic | `premium_sub` | unavailable |
 
+Official OpenAI guidance positions Sol for frontier complex reasoning/coding,
+Terra for a balance of intelligence and cost, and Luna for efficient
+high-volume workloads. All three support `none`, `low`, `medium`, `high`,
+`xhigh`, and `max`, with 1.05M context. Benchmark the current effort and one
+level lower on representative tasks. Use `medium` as the balanced starting
+point, `low` for latency-sensitive work, `high` or `xhigh` only after a measured
+quality gain, and reserve `max` for the hardest quality-first work.
+
+| Native task | Model | Default effort | Escalate only when |
+|-------------|-------|----------------|--------------------|
+| Mechanical verification, narrow review, scoped fix | Luna or Terra | `low` | A lower-effort attempt misses a named acceptance criterion |
+| Ordinary code-aware supervision and review | Sol | `medium` | Ambiguity spans components, a defect has meaningful consequence, or medium failed |
+| Architecture or hard debugging | Sol | `medium` | Competing hypotheses remain after evidence gathering; then try `high` |
+| Consequential security review | Sol | `high` | Use `xhigh` only for unresolved attack paths or failed high-effort verification |
+| Hardest quality-first fallback | Sol | `xhigh` | Use `max` only after xhigh fails or a named high-consequence uncertainty justifies it |
+| Non-coding strategy checkpoint | Fable 5 native | lowest native setting adequate to frame direction | Increase only when the advisor cannot resolve a named strategic uncertainty |
+
+API-equivalent planning prices, not measured subscription spend, were verified
+from official OpenAI model pages on 2026-08-12: Sol $5/$30 with $0.50 cached
+input, Terra $2/$12 with $0.20 cached input, and Luna $0.20/$1.20 with $0.02
+cached input. Prompts above 272K input tokens carry higher API pricing. The
+matrix's native cost-imputation object continues to price only Sol: Terra and
+Luna aliases were removed because their OpenRouter catalog prices differ from
+official native API prices and the existing schema cannot represent both
+without conflation.
+
+Sources: [OpenAI model guidance](https://developers.openai.com/api/docs/guides/latest-model),
+[Sol](https://developers.openai.com/api/docs/models/gpt-5.6-sol),
+[Terra](https://developers.openai.com/api/docs/models/gpt-5.6-terra), and
+[Luna](https://developers.openai.com/api/docs/models/gpt-5.6-luna).
+
+Anthropic describes Fable 5 as its frontier model for ambitious, long-running
+knowledge and coding work, and separately documents an advisor pattern in which
+Fable sets strategy while a smaller, cheaper model executes. Depot maps that
+pattern narrowly: Fable is a native-subscription-only, non-coding advisor
+checkpoint; a bounded OpenRouter worker may execute, and Codex remains the
+code-aware supervisor. Fable does not enter OpenRouter data, does not duplicate
+a full code review, and no `anthropic/*` routing slug is permitted. Sources:
+[Fable 5](https://www.anthropic.com/claude/fable) and
+[Anthropic's advisor/orchestration webinar](https://www.anthropic.com/webinars/building-on-the-claude-platform-claude-fable-5-and-model-orchestration-patterns).
+
 ## dm-review target topology and direct OpenRouter delegation
+
+The tables in this section mirror executable policy as of this evidence-only
+refresh. They intentionally do not implement the recommendations above. In
+particular, bulk Kimi and GLM fallback seats remain visible until the later
+routing chunk changes and reviews them.
 
 These calls use the OpenRouter API and retain `implementedBy: openrouter` even when the selected slug begins with `openai/`. A later Codex fallback is a separate native attempt with its own receipt.
 
@@ -131,6 +228,12 @@ Review timeouts are 3600s, extended to 7200s for bulk diffs of at least 10K line
 ## Pipeline execution cascade target topology
 
 Pipeline resolves abstract roles through `harness-profile.json`, then walks the class ladder in `model-cascade.json`. Its agentic OpenRouter executor is GLM-5.2-headed; Kimi remains a later capacity rung and the head of analysis-only frontier/bulk wrapper roles.
+
+That sentence reports current executable topology, not the refreshed
+recommendation. The proposal for the later routing chunk is to test the dated
+DeepSeek 0731 identity as the bounded execution head, use Grok 4.5 for harder
+bounded escalation, remove Kimi from implementation, and demote GLM-5.2 to an
+experimental last fallback. No order or policy changed in this refresh.
 
 | Role | Kind | Ordered models |
 |------|------|----------------|

--- a/plugins/openrouter/skills/openrouter-delegate/references/model-selection.md
+++ b/plugins/openrouter/skills/openrouter-delegate/references/model-selection.md
@@ -96,7 +96,9 @@ Only when the corresponding evidence was actually refreshed, update its
 `snapshot_date`, the snapshot on each changed entry under its `models`, aliases,
 prices, bytes-per-token estimate, and cited sources. An alias that targets a
 top-level routing model uses that routing model's own price and snapshot; do not
-copy or restamp it into the native model list.
+copy or restamp it into the native model list. When native and OpenRouter prices
+differ, use a distinct native-only identity so cost imputation preserves the
+official API-equivalent price without turning that identity into a routing slug.
 
 Record the source and observation date in the reviewed change. A native-cost
 refresh never changes the top-level routing `snapshot_date`, routing-model
@@ -186,10 +188,10 @@ API-equivalent planning prices, not measured subscription spend, were verified
 from official OpenAI model pages on 2026-08-12: Sol $5/$30 with $0.50 cached
 input, Terra $2/$12 with $0.20 cached input, and Luna $0.20/$1.20 with $0.02
 cached input. Prompts above 272K input tokens carry higher API pricing. The
-matrix's native cost-imputation object continues to price only Sol: Terra and
-Luna aliases were removed because their OpenRouter catalog prices differ from
-official native API prices and the existing schema cannot represent both
-without conflation.
+matrix's native cost-imputation object prices all three through explicit
+aliases. Terra and Luna target distinct native-only identities so their official
+API-equivalent costs remain separate from the cheaper top-level OpenRouter
+catalog prices; those identities are observation-only and never route work.
 
 Sources: [OpenAI model guidance](https://developers.openai.com/api/docs/guides/latest-model),
 [Sol](https://developers.openai.com/api/docs/models/gpt-5.6-sol),

--- a/tests/test_imputed_cost.py
+++ b/tests/test_imputed_cost.py
@@ -227,9 +227,20 @@ class ImputedCostTests(unittest.TestCase):
         events = translate_pipeline_receipts([_native_receipt()])
         summary = build_run_cost_summary(events, matrix=REAL_MATRIX)
         lane = summary["lanes"][0]
-        self.assertEqual(lane["cost_usd"], 4.0)
+        self.assertEqual(lane["cost_usd"], 8.0)
         self.assertIn(
-            "+model_alias(gpt-5.6-terra->openai/gpt-5.6-terra)",
+            "+model_alias(gpt-5.6-terra->openai/gpt-5.6-terra-native-api-equivalent)",
+            lane["measurement_source"],
+        )
+
+    def test_native_luna_alias_is_priceable(self):
+        events = translate_pipeline_receipts([
+            _native_receipt(model="gpt-5.6-luna"),
+        ])
+        lane = build_run_cost_summary(events, matrix=REAL_MATRIX)["lanes"][0]
+        self.assertEqual(lane["cost_usd"], 0.8)
+        self.assertIn(
+            "+model_alias(gpt-5.6-luna->openai/gpt-5.6-luna-native-api-equivalent)",
             lane["measurement_source"],
         )
 
@@ -451,7 +462,7 @@ class ImputedCostTests(unittest.TestCase):
                     self.assertEqual(cli.main(argv), 0)
                 self.assertEqual(stderr.getvalue(), "")
                 summary = json.loads(output.read_text(encoding="utf-8"))
-                self.assertEqual(summary["lanes"][0]["cost_usd"], 4.0)
+                self.assertEqual(summary["lanes"][0]["cost_usd"], 8.0)
                 self.assertEqual(summary["digest"], compute_cost_summary_digest(summary))
 
     def test_both_cli_commands_skip_unreadable_matrix_once(self):


### PR DESCRIPTION
## What changed

- refreshes the canonical OpenRouter model inventory from a fresh catalog observation
- adds exact price, cache, context, top-provider, tool, and reasoning evidence
- adds DeepSeek V4 Flash 0731 as a recommendation-only candidate without changing executable routing
- separates current independent evaluations, stale metrics, and local Depot/Assembly operator evidence
- documents native Codex effort guidance and Fable 5's native-only advisor role
- adds the durable 2026-08-12 refresh receipt
- bumps OpenRouter from 1.11.4 to 1.11.5 and regenerates the Codex manifest

## Why

The previous 2026-08-03 snapshot no longer matched operator experience or current model identities. In particular, the undated DeepSeek Flash slug resolves to the older 0423 release, Kimi's best role is focused security review rather than implementation, GLM-5.2 has required too much handholding locally, and the dated DeepSeek 0731 and Grok 4.5 variants merit bounded evaluation.

## Impact

This is evidence and recommendation documentation only. It does not change routing-policy.json, model-cascade.json, harness-profile.json, agent cards, executor defaults, authorization policy, provider gates, or any executable model order.

The proposed later routing direction is:

- DeepSeek V4 Flash 0731 for bounded low-cost execution
- Grok 4.5 for more demanding bounded escalation
- Kimi K3 for focused security review only
- GLM-5.2 as experimental/last fallback
- Fable 5 as a native non-coding advisor
- Codex 5.6 as the native code-aware supervisor

## Validation

- `jq empty` on every changed JSON file
- `bash tools/validate-openrouter-cascade.sh`
- `bash tools/validate-routing-economics.sh`
- `./tools/validate-dual-compat.sh`
- `./tools/generate-codex-manifests.py --check`
- `./tools/validate-composition.sh --all`
- `git diff --check`

All passed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Design-Machines-Studio/codesmith/depot/pr/32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789083004&installation_model_id=428410&pr_number=32&repository=Design-Machines-Studio%2Fdepot&return_to=https%3A%2F%2Fgithub.com%2FDesign-Machines-Studio%2Fdepot%2Fpull%2F32&signature=882c79fc96986f2e9369332cd3c42b0dc8b9a111db842f95c2baa9162be047f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->