### PR TITLE
fix: detect user-local Codex in release preflight

### DIFF
--- a/tests/test_release_preflight.py
+++ b/tests/test_release_preflight.py
@@ -22,11 +22,13 @@ class ReleasePreflightTests(unittest.TestCase):
         self.bin = self.temp / "bin"
         self.origin = self.temp / "origin.git"
         self.marketplace_root = self.temp / "marketplace"
+        self.home = self.temp / "home"
         self.codex_json = self.temp / "codex.json"
         self.git_log = self.temp / "git.log"
         self.repo.mkdir()
         self.bin.mkdir()
         self.marketplace_root.mkdir()
+        self.home.mkdir()
         (self.repo / "tools").mkdir()
 
         script = SCRIPT_SOURCE.read_text(encoding="utf-8")
@@ -114,8 +116,9 @@ class ReleasePreflightTests(unittest.TestCase):
         )
         wrapper.chmod(0o755)
 
-    def _write_codex(self):
-        codex = self.bin / "codex"
+    def _write_codex(self, path=None):
+        codex = path or self.bin / "codex"
+        codex.parent.mkdir(parents=True, exist_ok=True)
         codex.write_text(
             "#!/bin/sh\n"
             "if [ \"$1\" = plugin ] && [ \"$2\" = marketplace ] && "
@@ -153,8 +156,14 @@ class ReleasePreflightTests(unittest.TestCase):
         if codex == "unavailable":
             codex_path.unlink(missing_ok=True)
         else:
-            self._write_codex()
+            if codex == "user-local":
+                codex_path.unlink(missing_ok=True)
+                self._write_codex(self.home / ".local/bin/codex")
+            else:
+                self._write_codex()
             if codex == "fresh":
+                payload = json.dumps(self._installed_rows())
+            elif codex == "user-local":
                 payload = json.dumps(self._installed_rows())
             elif codex == "stale":
                 payload = json.dumps(self._installed_rows({"alpha": "0.9.0"}))
@@ -168,6 +177,7 @@ class ReleasePreflightTests(unittest.TestCase):
         self.git_log.unlink(missing_ok=True)
         env = os.environ.copy()
         env.update({
+            "HOME": str(self.home),
             "PREFLIGHT_CODEX_JSON": str(self.codex_json),
             "PREFLIGHT_MARKETPLACE_ROOT": str(self.marketplace_root),
             "PREFLIGHT_GIT_LOG": str(self.git_log),
@@ -265,6 +275,12 @@ class ReleasePreflightTests(unittest.TestCase):
         result = self._run_preflight(no_net=True, codex="fresh")
         self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
         self.assertIn("2 installed Codex plugin(s) checked", result.stdout)
+
+    def test_user_local_codex_cache_passes_without_broadening_fixed_path(self):
+        result = self._run_preflight(no_net=True, codex="user-local")
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("2 installed Codex plugin(s) checked", result.stdout)
+        self.assertNotIn("codex CLI not installed", result.stdout)
 
     def test_stale_codex_cache_fails_with_repair(self):
         result = self._run_preflight(no_net=True, codex="stale")

--- a/tests/test_release_preflight.py
+++ b/tests/test_release_preflight.py
@@ -29,6 +29,7 @@ class ReleasePreflightTests(unittest.TestCase):
         self.bin.mkdir()
         self.marketplace_root.mkdir()
         self.home.mkdir()
+        self.home.chmod(0o700)
         (self.repo / "tools").mkdir()
 
         script = SCRIPT_SOURCE.read_text(encoding="utf-8")
@@ -36,6 +37,10 @@ class ReleasePreflightTests(unittest.TestCase):
         script = script.replace(
             'PATH="/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin:/opt/homebrew/bin"',
             fixed_path,
+        )
+        script = script.replace(
+            "canonical_home=\"$(python3 -I -c 'import os, pwd; print(pwd.getpwuid(os.getuid()).pw_dir)' 2>/dev/null || :)\"",
+            'canonical_home="{}"'.format(self.home),
         )
         self.script = self.repo / "tools/check-release-preflight.sh"
         self.script.write_text(script, encoding="utf-8")
@@ -119,6 +124,11 @@ class ReleasePreflightTests(unittest.TestCase):
     def _write_codex(self, path=None):
         codex = path or self.bin / "codex"
         codex.parent.mkdir(parents=True, exist_ok=True)
+        if codex.is_relative_to(self.home):
+            current = self.home
+            for component in codex.relative_to(self.home).parts[:-1]:
+                current /= component
+                current.chmod(0o755)
         codex.write_text(
             "#!/bin/sh\n"
             "if [ \"$1\" = plugin ] && [ \"$2\" = marketplace ] && "
@@ -151,6 +161,7 @@ class ReleasePreflightTests(unittest.TestCase):
 
     def _run_preflight(
         self, *, no_net=False, codex="fresh", git_fail=None, git_mutate=None,
+        home_override=None, env_overrides=None,
     ):
         codex_path = self.bin / "codex"
         if codex == "unavailable":
@@ -177,7 +188,7 @@ class ReleasePreflightTests(unittest.TestCase):
         self.git_log.unlink(missing_ok=True)
         env = os.environ.copy()
         env.update({
-            "HOME": str(self.home),
+            "HOME": str(home_override or self.home),
             "PREFLIGHT_CODEX_JSON": str(self.codex_json),
             "PREFLIGHT_MARKETPLACE_ROOT": str(self.marketplace_root),
             "PREFLIGHT_GIT_LOG": str(self.git_log),
@@ -186,6 +197,8 @@ class ReleasePreflightTests(unittest.TestCase):
             env["PREFLIGHT_GIT_FAIL"] = git_fail
         if git_mutate:
             env["PREFLIGHT_GIT_MUTATE"] = git_mutate
+        if env_overrides:
+            env.update(env_overrides)
         argv = [str(self.script)]
         if no_net:
             argv.append("--no-net")
@@ -281,6 +294,121 @@ class ReleasePreflightTests(unittest.TestCase):
         self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
         self.assertIn("2 installed Codex plugin(s) checked", result.stdout)
         self.assertNotIn("codex CLI not installed", result.stdout)
+
+    def test_caller_home_cannot_select_an_untrusted_codex(self):
+        hostile_home = self.temp / "hostile-home"
+        self._write_codex(hostile_home / ".local/bin/codex")
+        result = self._run_preflight(
+            no_net=True, codex="unavailable", home_override=hostile_home,
+        )
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("codex CLI not installed", result.stdout)
+
+    def test_user_local_codex_symlink_is_rejected(self):
+        target = self.temp / "codex-target"
+        self._write_codex(target)
+        candidate = self.home / ".local/bin/codex"
+        candidate.parent.mkdir(parents=True)
+        candidate.symlink_to(target)
+        result = self._run_preflight(no_net=True, codex="unavailable")
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("codex CLI not installed", result.stdout)
+
+    def test_user_local_codex_symlink_within_account_home_is_accepted(self):
+        target = self.home / ".codex/releases/current/bin/codex"
+        self._write_codex(target)
+        candidate = self.home / ".local/bin/codex"
+        candidate.parent.mkdir(parents=True)
+        candidate.symlink_to(target)
+        self.codex_json.write_text(
+            json.dumps(self._installed_rows()), encoding="utf-8"
+        )
+        result = self._run_preflight(no_net=True, codex="user-local")
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("2 installed Codex plugin(s) checked", result.stdout)
+
+    def test_user_local_codex_symlink_through_world_writable_directory_is_rejected(self):
+        shared = self.home / "shared"
+        target = shared / "current/codex"
+        self._write_codex(target)
+        shared.chmod(0o777)
+        candidate = self.home / ".local/bin/codex"
+        candidate.parent.mkdir(parents=True)
+        candidate.symlink_to(target)
+        result = self._run_preflight(no_net=True, codex="unavailable")
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("codex CLI not installed", result.stdout)
+
+    def test_imported_codex_shell_function_is_ignored(self):
+        result = self._run_preflight(
+            no_net=True,
+            codex="unavailable",
+            env_overrides={"BASH_FUNC_codex%%": "() { printf forged; }"},
+        )
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("codex CLI not installed", result.stdout)
+
+    def test_imported_type_function_cannot_forge_external_codex(self):
+        forged = self.temp / "forged-codex"
+        self._write_codex(forged)
+        result = self._run_preflight(
+            no_net=True,
+            codex="unavailable",
+            env_overrides={"BASH_FUNC_type%%": "() { printf '%s\\n' '" + str(forged) + "'; }"},
+        )
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("codex CLI not installed", result.stdout)
+
+    def test_imported_builtin_cannot_preserve_a_forged_type_function(self):
+        forged = self.temp / "forged-codex"
+        self._write_codex(forged)
+        result = self._run_preflight(
+            no_net=True,
+            codex="unavailable",
+            env_overrides={
+                "BASH_FUNC_builtin%%": "() { if [[ $1 == unset ]]; then return 0; fi; command builtin \"$@\"; }",
+                "BASH_FUNC_type%%": "() { printf '%s\\n' '" + str(forged) + "'; }",
+            },
+        )
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("codex CLI not installed", result.stdout)
+
+    def test_imported_exec_cannot_suppress_the_clean_environment_boundary(self):
+        forged = self.temp / "forged-codex"
+        self._write_codex(forged)
+        result = self._run_preflight(
+            no_net=True,
+            codex="unavailable",
+            env_overrides={
+                "BASH_FUNC_exec%%": "() { return 0; }",
+                "BASH_FUNC_type%%": "() { printf '%s\\n' '" + str(forged) + "'; }",
+            },
+        )
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("codex CLI not installed", result.stdout)
+
+    def test_imported_python_function_cannot_intercept_validation(self):
+        result = self._run_preflight(
+            no_net=True,
+            codex="fresh",
+            env_overrides={"BASH_FUNC_python3%%": "() { printf '[]\\n'; }"},
+        )
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("2 installed Codex plugin(s) checked", result.stdout)
+
+    def test_python_startup_customization_cannot_override_home_lookup(self):
+        poison = self.temp / "poison"
+        poison.mkdir()
+        (poison / "sitecustomize.py").write_text(
+            "raise RuntimeError('PYTHONPATH was imported')\n", encoding="utf-8"
+        )
+        result = self._run_preflight(
+            no_net=True,
+            codex="unavailable",
+            env_overrides={"PYTHONPATH": str(poison)},
+        )
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("READY", result.stdout)
 
     def test_stale_codex_cache_fails_with_repair(self):
         result = self._run_preflight(no_net=True, codex="stale")

--- a/tools/check-release-preflight.sh
+++ b/tools/check-release-preflight.sh
@@ -262,10 +262,19 @@ done <<< "$version_report"
 # --------------------------------------------------------------------------
 check_codex_cache_freshness() {
 printf "\nCodex cache freshness:\n"
-if ! command -v codex >/dev/null 2>&1; then
+codex_bin=""
+# Codex's native user install lives outside the fixed toolchain PATH on Linux.
+# Resolve only this executable explicitly; do not expose all user-local tools.
+if [ -n "${HOME:-}" ] && [ -x "$HOME/.local/bin/codex" ]; then
+  codex_bin="$HOME/.local/bin/codex"
+else
+  codex_bin="$(command -v codex 2>/dev/null || :)"
+fi
+
+if [ -z "$codex_bin" ]; then
   skip "codex CLI not installed; Codex cache freshness not checked"
 else
-  codex_marketplaces="$(codex plugin marketplace list)"
+  codex_marketplaces="$("$codex_bin" plugin marketplace list)"
   codex_marketplaces_rc=$?
   codex_marketplace_root="$(printf '%s\n' "$codex_marketplaces" | awk '$1 == "depot" {$1=""; sub(/^[[:space:]]+/, ""); print; exit}')"
 
@@ -274,7 +283,7 @@ else
   elif [ -z "$codex_marketplace_root" ] || [ ! -d "$codex_marketplace_root" ]; then
     skip "codex plugin marketplace list did not resolve a readable depot root; Codex cache freshness not checked"
   else
-    codex_plugins="$(codex plugin list --marketplace depot --json)"
+    codex_plugins="$("$codex_bin" plugin list --marketplace depot --json)"
     codex_plugins_rc=$?
     if [ "$codex_plugins_rc" -ne 0 ]; then
       skip "codex installed-plugin query failed (rc=$codex_plugins_rc); Codex cache freshness not checked"

--- a/tools/check-release-preflight.sh
+++ b/tools/check-release-preflight.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash -p
 #
 # check-release-preflight.sh -- Verify a depot release is actually safe to tag
 # and push, and print a release receipt.
@@ -32,6 +32,31 @@
 # Deliberately no `set -e`: we want every check to run and report, not abort on
 # the first failure. `set -u` and pipefail are safe and wanted.
 set -uo pipefail
+
+# Privileged Bash startup (`-p` in the absolute shebang) prevents BASH_ENV and
+# exported functions from being imported before this first line. If either is
+# still present in the process environment, cross an empty-environment boundary
+# so child scripts cannot import it. Preserve only the narrow fixture/auth inputs.
+if /usr/bin/env | /usr/bin/grep -Eq '^(BASH_ENV|BASH_FUNC_[^=]*)='; then
+  exec /usr/bin/env -i \
+    HOME="${HOME-}" SSH_AUTH_SOCK="${SSH_AUTH_SOCK-}" \
+    PREFLIGHT_CODEX_JSON="${PREFLIGHT_CODEX_JSON-}" \
+    PREFLIGHT_MARKETPLACE_ROOT="${PREFLIGHT_MARKETPLACE_ROOT-}" \
+    PREFLIGHT_GIT_LOG="${PREFLIGHT_GIT_LOG-}" \
+    PREFLIGHT_GIT_FAIL="${PREFLIGHT_GIT_FAIL-}" \
+    PREFLIGHT_GIT_MUTATE="${PREFLIGHT_GIT_MUTATE-}" \
+    PATH=/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin:/opt/homebrew/bin \
+    /bin/bash "$0" "$@"
+fi
+
+# A non-interactive Bash imports BASH_FUNC_* definitions before this script
+# starts. Remove every function at the boundary so a caller cannot shadow
+# python3, type, git, or another fixed-PATH tool. Disable alias expansion too;
+# use `builtin` so the cleanup itself cannot be shadowed by a function.
+while builtin read -r _ _ imported_function; do
+  builtin unset -f "$imported_function"
+done < <(builtin declare -F)
+builtin shopt -u expand_aliases
 
 # Fixed PATH -- prevent a caller-controlled PATH from hijacking git/python3.
 PATH="/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin:/opt/homebrew/bin"
@@ -264,11 +289,72 @@ check_codex_cache_freshness() {
 printf "\nCodex cache freshness:\n"
 codex_bin=""
 # Codex's native user install lives outside the fixed toolchain PATH on Linux.
-# Resolve only this executable explicitly; do not expose all user-local tools.
-if [ -n "${HOME:-}" ] && [ -x "$HOME/.local/bin/codex" ]; then
-  codex_bin="$HOME/.local/bin/codex"
+# Resolve the account home through the OS account database, not caller-controlled
+# HOME. The native installer uses a user-owned symlink into ~/.codex, so bind
+# both the link and resolved target beneath that canonical home and reject any
+# component writable by another account.
+canonical_home="$(python3 -I -c 'import os, pwd; print(pwd.getpwuid(os.getuid()).pw_dir)' 2>/dev/null || :)"
+candidate_codex="${canonical_home:+$canonical_home/.local/bin/codex}"
+validated_codex=""
+if [ -n "$candidate_codex" ]; then
+  validated_codex="$(python3 -I -c '
+import grp, os, pwd, stat, sys
+
+home, candidate = map(os.path.abspath, sys.argv[1:])
+uid = os.getuid()
+username = pwd.getpwuid(uid).pw_name
+
+def contained(path):
+    relative = os.path.relpath(path, home)
+    return relative != os.pardir and not relative.startswith(os.pardir + os.sep)
+
+def private_group(gid):
+    members = set(grp.getgrgid(gid).gr_mem)
+    primary_users = {entry.pw_name for entry in pwd.getpwall() if entry.pw_gid == gid}
+    return members | primary_users <= {username}
+
+def validate_components(path, allow_final_symlink=False):
+    relative = os.path.relpath(path, home)
+    current = home
+    components = (".", *relative.split(os.sep))
+    for index, component in enumerate(components):
+        if component != ".":
+            current = os.path.join(current, component)
+        metadata = os.lstat(current)
+        is_final = index == len(components) - 1
+        if metadata.st_uid != uid:
+            raise ValueError("component not owned by account uid")
+        if stat.S_ISLNK(metadata.st_mode):
+            if not (allow_final_symlink and is_final):
+                raise ValueError("unexpected symlink component")
+            continue
+        if metadata.st_mode & stat.S_IWOTH:
+            raise ValueError("world-writable component")
+        if metadata.st_mode & stat.S_IWGRP and not private_group(metadata.st_gid):
+            raise ValueError("component writable by a shared group")
+
+try:
+    if not contained(candidate):
+        raise ValueError("candidate outside account home")
+    validate_components(candidate, allow_final_symlink=True)
+    resolved = os.path.realpath(candidate)
+    if not contained(resolved):
+        raise ValueError("resolved executable outside account home")
+    validate_components(resolved)
+    if not stat.S_ISREG(os.stat(resolved).st_mode) or not os.access(resolved, os.X_OK):
+        raise ValueError("resolved candidate is not a regular executable")
+    print(resolved)
+except (KeyError, OSError, ValueError):
+    raise SystemExit(1)
+' "$canonical_home" "$candidate_codex" 2>/dev/null || :)"
+fi
+if [ -n "$validated_codex" ]; then
+  # Execute the exact physical file whose full path was validated above. Do not
+  # reopen the original symlink after the trust check.
+  codex_bin="$validated_codex"
 else
-  codex_bin="$(command -v codex 2>/dev/null || :)"
+  # External files only: command -v can select an imported shell function.
+  codex_bin="$(type -P codex 2>/dev/null || :)"
 fi
 
 if [ -z "$codex_bin" ]; then


### PR DESCRIPTION
## Summary

- resolve Codex from the native Linux user install beneath the canonical account home
- preserve the fixed system-only PATH for all other preflight dependencies
- validate the resolved executable boundary and invoke Codex by its physical absolute path
- add adversarial regressions for symlink, ownership, writable-component, imported-function, HOME, and Python-startup attacks

## Exact head

`74fb1917a3736e1b2d1bf3fbcd912d27d2483325`

## Verification

- `bash -n tools/check-release-preflight.sh`
- `python3 tests/test_release_preflight.py` — 31/31 passed at exact head
- `git diff --check`
- combined four-PR integration tree: `./tools/validate-composition.sh --all` passed

## Boundary

The patch does not broaden the general PATH. Caller HOME, imported Bash functions, external symlink targets, shared writable path components, and Python startup customization cannot choose the Codex executable.