### PR TITLE
fix: make Workflow Authority build portable on NED Linux

### DIFF
--- a/native/workflow-authority/OPERATIONS.md
+++ b/native/workflow-authority/OPERATIONS.md
@@ -64,9 +64,14 @@ git status --short
 git rev-parse HEAD
 cd native/workflow-authority
 GO_BIN="$(command -v go)"
-GOTOOLCHAIN=auto "$GO_BIN" build -tags libfido2 -o workflow-authority ./cmd/workflow-authority
+LIBFIDO2_VERSION="$(pkg-config --modversion libfido2)"
+IFS=. read -r LIBFIDO2_MAJOR LIBFIDO2_MINOR LIBFIDO2_PATCH <<EOF
+$LIBFIDO2_VERSION
+EOF
+LIBFIDO2_CPPFLAGS="-DWORKFLOW_AUTHORITY_LIBFIDO2_MAJOR=$LIBFIDO2_MAJOR -DWORKFLOW_AUTHORITY_LIBFIDO2_MINOR=$LIBFIDO2_MINOR -DWORKFLOW_AUTHORITY_LIBFIDO2_PATCH=$LIBFIDO2_PATCH"
+CGO_CPPFLAGS="$LIBFIDO2_CPPFLAGS" GOTOOLCHAIN=auto "$GO_BIN" build -tags libfido2 -o workflow-authority ./cmd/workflow-authority
 cp workflow-authority workflow-authority-admin
-GOTOOLCHAIN=auto "$GO_BIN" build -tags libfido2 -o workflow-authorityd ./cmd/workflow-authorityd
+CGO_CPPFLAGS="$LIBFIDO2_CPPFLAGS" GOTOOLCHAIN=auto "$GO_BIN" build -tags libfido2 -o workflow-authorityd ./cmd/workflow-authorityd
 ```
 
 The two client filenames intentionally contain the same binary: administrative

--- a/native/workflow-authority/OPERATIONS.md
+++ b/native/workflow-authority/OPERATIONS.md
@@ -22,19 +22,51 @@ macOS will use the same provider-dispatch protocol and receipt verification, but
 this Linux systemd/libfido2 installation workflow does not claim macOS runtime
 support.
 
-## Packaging build gate
+## Ubuntu distro prerequisites
 
-Build release artifacts only on a trusted Linux packaging host with Go 1.26.5,
-cgo, `pkg-config`, and exactly libfido2 1.17.0. The production adapter is behind
-the `libfido2` build tag; an untagged build deliberately contains the
-fail-closed fixture adapter and must not be installed as production authority.
+Use Ubuntu's signed packages from the configured distro repositories for the Go
+launcher, cgo compiler, `pkg-config`, and libfido2 development files:
+
+```sh
+sudo apt install golang-go build-essential pkg-config libfido2-dev
+```
+
+The distro Go launcher may be older than the module toolchain. The validator
+resolves `go` from the operator's executable `PATH`, sets `GOTOOLCHAIN=auto`,
+and requires the module-selected toolchain to report `go1.26.5`. It resolves
+`gofmt` from that selected toolchain's `GOROOT`. The supported native-library
+range is libfido2 1.x at 1.16.0 or newer; 1.15 and older and major version 2 or
+newer fail closed.
+
+## Production-tag build proof from a repository checkout
+
+From a candidate repository checkout, run the complete validation gate:
 
 ```sh
 WORKFLOW_AUTHORITY_REQUIRE_PRODUCTION_BUILD=1 ./tools/validate-workflow-authority.sh
+```
+
+The production adapter is behind the `libfido2` build tag; an untagged build
+deliberately contains the fail-closed fixture adapter and must not be installed
+as production authority. A green candidate-branch gate proves that the tagged
+source builds on the host. It does not authorize installing binaries from that
+checkout, access a FIDO authenticator, provision a provider credential, contact
+a provider, or claim broker status `ready`.
+
+## Reviewed trusted-main artifacts
+
+Only after review and merge, build installation artifacts from a clean checkout
+of the reviewed trusted-main commit. Record and verify that exact commit before
+building:
+
+```sh
+git status --short
+git rev-parse HEAD
 cd native/workflow-authority
-GOTOOLCHAIN=auto /usr/local/go/bin/go build -tags libfido2 -o workflow-authority ./cmd/workflow-authority
+GO_BIN="$(command -v go)"
+GOTOOLCHAIN=auto "$GO_BIN" build -tags libfido2 -o workflow-authority ./cmd/workflow-authority
 cp workflow-authority workflow-authority-admin
-GOTOOLCHAIN=auto /usr/local/go/bin/go build -tags libfido2 -o workflow-authorityd ./cmd/workflow-authorityd
+GOTOOLCHAIN=auto "$GO_BIN" build -tags libfido2 -o workflow-authorityd ./cmd/workflow-authorityd
 ```
 
 The two client filenames intentionally contain the same binary: administrative
@@ -44,8 +76,9 @@ explicit production-build coverage gap rather than Linux/libfido2 proof.
 
 ## Package installation
 
-Run these steps from a trusted, verified package staging directory as root. Do
-not build or copy binaries from a repository-worker checkout.
+Run these steps from a trusted, verified package staging directory as root,
+using only artifacts built from the reviewed, merged trusted-main commit. Do
+not build or copy binaries from a feature or repository-worker checkout.
 
 ```sh
 install -o root -g root -m 0755 workflow-authority /usr/local/bin/workflow-authority
@@ -64,11 +97,12 @@ Install the fixed root-owned provider policy at
 Create the `workflow-authority` group and add only independently authenticated
 local client accounts. Do not enable or start the socket yet.
 
-## Enrollment and credential custody
+## Later interactive enrollment and credential custody
 
 Run administrative commands interactively from the controlling terminal. The
 program rejects redirected stdin and a terminal that changes during the
-operation.
+operation. This human ceremony happens only after trusted-main installation; it
+is not part of repository production-build proof.
 
 ```sh
 sudo /usr/local/sbin/workflow-authority-admin enroll-fido

--- a/native/workflow-authority/OPERATIONS.md
+++ b/native/workflow-authority/OPERATIONS.md
@@ -32,11 +32,12 @@ sudo apt install golang-go build-essential pkg-config libfido2-dev
 ```
 
 The distro Go launcher may be older than the module toolchain. The validator
-resolves `go` from the operator's executable `PATH`, sets `GOTOOLCHAIN=auto`,
-and requires the module-selected toolchain to report `go1.26.5`. It resolves
-`gofmt` from that selected toolchain's `GOROOT`. The supported native-library
-range is libfido2 1.x at 1.16.0 or newer; 1.15 and older and major version 2 or
-newer fail closed.
+resolves `go` and `pkg-config` only from its fixed system-tool path, clears
+caller-controlled Go, cgo, and pkg-config build overrides, sets
+`GOTOOLCHAIN=auto`, and requires the module-selected toolchain to report
+`go1.26.5`. It resolves `gofmt` from that selected toolchain's `GOROOT`. The
+supported native-library range is libfido2 1.x at 1.16.0 or newer; 1.15 and
+older and major version 2 or newer fail closed.
 
 ## Production-tag build proof from a repository checkout
 
@@ -56,22 +57,15 @@ a provider, or claim broker status `ready`.
 ## Reviewed trusted-main artifacts
 
 Only after review and merge, build installation artifacts from a clean checkout
-of the reviewed trusted-main commit. Record and verify that exact commit before
-building:
+of the reviewed trusted-main commit. The repository-owned gate rejects a dirty
+checkout or commit mismatch, reuses its authenticated toolchain and sanitized
+build environment, and writes commit, tool-version, and checksum evidence:
 
 ```sh
-git status --short
-git rev-parse HEAD
-cd native/workflow-authority
-GO_BIN="$(command -v go)"
-LIBFIDO2_VERSION="$(pkg-config --modversion libfido2)"
-IFS=. read -r LIBFIDO2_MAJOR LIBFIDO2_MINOR LIBFIDO2_PATCH <<EOF
-$LIBFIDO2_VERSION
-EOF
-LIBFIDO2_CPPFLAGS="-DWORKFLOW_AUTHORITY_LIBFIDO2_MAJOR=$LIBFIDO2_MAJOR -DWORKFLOW_AUTHORITY_LIBFIDO2_MINOR=$LIBFIDO2_MINOR -DWORKFLOW_AUTHORITY_LIBFIDO2_PATCH=$LIBFIDO2_PATCH"
-CGO_CPPFLAGS="$LIBFIDO2_CPPFLAGS" GOTOOLCHAIN=auto "$GO_BIN" build -tags libfido2 -o workflow-authority ./cmd/workflow-authority
-cp workflow-authority workflow-authority-admin
-CGO_CPPFLAGS="$LIBFIDO2_CPPFLAGS" GOTOOLCHAIN=auto "$GO_BIN" build -tags libfido2 -o workflow-authorityd ./cmd/workflow-authorityd
+REVIEWED_COMMIT=<approved-full-commit-sha-from-review-record>
+WORKFLOW_AUTHORITY_REVIEWED_COMMIT="$REVIEWED_COMMIT" \
+WORKFLOW_AUTHORITY_ARTIFACT_DIR=/absolute/path/to/empty-package-staging \
+  ./tools/validate-workflow-authority.sh
 ```
 
 The two client filenames intentionally contain the same binary: administrative

--- a/native/workflow-authority/internal/authority/fido_libfido2.go
+++ b/native/workflow-authority/internal/authority/fido_libfido2.go
@@ -8,10 +8,10 @@ package authority
 #include <string.h>
 #include <fido.h>
 
-#if !defined(FIDO_VERSION_MAJOR) || !defined(FIDO_VERSION_MINOR) || !defined(FIDO_VERSION_PATCH)
-#error "libfido2 version macros required"
+#if !defined(WORKFLOW_AUTHORITY_LIBFIDO2_MAJOR) || !defined(WORKFLOW_AUTHORITY_LIBFIDO2_MINOR) || !defined(WORKFLOW_AUTHORITY_LIBFIDO2_PATCH)
+#error "workflow-authority libfido2 version macros required from pkg-config"
 #endif
-#if FIDO_VERSION_MAJOR != 1 || FIDO_VERSION_MINOR < 16
+#if WORKFLOW_AUTHORITY_LIBFIDO2_MAJOR != 1 || WORKFLOW_AUTHORITY_LIBFIDO2_MINOR < 16
 #error "workflow-authority requires libfido2 >=1.16.0 and <2.0.0"
 #endif
 

--- a/native/workflow-authority/internal/authority/fido_libfido2.go
+++ b/native/workflow-authority/internal/authority/fido_libfido2.go
@@ -11,8 +11,8 @@ package authority
 #if !defined(FIDO_VERSION_MAJOR) || !defined(FIDO_VERSION_MINOR) || !defined(FIDO_VERSION_PATCH)
 #error "libfido2 version macros required"
 #endif
-#if FIDO_VERSION_MAJOR != 1 || FIDO_VERSION_MINOR != 17 || FIDO_VERSION_PATCH != 0
-#error "workflow-authority requires exactly libfido2 1.17.0"
+#if FIDO_VERSION_MAJOR != 1 || FIDO_VERSION_MINOR < 16
+#error "workflow-authority requires libfido2 >=1.16.0 and <2.0.0"
 #endif
 
 typedef struct {

--- a/native/workflow-authority/internal/authority/fido_test.go
+++ b/native/workflow-authority/internal/authority/fido_test.go
@@ -20,21 +20,35 @@ import (
 	"designmachines.dev/workflow-authority/internal/protocol"
 )
 
-func TestStubNeverReportsProductionReady(t *testing.T) {
+func TestUnavailableAdapterNeverReportsProductionReady(t *testing.T) {
 	adapter := NewFIDOAdapter()
 	readiness := adapter.Readiness(context.Background())
-	if readiness.Production || readiness.Adapter != "stub" || readiness.InternalUV {
-		t.Fatalf("unsafe stub readiness: %+v", readiness)
+	if readiness.Production || readiness.InternalUV {
+		t.Fatalf("unavailable adapter reported ready: %+v", readiness)
+	}
+	switch readiness.Adapter {
+	case "stub":
+		if readiness.Version != "unavailable" {
+			t.Fatalf("unexpected stub version: %+v", readiness)
+		}
+	case "libfido2":
+		if readiness.Version != FIDO2Version {
+			t.Fatalf("unexpected libfido2 compatibility label: %+v", readiness)
+		}
+	default:
+		t.Fatalf("unexpected FIDO adapter: %+v", readiness)
 	}
 	if _, err := adapter.Assert(context.Background(), []byte("challenge"), Credential{}); !errors.Is(err, ErrUnavailable) {
-		t.Fatalf("stub assertion: %v", err)
+		t.Fatalf("unavailable assertion: %v", err)
 	}
 }
 
-func TestStubEnrollerFailsClosed(t *testing.T) {
-	credential, err := NewFIDOEnroller().Enroll(context.Background(), enrollment.Request{Generation: 1})
+func TestUnavailableEnrollerFailsClosed(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	credential, err := NewFIDOEnroller().Enroll(ctx, enrollment.Request{Generation: 1})
 	if !errors.Is(err, enrollment.ErrUnavailable) || len(credential.ID) != 0 {
-		t.Fatalf("stub enrollment did not fail closed: %#v %v", credential, err)
+		t.Fatalf("unavailable enrollment did not fail closed: %#v %v", credential, err)
 	}
 }
 
@@ -276,7 +290,7 @@ func TestPinnedNativeSourceAndNoHostPINFallback(t *testing.T) {
 		t.Fatal(err)
 	}
 	source := string(raw)
-	for _, marker := range []string{"FIDO_VERSION_MAJOR != 1", "FIDO_VERSION_MINOR < 16", "workflow-authority requires libfido2 >=1.16.0 and <2.0.0", "dm_ready", "fido_dev_has_uv", "fido_dev_set_timeout(op->dev, 30000)", "fido_assert_authdata_raw_ptr", "dm_operation_cancel", "fido_dev_cancel(op->dev)", "FIDO_OPT_TRUE", "fido_dev_get_assert(op->dev, op->assert, NULL)"} {
+	for _, marker := range []string{"WORKFLOW_AUTHORITY_LIBFIDO2_MAJOR != 1", "WORKFLOW_AUTHORITY_LIBFIDO2_MINOR < 16", "workflow-authority requires libfido2 >=1.16.0 and <2.0.0", "dm_ready", "fido_dev_has_uv", "fido_dev_set_timeout(op->dev, 30000)", "fido_assert_authdata_raw_ptr", "dm_operation_cancel", "fido_dev_cancel(op->dev)", "FIDO_OPT_TRUE", "fido_dev_get_assert(op->dev, op->assert, NULL)"} {
 		if !strings.Contains(source, marker) {
 			t.Fatalf("native invariant missing: %s", marker)
 		}

--- a/native/workflow-authority/internal/authority/fido_test.go
+++ b/native/workflow-authority/internal/authority/fido_test.go
@@ -276,7 +276,7 @@ func TestPinnedNativeSourceAndNoHostPINFallback(t *testing.T) {
 		t.Fatal(err)
 	}
 	source := string(raw)
-	for _, marker := range []string{"FIDO_VERSION_MAJOR != 1", "FIDO_VERSION_MINOR != 17", "FIDO_VERSION_PATCH != 0", "dm_ready", "fido_dev_has_uv", "fido_dev_set_timeout(op->dev, 30000)", "fido_assert_authdata_raw_ptr", "dm_operation_cancel", "fido_dev_cancel(op->dev)", "FIDO_OPT_TRUE", "fido_dev_get_assert(op->dev, op->assert, NULL)"} {
+	for _, marker := range []string{"FIDO_VERSION_MAJOR != 1", "FIDO_VERSION_MINOR < 16", "workflow-authority requires libfido2 >=1.16.0 and <2.0.0", "dm_ready", "fido_dev_has_uv", "fido_dev_set_timeout(op->dev, 30000)", "fido_assert_authdata_raw_ptr", "dm_operation_cancel", "fido_dev_cancel(op->dev)", "FIDO_OPT_TRUE", "fido_dev_get_assert(op->dev, op->assert, NULL)"} {
 		if !strings.Contains(source, marker) {
 			t.Fatalf("native invariant missing: %s", marker)
 		}

--- a/native/workflow-authority/internal/authority/fido_test.go
+++ b/native/workflow-authority/internal/authority/fido_test.go
@@ -22,7 +22,9 @@ import (
 
 func TestUnavailableAdapterNeverReportsProductionReady(t *testing.T) {
 	adapter := NewFIDOAdapter()
-	readiness := adapter.Readiness(context.Background())
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	readiness := adapter.Readiness(ctx)
 	if readiness.Production || readiness.InternalUV {
 		t.Fatalf("unavailable adapter reported ready: %+v", readiness)
 	}
@@ -38,7 +40,7 @@ func TestUnavailableAdapterNeverReportsProductionReady(t *testing.T) {
 	default:
 		t.Fatalf("unexpected FIDO adapter: %+v", readiness)
 	}
-	if _, err := adapter.Assert(context.Background(), []byte("challenge"), Credential{}); !errors.Is(err, ErrUnavailable) {
+	if _, err := adapter.Assert(ctx, []byte("challenge"), Credential{}); !errors.Is(err, ErrUnavailable) {
 		t.Fatalf("unavailable assertion: %v", err)
 	}
 }

--- a/native/workflow-authority/internal/authority/run.go
+++ b/native/workflow-authority/internal/authority/run.go
@@ -26,7 +26,7 @@ import (
 
 const (
 	ProductionSocket = "/run/design-machines/workflow-authority/authority.sock"
-	FIDO2Version     = "1.17.0"
+	FIDO2Version     = "1.x>=1.16.0"
 )
 
 type Diagnostic struct {

--- a/tests/test_workflow_authority_integration.py
+++ b/tests/test_workflow_authority_integration.py
@@ -50,7 +50,8 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 GO_MODULE = REPO_ROOT / "native" / "workflow-authority"
-GO_BIN = Path("/usr/local/go/bin/go")
+GO_BIN_VALUE = os.environ.get("WORKFLOW_AUTHORITY_GO_BIN")
+GO_BIN = Path(GO_BIN_VALUE) if GO_BIN_VALUE else None
 FIXTURE_TAG = "fixture"
 FIXTURE_PACKAGE = "./cmd/workflow-authority-fixture"
 
@@ -170,8 +171,10 @@ class HarnessBase(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        if not GO_BIN.is_file():
-            raise unittest.SkipTest("exact Go launcher unavailable: {}".format(GO_BIN))
+        if GO_BIN is None or not GO_BIN.is_absolute() or not GO_BIN.is_file():
+            raise unittest.SkipTest(
+                "explicit absolute Go launcher unavailable: {}".format(GO_BIN_VALUE)
+            )
         cls._binary_dir = tempfile.TemporaryDirectory(prefix="wa-fixture-bin-")
         cls.binary = Path(cls._binary_dir.name) / "workflow-authority-fixture"
         completed = cls.go(
@@ -987,7 +990,7 @@ class UnrunLaneLedgerTest(unittest.TestCase):
             "that path would be invisible",
         )
         for requirement, reason in (
-            ("libfido2", "real authenticator and libfido2 1.17.0 require Linux hardware"),
+            ("libfido2", "real authenticator and libfido2 hardware are not exercised"),
             ("systemd", "root systemd install, socket activation, and tmpfiles require Linux root"),
             ("credential-provisioning", "production credential provisioning is separately gated"),
             ("provider-live", "system TLS and live OpenRouter contact are separately gated"),

--- a/tests/test_workflow_authority_validator.py
+++ b/tests/test_workflow_authority_validator.py
@@ -2,6 +2,7 @@
 
 import os
 import re
+import shutil
 import subprocess
 import tempfile
 import unittest
@@ -18,6 +19,7 @@ FIDO_SOURCE = (
     / "authority"
     / "fido_libfido2.go"
 )
+GO_MODULE = REPO_ROOT / "native" / "workflow-authority"
 
 
 class WorkflowAuthorityValidatorTest(unittest.TestCase):
@@ -136,7 +138,9 @@ printf '%s\\n' \\
         minimum = re.search(r'LIBFIDO2_MIN_VERSION="(\d+)\.(\d+)\.(\d+)"', shell)
         next_major = re.search(r'LIBFIDO2_NEXT_MAJOR="(\d+)"', shell)
         c_guard = re.search(
-            r"FIDO_VERSION_MAJOR != (\d+) \|\| FIDO_VERSION_MINOR < (\d+)", c_source
+            r"WORKFLOW_AUTHORITY_LIBFIDO2_MAJOR != (\d+) \|\| "
+            r"WORKFLOW_AUTHORITY_LIBFIDO2_MINOR < (\d+)",
+            c_source,
         )
         self.assertIsNotNone(minimum)
         self.assertIsNotNone(next_major)
@@ -147,12 +151,60 @@ printf '%s\\n' \\
         )
         self.assertIn('pkg-config --atleast-version="$LIBFIDO2_MIN_VERSION" libfido2', shell)
         self.assertIn('! pkg-config --atleast-version="$LIBFIDO2_NEXT_MAJOR" libfido2', shell)
+        for component in ("MAJOR", "MINOR", "PATCH"):
+            self.assertIn("WORKFLOW_AUTHORITY_LIBFIDO2_{}".format(component), shell)
+            self.assertIn("WORKFLOW_AUTHORITY_LIBFIDO2_{}".format(component), c_source)
 
     def test_wrong_selected_go_toolchain_fails_clearly(self):
         completed, go_launcher, _ = self.run_validator("1.16.7", go_version="go1.26.4")
         self.assertNotEqual(completed.returncode, 0)
         self.assertIn("requires selected Go toolchain go1.26.5", completed.stderr)
         self.assertIn(str(go_launcher), completed.stderr)
+
+    def test_installed_compatible_libfido2_compiles_production_adapter(self):
+        go_bin = shutil.which("go")
+        pkg_config = shutil.which("pkg-config")
+        if not go_bin or not pkg_config or os.uname().sysname != "Linux":
+            self.skipTest("real Linux Go and pkg-config toolchain unavailable")
+        minimum = subprocess.run(
+            [pkg_config, "--atleast-version=1.16.0", "libfido2"], check=False
+        )
+        next_major = subprocess.run(
+            [pkg_config, "--atleast-version=2", "libfido2"], check=False
+        )
+        if minimum.returncode != 0 or next_major.returncode == 0:
+            self.skipTest("installed libfido2 is outside the supported production range")
+        version = subprocess.run(
+            [pkg_config, "--modversion", "libfido2"],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+        match = re.fullmatch(r"(\d+)\.(\d+)\.(\d+)", version)
+        self.assertIsNotNone(match, "pkg-config returned a non-numeric libfido2 version")
+
+        with tempfile.TemporaryDirectory(prefix="wa-real-cgo-cache-") as go_cache:
+            environment = dict(os.environ)
+            environment.update(
+                {
+                    "CGO_CPPFLAGS": (
+                        "-DWORKFLOW_AUTHORITY_LIBFIDO2_MAJOR={} "
+                        "-DWORKFLOW_AUTHORITY_LIBFIDO2_MINOR={} "
+                        "-DWORKFLOW_AUTHORITY_LIBFIDO2_PATCH={}"
+                    ).format(*match.groups()),
+                    "GOCACHE": go_cache,
+                    "GOTOOLCHAIN": "auto",
+                }
+            )
+            completed = subprocess.run(
+                [go_bin, "test", "-tags", "libfido2", "./internal/authority"],
+                cwd=GO_MODULE,
+                env=environment,
+                capture_output=True,
+                text=True,
+                timeout=120,
+            )
+        self.assertEqual(completed.returncode, 0, completed.stdout + completed.stderr)
 
 
 if __name__ == "__main__":

--- a/tests/test_workflow_authority_validator.py
+++ b/tests/test_workflow_authority_validator.py
@@ -36,6 +36,10 @@ class WorkflowAuthorityValidatorTest(unittest.TestCase):
             self.make_executable(
                 fake_bin / "go",
                 """#!/usr/bin/env bash
+if [[ "$(umask)" != "0022" ]]; then
+  printf 'unsafe validator umask: %s\\n' "$(umask)" >&2
+  exit 90
+fi
 if [[ "$*" == "env GOVERSION" ]]; then
   printf '%s\\n' "${FAKE_GO_VERSION}"
 elif [[ "$*" == "env GOROOT" ]]; then

--- a/tests/test_workflow_authority_validator.py
+++ b/tests/test_workflow_authority_validator.py
@@ -27,17 +27,64 @@ class WorkflowAuthorityValidatorTest(unittest.TestCase):
         path.write_text(source, encoding="utf-8")
         path.chmod(0o755)
 
-    def run_validator(self, libfido2_version, go_version="go1.26.5"):
+    def run_validator(self, libfido2_version, go_version="go1.26.5", hostile_env=None, artifact_case=None):
         with tempfile.TemporaryDirectory(prefix="wa-validator-") as directory:
             root = Path(directory)
+            fixture_repo = root / "repo"
+            fixture_tools = fixture_repo / "tools"
             fake_bin = root / "distro-bin"
             fake_goroot = root / "selected-toolchain"
+            fixture_tools.mkdir(parents=True)
             fake_bin.mkdir()
             (fake_goroot / "bin").mkdir(parents=True)
+
+            validator_source = VALIDATOR.read_text(encoding="utf-8")
+            path_line = 'PATH="/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin:/usr/local/go/bin:/opt/homebrew/bin"'
+            self.assertEqual(validator_source.count(path_line), 1)
+            validator_source = validator_source.replace(
+                path_line, 'PATH="{}:/usr/bin:/bin:/usr/sbin:/sbin"'.format(fake_bin)
+            )
+            for trusted_line, replacement in (
+                ('GO_BIN="$(trusted_executable "$GO_BIN")" || { printf \'FAIL  Go launcher is not root-owned and non-writable\\n\' >&2; exit 1; }', 'GO_BIN="$(readlink -f "$GO_BIN")"'),
+                ('PKG_CONFIG_BIN="$(trusted_executable "$PKG_CONFIG_BIN")" || { printf \'FAIL  pkg-config is not root-owned and non-writable\\n\' >&2; exit 1; }', 'PKG_CONFIG_BIN="$(readlink -f "$PKG_CONFIG_BIN")"'),
+                ('CC="$(trusted_executable "$CC_BIN")" || { printf \'FAIL  C compiler is not root-owned and non-writable\\n\' >&2; exit 1; }', 'CC="$(readlink -f "$CC_BIN")"'),
+                ('PYTHON="$(trusted_executable "$(type -P "$CANDIDATE")")" || continue', 'PYTHON="$(readlink -f "$(type -P "$CANDIDATE")")"'),
+            ):
+                self.assertEqual(validator_source.count(trusted_line), 1)
+                validator_source = validator_source.replace(trusted_line, replacement)
+            validator_source = validator_source.replace(
+                'case "$(readlink -f "$GO_ROOT")" in\n  "$GO_MODULE_CACHE"/*) ;;',
+                'case "$(readlink -f "$GO_ROOT")" in\n  "$FAKE_GO_ROOT"/*|"$FAKE_GO_ROOT") ;;',
+            )
+            fixture_validator = fixture_tools / VALIDATOR.name
+            fixture_validator.write_text(validator_source, encoding="utf-8")
+            fixture_validator.chmod(0o755)
+            (fixture_repo / "native").mkdir()
+            shutil.copytree(
+                REPO_ROOT / "native/workflow-authority",
+                fixture_repo / "native/workflow-authority",
+            )
+            (fixture_repo / "plugins").symlink_to(
+                REPO_ROOT / "plugins", target_is_directory=True
+            )
+            (fixture_repo / "tests").mkdir()
+            (fixture_repo / "tests/test_workflow_authority_integration.py").symlink_to(
+                REPO_ROOT / "tests/test_workflow_authority_integration.py"
+            )
+            subprocess.run(["git", "init", "-q"], cwd=fixture_repo, check=True)
+            subprocess.run(["git", "config", "user.name", "Fixture"], cwd=fixture_repo, check=True)
+            subprocess.run(["git", "config", "user.email", "fixture@example.invalid"], cwd=fixture_repo, check=True)
+            subprocess.run(["git", "add", "."], cwd=fixture_repo, check=True)
+            subprocess.run(["git", "commit", "-q", "-m", "fixture"], cwd=fixture_repo, check=True)
+            fixture_commit = subprocess.run(
+                ["git", "rev-parse", "HEAD"], cwd=fixture_repo, check=True,
+                capture_output=True, text=True,
+            ).stdout.strip()
 
             self.make_executable(
                 fake_bin / "go",
                 """#!/usr/bin/env bash
+printf '%s|cpp=%s|goenv=%s|cc=%s|pkg=%s\\n' "$*" "${CGO_CPPFLAGS:-}" "${GOENV:-}" "${CC:-}" "${PKG_CONFIG:-}" >> "$FAKE_GO_LOG"
 if [[ "$(umask)" != "0022" ]]; then
   printf 'unsafe validator umask: %s\\n' "$(umask)" >&2
   exit 90
@@ -51,19 +98,22 @@ elif [[ "$1" == "list" && "$*" == *"-tags fixture"* ]]; then
 elif [[ "$1" == "list" ]]; then
   printf '%s\\n' 'designmachines.dev/workflow-authority/internal/authority'
 fi
+if [[ "$*" == *"-tags libfido2"* && "${CGO_CPPFLAGS:-}" != "${FAKE_EXPECTED_CPPFLAGS}" ]]; then
+  printf 'missing expected production CGO_CPPFLAGS\\n' >&2
+  exit 91
+fi
+previous=""
+for argument in "$@"; do
+  if [[ "$previous" == "-o" ]]; then printf 'fixture-binary\\n' > "$argument"; chmod 0755 "$argument"; fi
+  previous="$argument"
+done
 """,
             )
             self.make_executable(fake_goroot / "bin" / "gofmt", "#!/usr/bin/env bash\n")
 
-            if libfido2_version.startswith("1.15."):
-                minimum_result = 1
-                next_major_result = 1
-            elif libfido2_version.startswith("1.16."):
-                minimum_result = 0
-                next_major_result = 1
-            else:
-                minimum_result = 0
-                next_major_result = 0
+            version_tuple = tuple(map(int, libfido2_version.split(".")))
+            minimum_result = int(version_tuple < (1, 16, 0))
+            next_major_result = int(version_tuple < (2, 0, 0))
             self.make_executable(
                 fake_bin / "pkg-config",
                 """#!/usr/bin/env bash
@@ -101,21 +151,52 @@ printf '%s\\n' \\
                     "FAKE_LIBFIDO2_VERSION": libfido2_version,
                     "FAKE_MINIMUM_RESULT": str(minimum_result),
                     "FAKE_NEXT_MAJOR_RESULT": str(next_major_result),
+                    "FAKE_EXPECTED_CPPFLAGS": (
+                        "-DWORKFLOW_AUTHORITY_LIBFIDO2_MAJOR={} "
+                        "-DWORKFLOW_AUTHORITY_LIBFIDO2_MINOR={} "
+                        "-DWORKFLOW_AUTHORITY_LIBFIDO2_PATCH={}"
+                    ).format(*version_tuple),
                     "WORKFLOW_AUTHORITY_REQUIRE_PRODUCTION_BUILD": "1",
+                    "FAKE_GO_LOG": str(root / "go.log"),
                 }
             )
+            if hostile_env:
+                environment.update(hostile_env)
+            artifact_dir = root / "artifacts"
+            if artifact_case:
+                environment["WORKFLOW_AUTHORITY_ARTIFACT_DIR"] = str(artifact_dir)
+                environment["WORKFLOW_AUTHORITY_REVIEWED_COMMIT"] = fixture_commit
+                if artifact_case == "mismatch":
+                    environment["WORKFLOW_AUTHORITY_REVIEWED_COMMIT"] = "0" * 40
+                elif artifact_case == "dirty":
+                    (fixture_repo / "dirty.txt").write_text("dirty\n", encoding="utf-8")
+                elif artifact_case == "nonempty":
+                    artifact_dir.mkdir()
+                    (artifact_dir / "existing").write_text("occupied\n", encoding="utf-8")
+                elif artifact_case == "missing-commit":
+                    environment.pop("WORKFLOW_AUTHORITY_REVIEWED_COMMIT")
+                elif artifact_case == "ignored":
+                    exclude = fixture_repo / ".git/info/exclude"
+                    exclude.write_text("native/workflow-authority/ignored.go\n", encoding="utf-8")
+                    ignored = fixture_repo / "native/workflow-authority/ignored.go"
+                    ignored.write_text("package ignored\n", encoding="utf-8")
             completed = subprocess.run(
-                ["bash", str(VALIDATOR)],
-                cwd=REPO_ROOT,
+                ["bash", str(fixture_validator)],
+                cwd=fixture_repo,
                 env=environment,
                 capture_output=True,
                 text=True,
                 timeout=30,
             )
-            return completed, fake_bin / "go", fake_goroot
+            ledger = (root / "go.log").read_text(encoding="utf-8") if (root / "go.log").exists() else ""
+            artifact_snapshot = {
+                path.name: (path.read_bytes(), path.stat().st_mode & 0o777)
+                for path in artifact_dir.glob("*") if path.is_file()
+            }
+            return completed, fake_bin / "go", fake_goroot, ledger, artifact_snapshot
 
     def test_non_usr_local_launcher_selects_go_1_26_5_and_accepts_libfido2_1_16(self):
-        completed, go_launcher, go_root = self.run_validator("1.16.7")
+        completed, go_launcher, go_root, ledger, _ = self.run_validator("1.16.7")
         self.assertEqual(completed.returncode, 0, completed.stdout + completed.stderr)
         self.assertTrue(go_launcher.is_absolute())
         self.assertFalse(str(go_launcher).startswith("/usr/local/"))
@@ -123,14 +204,32 @@ printf '%s\\n' \\
         self.assertIn("GOVERSION=go1.26.5", completed.stdout)
         self.assertIn("GOROOT={}".format(go_root), completed.stdout)
         self.assertIn("libfido2 1.16.7 (required >=1.16.0,<2)", completed.stdout)
+        tagged = [line.split("|", 1)[0] for line in ledger.splitlines() if "-tags libfido2" in line]
+        self.assertEqual(tagged, [
+            "test -tags libfido2 ./...",
+            "test -race -tags libfido2 ./...",
+            "vet -tags libfido2 ./...",
+            "build -tags libfido2 ./cmd/workflow-authority ./cmd/workflow-authorityd",
+        ])
+        for line in ledger.splitlines():
+            self.assertIn("|goenv=off|", line)
 
     def test_libfido2_1_15_and_2_x_are_rejected(self):
         for version in ("1.15.9", "2.0.0"):
             with self.subTest(version=version):
-                completed, _, _ = self.run_validator(version)
+                completed, _, _, _, _ = self.run_validator(version)
                 self.assertNotEqual(completed.returncode, 0)
                 self.assertIn("requires Linux, pkg-config, and libfido2 >=1.16.0,<2", completed.stderr)
                 self.assertIn("libfido2={}".format(version), completed.stderr)
+
+    def test_later_libfido2_1_x_versions_are_accepted(self):
+        for version in ("1.17.0", "1.99.4"):
+            with self.subTest(version=version):
+                completed, _, _, _, _ = self.run_validator(version)
+                self.assertEqual(
+                    completed.returncode, 0, completed.stdout + completed.stderr
+                )
+                self.assertIn("libfido2 {}".format(version), completed.stdout)
 
     def test_shell_and_c_guards_express_the_same_range(self):
         shell = VALIDATOR.read_text(encoding="utf-8")
@@ -149,17 +248,63 @@ printf '%s\\n' \\
             (minimum.group(1), minimum.group(2), next_major.group(1)),
             (c_guard.group(1), c_guard.group(2), str(int(c_guard.group(1)) + 1)),
         )
-        self.assertIn('pkg-config --atleast-version="$LIBFIDO2_MIN_VERSION" libfido2', shell)
-        self.assertIn('! pkg-config --atleast-version="$LIBFIDO2_NEXT_MAJOR" libfido2', shell)
+        self.assertIn('"$PKG_CONFIG_BIN" --atleast-version="$LIBFIDO2_MIN_VERSION" libfido2', shell)
+        self.assertIn('! "$PKG_CONFIG_BIN" --atleast-version="$LIBFIDO2_NEXT_MAJOR" libfido2', shell)
         for component in ("MAJOR", "MINOR", "PATCH"):
             self.assertIn("WORKFLOW_AUTHORITY_LIBFIDO2_{}".format(component), shell)
             self.assertIn("WORKFLOW_AUTHORITY_LIBFIDO2_{}".format(component), c_source)
 
     def test_wrong_selected_go_toolchain_fails_clearly(self):
-        completed, go_launcher, _ = self.run_validator("1.16.7", go_version="go1.26.4")
+        completed, go_launcher, _, _, _ = self.run_validator("1.16.7", go_version="go1.26.4")
         self.assertNotEqual(completed.returncode, 0)
         self.assertIn("requires selected Go toolchain go1.26.5", completed.stderr)
         self.assertIn(str(go_launcher), completed.stderr)
+
+    def test_caller_build_environment_and_exported_functions_are_ignored(self):
+        completed, go_launcher, _, ledger, _ = self.run_validator(
+            "1.16.7",
+            hostile_env={
+                "GOENV": "/tmp/evil-go-env",
+                "GOFLAGS": "-overlay=/tmp/evil-overlay.json",
+                "CC": "/tmp/evil-cc",
+                "PKG_CONFIG": "/tmp/evil-pkg-config",
+                "BASH_FUNC_go%%": "() { exit 88; }",
+                "BASH_FUNC_pkg-config%%": "() { printf '9.9.9\\n'; }",
+            },
+        )
+        self.assertEqual(completed.returncode, 0, completed.stdout + completed.stderr)
+        self.assertIn("launcher={}".format(go_launcher), completed.stdout)
+        self.assertNotIn("evil", ledger)
+        self.assertTrue(all("|goenv=off|" in line for line in ledger.splitlines()))
+
+    def test_artifact_build_requires_exact_clean_commit_and_empty_staging(self):
+        for case, expected in (
+            ("mismatch", "does not match reviewed artifact commit"),
+            ("dirty", "requires a clean checkout"),
+            ("nonempty", "must be absent or empty"),
+            ("missing-commit", "require both"),
+            ("ignored", "ignored build inputs"),
+        ):
+            with self.subTest(case=case):
+                completed, _, _, _, _ = self.run_validator("1.16.7", artifact_case=case)
+                self.assertNotEqual(completed.returncode, 0)
+                self.assertIn(expected, completed.stderr)
+
+    def test_artifact_build_emits_equal_clients_and_verifiable_receipt(self):
+        completed, _, _, _, artifacts = self.run_validator("1.16.7", artifact_case="valid")
+        self.assertEqual(completed.returncode, 0, completed.stdout + completed.stderr)
+        expected = {"workflow-authority", "workflow-authority-admin", "workflow-authorityd", "BUILD-RECEIPT.txt"}
+        self.assertEqual(set(artifacts), expected)
+        self.assertEqual(artifacts["workflow-authority"][0], artifacts["workflow-authority-admin"][0])
+        for binary in expected - {"BUILD-RECEIPT.txt"}:
+            self.assertEqual(artifacts[binary][1], 0o755)
+        receipt = artifacts["BUILD-RECEIPT.txt"][0].decode()
+        self.assertIn("commit=", receipt)
+        self.assertIn("go_version=go1.26.5", receipt)
+        self.assertIn("libfido2=1.16.7", receipt)
+        self.assertEqual(receipt.count("  workflow-authority\n"), 1)
+        self.assertEqual(receipt.count("  workflow-authority-admin\n"), 1)
+        self.assertEqual(receipt.count("  workflow-authorityd\n"), 1)
 
     def test_installed_compatible_libfido2_compiles_production_adapter(self):
         go_bin = shutil.which("go")

--- a/tests/test_workflow_authority_validator.py
+++ b/tests/test_workflow_authority_validator.py
@@ -1,0 +1,155 @@
+"""Focused portability tests for tools/validate-workflow-authority.sh."""
+
+import os
+import re
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+VALIDATOR = REPO_ROOT / "tools" / "validate-workflow-authority.sh"
+FIDO_SOURCE = (
+    REPO_ROOT
+    / "native"
+    / "workflow-authority"
+    / "internal"
+    / "authority"
+    / "fido_libfido2.go"
+)
+
+
+class WorkflowAuthorityValidatorTest(unittest.TestCase):
+    def make_executable(self, path, source):
+        path.write_text(source, encoding="utf-8")
+        path.chmod(0o755)
+
+    def run_validator(self, libfido2_version, go_version="go1.26.5"):
+        with tempfile.TemporaryDirectory(prefix="wa-validator-") as directory:
+            root = Path(directory)
+            fake_bin = root / "distro-bin"
+            fake_goroot = root / "selected-toolchain"
+            fake_bin.mkdir()
+            (fake_goroot / "bin").mkdir(parents=True)
+
+            self.make_executable(
+                fake_bin / "go",
+                """#!/usr/bin/env bash
+if [[ "$*" == "env GOVERSION" ]]; then
+  printf '%s\\n' "${FAKE_GO_VERSION}"
+elif [[ "$*" == "env GOROOT" ]]; then
+  printf '%s\\n' "${FAKE_GO_ROOT}"
+elif [[ "$1" == "list" && "$*" == *"-tags fixture"* ]]; then
+  printf '%s\\n' 'designmachines.dev/workflow-authority/cmd/workflow-authority-fixture'
+elif [[ "$1" == "list" ]]; then
+  printf '%s\\n' 'designmachines.dev/workflow-authority/internal/authority'
+fi
+""",
+            )
+            self.make_executable(fake_goroot / "bin" / "gofmt", "#!/usr/bin/env bash\n")
+
+            if libfido2_version.startswith("1.15."):
+                minimum_result = 1
+                next_major_result = 1
+            elif libfido2_version.startswith("1.16."):
+                minimum_result = 0
+                next_major_result = 1
+            else:
+                minimum_result = 0
+                next_major_result = 0
+            self.make_executable(
+                fake_bin / "pkg-config",
+                """#!/usr/bin/env bash
+case "$1" in
+  --modversion) printf '%s\\n' "${FAKE_LIBFIDO2_VERSION}" ;;
+  --atleast-version=1.16.0) exit ${FAKE_MINIMUM_RESULT} ;;
+  --atleast-version=2) exit ${FAKE_NEXT_MAJOR_RESULT} ;;
+  *) exit 1 ;;
+esac
+""",
+            )
+            self.make_executable(
+                fake_bin / "python3",
+                """#!/usr/bin/env bash
+if [[ "$1" == "-I" ]]; then
+  exit 0
+fi
+printf '%s\\n' \\
+  'test_accept (tests.test_workflow_authority_integration.WorkflowAuthorityIntegrationTest.test_accept) ... ok' \\
+  'test_deny (tests.test_workflow_authority_integration.DenyMatrixTest.test_deny) ... ok' \\
+  'test_hostility (tests.test_workflow_authority_integration.ProcessHostilityTest.test_hostility) ... ok' \\
+  'test_gaps (tests.test_workflow_authority_integration.UnrunLaneLedgerTest.test_gaps) ... ok' \\
+  'Ran 4 tests in 0.001s' \\
+  'OK' \\
+  '  GAP  fixture: fake harness does not exercise broker behavior'
+""",
+            )
+
+            environment = dict(os.environ)
+            environment.update(
+                {
+                    "PATH": "{}:{}".format(fake_bin, environment["PATH"]),
+                    "FAKE_GO_VERSION": go_version,
+                    "FAKE_GO_ROOT": str(fake_goroot),
+                    "FAKE_LIBFIDO2_VERSION": libfido2_version,
+                    "FAKE_MINIMUM_RESULT": str(minimum_result),
+                    "FAKE_NEXT_MAJOR_RESULT": str(next_major_result),
+                    "WORKFLOW_AUTHORITY_REQUIRE_PRODUCTION_BUILD": "1",
+                }
+            )
+            completed = subprocess.run(
+                ["bash", str(VALIDATOR)],
+                cwd=REPO_ROOT,
+                env=environment,
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+            return completed, fake_bin / "go", fake_goroot
+
+    def test_non_usr_local_launcher_selects_go_1_26_5_and_accepts_libfido2_1_16(self):
+        completed, go_launcher, go_root = self.run_validator("1.16.7")
+        self.assertEqual(completed.returncode, 0, completed.stdout + completed.stderr)
+        self.assertTrue(go_launcher.is_absolute())
+        self.assertFalse(str(go_launcher).startswith("/usr/local/"))
+        self.assertIn("launcher={}".format(go_launcher), completed.stdout)
+        self.assertIn("GOVERSION=go1.26.5", completed.stdout)
+        self.assertIn("GOROOT={}".format(go_root), completed.stdout)
+        self.assertIn("libfido2 1.16.7 (required >=1.16.0,<2)", completed.stdout)
+
+    def test_libfido2_1_15_and_2_x_are_rejected(self):
+        for version in ("1.15.9", "2.0.0"):
+            with self.subTest(version=version):
+                completed, _, _ = self.run_validator(version)
+                self.assertNotEqual(completed.returncode, 0)
+                self.assertIn("requires Linux, pkg-config, and libfido2 >=1.16.0,<2", completed.stderr)
+                self.assertIn("libfido2={}".format(version), completed.stderr)
+
+    def test_shell_and_c_guards_express_the_same_range(self):
+        shell = VALIDATOR.read_text(encoding="utf-8")
+        c_source = FIDO_SOURCE.read_text(encoding="utf-8")
+        minimum = re.search(r'LIBFIDO2_MIN_VERSION="(\d+)\.(\d+)\.(\d+)"', shell)
+        next_major = re.search(r'LIBFIDO2_NEXT_MAJOR="(\d+)"', shell)
+        c_guard = re.search(
+            r"FIDO_VERSION_MAJOR != (\d+) \|\| FIDO_VERSION_MINOR < (\d+)", c_source
+        )
+        self.assertIsNotNone(minimum)
+        self.assertIsNotNone(next_major)
+        self.assertIsNotNone(c_guard)
+        self.assertEqual(
+            (minimum.group(1), minimum.group(2), next_major.group(1)),
+            (c_guard.group(1), c_guard.group(2), str(int(c_guard.group(1)) + 1)),
+        )
+        self.assertIn('pkg-config --atleast-version="$LIBFIDO2_MIN_VERSION" libfido2', shell)
+        self.assertIn('! pkg-config --atleast-version="$LIBFIDO2_NEXT_MAJOR" libfido2', shell)
+
+    def test_wrong_selected_go_toolchain_fails_clearly(self):
+        completed, go_launcher, _ = self.run_validator("1.16.7", go_version="go1.26.4")
+        self.assertNotEqual(completed.returncode, 0)
+        self.assertIn("requires selected Go toolchain go1.26.5", completed.stderr)
+        self.assertIn(str(go_launcher), completed.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/README.md
+++ b/tools/README.md
@@ -134,9 +134,11 @@ authority boundaries, cleanup safety, promotion gates, and troubleshooting.
 
 ## validate-workflow-authority.sh
 
-Runs the native Workflow Authority broker's local release-candidate suite with
-exact Go 1.26.5: normal tests, the race detector, `go vet`, and untagged fixture
-binary builds. The suite
+Runs the native Workflow Authority broker's local release-candidate suite. It
+resolves the operator's executable `go` from `PATH`, uses `GOTOOLCHAIN=auto`,
+and requires the module-selected toolchain to report exact Go 1.26.5. The suite
+runs normal tests, the race detector, `go vet`, and untagged fixture binary
+builds. It
 includes a real Unix-socket exchange across the durable allocator, IPC server,
 authority manager, disclosure scanner, fixture credential reader, loopback TLS
 provider, fixed client verifier, and signed terminal receipt. It also proves
@@ -153,9 +155,9 @@ relaxes a check above:
   `workflow-authority-fixture` package and `go list -tags fixture ./...` must, so the
   harness scaffolding can never become a shipped code path. The tagged sources are then
   vetted and built.
-- **Formatting.** `gofmt -l` over the module, using the `gofmt` beside the pinned Go
-  launcher. `go vet` and `go build` both accept unformatted source, so this is the only
-  check that holds the convention.
+- **Formatting.** `gofmt -l` over the module, using `gofmt` from the selected
+  toolchain's `go env GOROOT`. `go vet` and `go build` both accept unformatted source,
+  so this is the only check that holds the convention.
 - **Credential-shaped literal scan.** The module and the acceptance harness must contain
   no AWS key, OpenRouter/Anthropic key, GitHub token, GitLab token, or PEM private-key
   shape. Tripwire vectors in the product's own scanner tests are concatenated at runtime
@@ -179,19 +181,31 @@ sibling inspection, live provider contact, systemd install, and so on. A `GAP` i
 reported non-claim, not a failure; treat the set of `GAP` ids as the boundary of what a
 green run means.
 
-On Linux with exactly libfido2 1.17.0, the validator additionally tests, race
-tests, vets, and builds with `-tags libfido2`. A pinned packaging/CI lane must
-require that evidence rather than accepting a local coverage gap:
+On Ubuntu, install the distro prerequisites (`go`, a cgo compiler,
+`pkg-config`, and `libfido2-dev`) from the configured signed repositories. On
+Linux with libfido2 1.x at 1.16.0 or newer, the validator additionally tests,
+race tests, vets, and builds with `-tags libfido2`; libfido2 1.15 and older and
+major version 2 or newer are rejected. A packaging/CI lane must require that
+evidence rather than accepting a local coverage gap:
 
 ```bash
 WORKFLOW_AUTHORITY_REQUIRE_PRODUCTION_BUILD=1 ./tools/validate-workflow-authority.sh
 ```
 
-Without the pinned Linux dependency, the command reports an explicit
+Without the supported Linux dependency, the command reports an explicit
 `COVERAGE-GAP`; it does not claim production build proof. All local modes still
 perform no root installation, hardware gesture, external provider request, or
 worker-principal/credential-custody acceptance. Those remain separate operator
 evidence.
+
+This command proves a production-tag build from the current repository
+checkout; it does not make that checkout an installation source. Installation
+artifacts must be built later from the exact reviewed, merged trusted-main
+commit. Interactive FIDO enrollment and provider credential custody happen
+only after that trusted-main installation and remain human/operator steps. See
+`native/workflow-authority/OPERATIONS.md` for the fixed paths, ownership and
+permission model, service workflow, UP+UV requirements, and fail-closed status
+contract.
 
 ## validate-quality-pulse.sh
 

--- a/tools/README.md
+++ b/tools/README.md
@@ -135,10 +135,10 @@ authority boundaries, cleanup safety, promotion gates, and troubleshooting.
 ## validate-workflow-authority.sh
 
 Runs the native Workflow Authority broker's local release-candidate suite. It
-resolves the operator's executable `go` from `PATH`, uses `GOTOOLCHAIN=auto`,
-and requires the module-selected toolchain to report exact Go 1.26.5. The suite
-runs normal tests, the race detector, `go vet`, and untagged fixture binary
-builds. It
+resolves `go` and `pkg-config` from a fixed system-tool path, clears inherited
+Go, cgo, and pkg-config build overrides, uses `GOTOOLCHAIN=auto`, and requires
+the module-selected toolchain to report exact Go 1.26.5. The suite runs normal
+tests, the race detector, `go vet`, and untagged fixture binary builds. It
 includes a real Unix-socket exchange across the durable allocator, IPC server,
 authority manager, disclosure scanner, fixture credential reader, loopback TLS
 provider, fixed client verifier, and signed terminal receipt. It also proves

--- a/tools/validate-workflow-authority.sh
+++ b/tools/validate-workflow-authority.sh
@@ -189,21 +189,25 @@ grep -E '^  GAP  ' "$harness_log" || true
 
 installed_libfido2=""
 compatible_libfido2=0
+libfido2_cgo_cppflags=""
 if [[ "$(uname -s)" == "Linux" ]] && command -v pkg-config >/dev/null 2>&1; then
   installed_libfido2="$(pkg-config --modversion libfido2 2>/dev/null || true)"
   if pkg-config --atleast-version="$LIBFIDO2_MIN_VERSION" libfido2 && \
      ! pkg-config --atleast-version="$LIBFIDO2_NEXT_MAJOR" libfido2; then
-    compatible_libfido2=1
+    if [[ "$installed_libfido2" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+      compatible_libfido2=1
+      libfido2_cgo_cppflags="-DWORKFLOW_AUTHORITY_LIBFIDO2_MAJOR=${BASH_REMATCH[1]} -DWORKFLOW_AUTHORITY_LIBFIDO2_MINOR=${BASH_REMATCH[2]} -DWORKFLOW_AUTHORITY_LIBFIDO2_PATCH=${BASH_REMATCH[3]}"
+    fi
   fi
 fi
 
 if [[ "$(uname -s)" == "Linux" && "$compatible_libfido2" == "1" ]]; then
   (
     cd "$MODULE"
-    GOTOOLCHAIN=auto GOCACHE="$GO_CACHE" "$GO_BIN" test -tags libfido2 ./...
-    GOTOOLCHAIN=auto GOCACHE="$GO_CACHE" "$GO_BIN" test -race -tags libfido2 ./...
-    GOTOOLCHAIN=auto GOCACHE="$GO_CACHE" "$GO_BIN" vet -tags libfido2 ./...
-    GOTOOLCHAIN=auto GOCACHE="$GO_CACHE" "$GO_BIN" build -tags libfido2 ./cmd/workflow-authority ./cmd/workflow-authorityd
+    CGO_CPPFLAGS="$libfido2_cgo_cppflags" GOTOOLCHAIN=auto GOCACHE="$GO_CACHE" "$GO_BIN" test -tags libfido2 ./...
+    CGO_CPPFLAGS="$libfido2_cgo_cppflags" GOTOOLCHAIN=auto GOCACHE="$GO_CACHE" "$GO_BIN" test -race -tags libfido2 ./...
+    CGO_CPPFLAGS="$libfido2_cgo_cppflags" GOTOOLCHAIN=auto GOCACHE="$GO_CACHE" "$GO_BIN" vet -tags libfido2 ./...
+    CGO_CPPFLAGS="$libfido2_cgo_cppflags" GOTOOLCHAIN=auto GOCACHE="$GO_CACHE" "$GO_BIN" build -tags libfido2 ./cmd/workflow-authority ./cmd/workflow-authorityd
   )
   printf 'OK    workflow authority fixture and production libfido2 validation passed with %s and libfido2 %s (required >=%s,<%s)\n' "$version" "$installed_libfido2" "$LIBFIDO2_MIN_VERSION" "$LIBFIDO2_NEXT_MAJOR"
 else

--- a/tools/validate-workflow-authority.sh
+++ b/tools/validate-workflow-authority.sh
@@ -1,6 +1,21 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+while builtin read -r _ _ imported_function; do
+  builtin unset -f "$imported_function"
+done < <(builtin declare -F)
+builtin shopt -u expand_aliases
+
+# Validation is a release trust boundary. Resolve launchers only from the
+# system installation paths and remove caller-controlled build configuration
+# before any version probe, compilation, or pkg-config lookup.
+PATH="/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin:/usr/local/go/bin:/opt/homebrew/bin"
+export PATH
+export GOENV=off
+unset GOFLAGS GOROOT GOWORK GOBIN GOPATH GOPROXY GONOPROXY GONOSUMDB GOPRIVATE GOSUMDB
+unset PKG_CONFIG PKG_CONFIG_PATH PKG_CONFIG_LIBDIR PKG_CONFIG_SYSROOT_DIR
+unset CC CXX AR CGO_CFLAGS CGO_CPPFLAGS CGO_CXXFLAGS CGO_LDFLAGS
+
 # Security-sensitive fixture roots must not inherit a group-writable operator
 # umask. Go's testing package creates the per-test child beneath its private
 # temporary root using 0777, so an interactive 0002 umask makes secure ancestor
@@ -8,24 +23,71 @@ set -euo pipefail
 umask 0022
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-GO_CACHE="${TMPDIR:-/tmp}/workflow-authority-go-cache"
+GO_CACHE="$(mktemp -d /tmp/workflow-authority-go-cache.XXXXXX)"
+GO_MODULE_CACHE="$GO_CACHE/mod"
+mkdir -m 0700 "$GO_MODULE_CACHE"
+export GOMODCACHE="$GO_MODULE_CACHE"
+export GOPROXY=https://proxy.golang.org
+export GOSUMDB=sum.golang.org
+HARNESS_LOG=""
+cleanup() {
+  chmod -R u+w "$GO_CACHE" 2>/dev/null || true
+  rm -rf "$GO_CACHE"
+  [ -z "$HARNESS_LOG" ] || rm -f "$HARNESS_LOG"
+}
+trap cleanup EXIT
 MODULE="$ROOT/native/workflow-authority"
 LIBFIDO2_MIN_VERSION="1.16.0"
 LIBFIDO2_NEXT_MAJOR="2"
 REQUIRE_PRODUCTION_BUILD="${WORKFLOW_AUTHORITY_REQUIRE_PRODUCTION_BUILD:-0}"
+ARTIFACT_DIR="${WORKFLOW_AUTHORITY_ARTIFACT_DIR:-}"
+REVIEWED_COMMIT="${WORKFLOW_AUTHORITY_REVIEWED_COMMIT:-}"
+
+if [[ -n "$ARTIFACT_DIR" || -n "$REVIEWED_COMMIT" ]]; then
+  [[ -n "$ARTIFACT_DIR" && -n "$REVIEWED_COMMIT" ]] || { printf 'FAIL  artifact builds require both WORKFLOW_AUTHORITY_ARTIFACT_DIR and WORKFLOW_AUTHORITY_REVIEWED_COMMIT\n' >&2; exit 1; }
+  [[ "$(git -C "$ROOT" rev-parse HEAD)" == "$REVIEWED_COMMIT" ]] || { printf 'FAIL  checkout does not match reviewed artifact commit %s\n' "$REVIEWED_COMMIT" >&2; exit 1; }
+  [[ -z "$(git -C "$ROOT" status --porcelain --untracked-files=normal)" ]] || { printf 'FAIL  artifact build requires a clean checkout\n' >&2; exit 1; }
+  module_relative="${MODULE#"$ROOT"/}"
+  [[ -z "$(git -C "$ROOT" ls-files --others --exclude-standard -- "$module_relative")" ]] || { printf 'FAIL  artifact module contains untracked build inputs\n' >&2; exit 1; }
+  [[ -z "$(git -C "$ROOT" ls-files --others --ignored --exclude-standard -- "$module_relative")" ]] || { printf 'FAIL  artifact module contains ignored build inputs\n' >&2; exit 1; }
+  REQUIRE_PRODUCTION_BUILD=1
+fi
 
 if [[ "$REQUIRE_PRODUCTION_BUILD" != "0" && "$REQUIRE_PRODUCTION_BUILD" != "1" ]]; then
   printf 'FAIL  WORKFLOW_AUTHORITY_REQUIRE_PRODUCTION_BUILD must be 0 or 1\n' >&2
   exit 1
 fi
 
-GO_BIN="$(command -v go 2>/dev/null || true)"
+trusted_executable() {
+  local path="$1" component metadata
+  [[ "$path" == /* && -x "$path" ]] || return 1
+  path="$(readlink -f "$path")" || return 1
+  component="$path"
+  while [[ "$component" != / ]]; do
+    metadata="$(stat -Lc '%u %a' "$component")" || return 1
+    [[ "${metadata%% *}" == 0 ]] || return 1
+    mode="${metadata#* }"
+    (( (8#$mode & 022) == 0 )) || return 1
+    component="$(dirname "$component")"
+  done
+  printf '%s\n' "$path"
+}
+
+GO_BIN="$(type -P go 2>/dev/null || true)"
 if [[ -z "$GO_BIN" || ! -x "$GO_BIN" ]]; then
   printf 'FAIL  executable Go launcher not found on PATH\n' >&2
   exit 1
 fi
-if [[ "$GO_BIN" != /* ]]; then
-  GO_BIN="$(cd "$(dirname "$GO_BIN")" && pwd -P)/$(basename "$GO_BIN")"
+GO_BIN="$(trusted_executable "$GO_BIN")" || { printf 'FAIL  Go launcher is not root-owned and non-writable\n' >&2; exit 1; }
+PKG_CONFIG_BIN="$(type -P pkg-config 2>/dev/null || true)"
+if [[ -n "$PKG_CONFIG_BIN" ]]; then
+  PKG_CONFIG_BIN="$(trusted_executable "$PKG_CONFIG_BIN")" || { printf 'FAIL  pkg-config is not root-owned and non-writable\n' >&2; exit 1; }
+  export PKG_CONFIG="$PKG_CONFIG_BIN"
+fi
+CC_BIN="$(type -P cc 2>/dev/null || true)"
+if [[ -n "$CC_BIN" ]]; then
+  CC="$(trusted_executable "$CC_BIN")" || { printf 'FAIL  C compiler is not root-owned and non-writable\n' >&2; exit 1; }
+  export CC
 fi
 
 if ! version="$(cd "$MODULE" && GOTOOLCHAIN=auto GOCACHE="$GO_CACHE" "$GO_BIN" env GOVERSION)"; then
@@ -40,6 +102,10 @@ if ! GO_ROOT="$(cd "$MODULE" && GOTOOLCHAIN=auto GOCACHE="$GO_CACHE" "$GO_BIN" e
   printf 'FAIL  selected Go %s toolchain did not report GOROOT\n' "$version" >&2
   exit 1
 fi
+case "$(readlink -f "$GO_ROOT")" in
+  "$GO_MODULE_CACHE"/*) ;;
+  *) printf 'FAIL  selected auto-toolchain GOROOT escaped the private verified module cache: %s\n' "$GO_ROOT" >&2; exit 1 ;;
+esac
 GOFMT_BIN="$GO_ROOT/bin/gofmt"
 if [[ ! -x "$GOFMT_BIN" ]]; then
   printf 'FAIL  gofmt unavailable in selected Go %s toolchain GOROOT: %s\n' "$version" "$GOFMT_BIN" >&2
@@ -129,9 +195,9 @@ fi
 # pass. Assert that tests actually ran.
 PYTHON=""
 for CANDIDATE in python3 python3.13 python3.12; do
-  if command -v "$CANDIDATE" >/dev/null 2>&1 && \
+  if type -P "$CANDIDATE" >/dev/null 2>&1 && \
      "$CANDIDATE" -I -c 'import sys; raise SystemExit(0 if sys.version_info >= (3, 12) else 1)' >/dev/null 2>&1; then
-    PYTHON="$(command -v "$CANDIDATE")"
+    PYTHON="$(trusted_executable "$(type -P "$CANDIDATE")")" || continue
     break
   fi
 done
@@ -140,8 +206,8 @@ if [ -z "$PYTHON" ]; then
   exit 1
 fi
 
-harness_log="$(mktemp "${TMPDIR:-/tmp}/workflow-authority-harness.XXXXXX")"
-trap 'rm -f "$harness_log"' EXIT
+harness_log="$(mktemp /tmp/workflow-authority-harness.XXXXXX)"
+HARNESS_LOG="$harness_log"
 # tests/__init__.py imports workflow_kernel at module level, so the harness
 # cannot be collected without the kernel references on PYTHONPATH.
 if ! (cd "$ROOT" && WORKFLOW_AUTHORITY_E2E=1 \
@@ -190,10 +256,10 @@ grep -E '^  GAP  ' "$harness_log" || true
 installed_libfido2=""
 compatible_libfido2=0
 libfido2_cgo_cppflags=""
-if [[ "$(uname -s)" == "Linux" ]] && command -v pkg-config >/dev/null 2>&1; then
-  installed_libfido2="$(pkg-config --modversion libfido2 2>/dev/null || true)"
-  if pkg-config --atleast-version="$LIBFIDO2_MIN_VERSION" libfido2 && \
-     ! pkg-config --atleast-version="$LIBFIDO2_NEXT_MAJOR" libfido2; then
+if [[ "$(uname -s)" == "Linux" && -n "$PKG_CONFIG_BIN" ]]; then
+  installed_libfido2="$("$PKG_CONFIG_BIN" --modversion libfido2 2>/dev/null || true)"
+  if "$PKG_CONFIG_BIN" --atleast-version="$LIBFIDO2_MIN_VERSION" libfido2 && \
+     ! "$PKG_CONFIG_BIN" --atleast-version="$LIBFIDO2_NEXT_MAJOR" libfido2; then
     if [[ "$installed_libfido2" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
       compatible_libfido2=1
       libfido2_cgo_cppflags="-DWORKFLOW_AUTHORITY_LIBFIDO2_MAJOR=${BASH_REMATCH[1]} -DWORKFLOW_AUTHORITY_LIBFIDO2_MINOR=${BASH_REMATCH[2]} -DWORKFLOW_AUTHORITY_LIBFIDO2_PATCH=${BASH_REMATCH[3]}"
@@ -209,6 +275,23 @@ if [[ "$(uname -s)" == "Linux" && "$compatible_libfido2" == "1" ]]; then
     CGO_CPPFLAGS="$libfido2_cgo_cppflags" GOTOOLCHAIN=auto GOCACHE="$GO_CACHE" "$GO_BIN" vet -tags libfido2 ./...
     CGO_CPPFLAGS="$libfido2_cgo_cppflags" GOTOOLCHAIN=auto GOCACHE="$GO_CACHE" "$GO_BIN" build -tags libfido2 ./cmd/workflow-authority ./cmd/workflow-authorityd
   )
+  if [[ -n "$ARTIFACT_DIR" ]]; then
+    if [[ -e "$ARTIFACT_DIR" && -n "$(find "$ARTIFACT_DIR" -mindepth 1 -maxdepth 1 -print -quit)" ]]; then
+      printf 'FAIL  artifact directory must be absent or empty: %s\n' "$ARTIFACT_DIR" >&2
+      exit 1
+    fi
+    mkdir -p "$ARTIFACT_DIR"
+    (
+      cd "$MODULE"
+      CGO_CPPFLAGS="$libfido2_cgo_cppflags" GOTOOLCHAIN=auto GOCACHE="$GO_CACHE" "$GO_BIN" build -tags libfido2 -o "$ARTIFACT_DIR/workflow-authority" ./cmd/workflow-authority
+      cp "$ARTIFACT_DIR/workflow-authority" "$ARTIFACT_DIR/workflow-authority-admin"
+      CGO_CPPFLAGS="$libfido2_cgo_cppflags" GOTOOLCHAIN=auto GOCACHE="$GO_CACHE" "$GO_BIN" build -tags libfido2 -o "$ARTIFACT_DIR/workflow-authorityd" ./cmd/workflow-authorityd
+    )
+    {
+      printf 'commit=%s\ngo_launcher=%s\ngo_version=%s\nlibfido2=%s\n' "$REVIEWED_COMMIT" "$GO_BIN" "$version" "$installed_libfido2"
+      (cd "$ARTIFACT_DIR" && sha256sum workflow-authority workflow-authority-admin workflow-authorityd)
+    } | tee "$ARTIFACT_DIR/BUILD-RECEIPT.txt"
+  fi
   printf 'OK    workflow authority fixture and production libfido2 validation passed with %s and libfido2 %s (required >=%s,<%s)\n' "$version" "$installed_libfido2" "$LIBFIDO2_MIN_VERSION" "$LIBFIDO2_NEXT_MAJOR"
 else
   if [[ "$REQUIRE_PRODUCTION_BUILD" == "1" ]]; then

--- a/tools/validate-workflow-authority.sh
+++ b/tools/validate-workflow-authority.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Security-sensitive fixture roots must not inherit a group-writable operator
+# umask. Go's testing package creates the per-test child beneath its private
+# temporary root using 0777, so an interactive 0002 umask makes secure ancestor
+# checks fail on Linux even though the same tests pass under 0022.
+umask 0022
+
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 GO_CACHE="${TMPDIR:-/tmp}/workflow-authority-go-cache"
 MODULE="$ROOT/native/workflow-authority"

--- a/tools/validate-workflow-authority.sh
+++ b/tools/validate-workflow-authority.sh
@@ -2,10 +2,10 @@
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-GO_BIN="/usr/local/go/bin/go"
 GO_CACHE="${TMPDIR:-/tmp}/workflow-authority-go-cache"
 MODULE="$ROOT/native/workflow-authority"
-LIBFIDO2_VERSION="1.17.0"
+LIBFIDO2_MIN_VERSION="1.16.0"
+LIBFIDO2_NEXT_MAJOR="2"
 REQUIRE_PRODUCTION_BUILD="${WORKFLOW_AUTHORITY_REQUIRE_PRODUCTION_BUILD:-0}"
 
 if [[ "$REQUIRE_PRODUCTION_BUILD" != "0" && "$REQUIRE_PRODUCTION_BUILD" != "1" ]]; then
@@ -13,16 +13,33 @@ if [[ "$REQUIRE_PRODUCTION_BUILD" != "0" && "$REQUIRE_PRODUCTION_BUILD" != "1" ]
   exit 1
 fi
 
-if [[ ! -x "$GO_BIN" ]]; then
-  printf 'FAIL  exact Go launcher unavailable: %s\n' "$GO_BIN" >&2
+GO_BIN="$(command -v go 2>/dev/null || true)"
+if [[ -z "$GO_BIN" || ! -x "$GO_BIN" ]]; then
+  printf 'FAIL  executable Go launcher not found on PATH\n' >&2
   exit 1
+fi
+if [[ "$GO_BIN" != /* ]]; then
+  GO_BIN="$(cd "$(dirname "$GO_BIN")" && pwd -P)/$(basename "$GO_BIN")"
 fi
 
-version="$(cd "$MODULE" && GOTOOLCHAIN=auto GOCACHE="$GO_CACHE" "$GO_BIN" env GOVERSION)"
-if [[ "$version" != "go1.26.5" ]]; then
-  printf 'FAIL  workflow authority requires Go 1.26.5, got %s\n' "$version" >&2
+if ! version="$(cd "$MODULE" && GOTOOLCHAIN=auto GOCACHE="$GO_CACHE" "$GO_BIN" env GOVERSION)"; then
+  printf 'FAIL  Go launcher %s could not select the module toolchain with GOTOOLCHAIN=auto\n' "$GO_BIN" >&2
   exit 1
 fi
+if [[ "$version" != "go1.26.5" ]]; then
+  printf 'FAIL  workflow authority requires selected Go toolchain go1.26.5, got %s from %s\n' "$version" "$GO_BIN" >&2
+  exit 1
+fi
+if ! GO_ROOT="$(cd "$MODULE" && GOTOOLCHAIN=auto GOCACHE="$GO_CACHE" "$GO_BIN" env GOROOT)"; then
+  printf 'FAIL  selected Go %s toolchain did not report GOROOT\n' "$version" >&2
+  exit 1
+fi
+GOFMT_BIN="$GO_ROOT/bin/gofmt"
+if [[ ! -x "$GOFMT_BIN" ]]; then
+  printf 'FAIL  gofmt unavailable in selected Go %s toolchain GOROOT: %s\n' "$version" "$GOFMT_BIN" >&2
+  exit 1
+fi
+printf 'OK    workflow authority Go toolchain launcher=%s GOVERSION=%s GOROOT=%s\n' "$GO_BIN" "$version" "$GO_ROOT"
 
 (
   cd "$MODULE"
@@ -62,11 +79,6 @@ fi
 # gate reports success on a file gofmt would rewrite -- which is exactly how the
 # fixture launcher shipped unformatted. gofmt reads files directly, so one pass
 # covers tagged and untagged sources with no build-tag selection.
-GOFMT_BIN="$(dirname "$GO_BIN")/gofmt"
-if [[ ! -x "$GOFMT_BIN" ]]; then
-  printf 'FAIL  exact gofmt unavailable beside the pinned Go launcher: %s\n' "$GOFMT_BIN" >&2
-  exit 1
-fi
 unformatted="$(cd "$MODULE" && "$GOFMT_BIN" -l . || true)"
 if [ -n "$unformatted" ]; then
   printf 'FAIL  unformatted Go source in the authority module:\n%s\n' "$unformatted" >&2
@@ -127,6 +139,7 @@ trap 'rm -f "$harness_log"' EXIT
 # tests/__init__.py imports workflow_kernel at module level, so the harness
 # cannot be collected without the kernel references on PYTHONPATH.
 if ! (cd "$ROOT" && WORKFLOW_AUTHORITY_E2E=1 \
+      WORKFLOW_AUTHORITY_GO_BIN="$GO_BIN" \
       PYTHONPATH="$ROOT/plugins/workflow-kernel/skills/workflow-kernel/references" \
       "$PYTHON" -m unittest -v tests.test_workflow_authority_integration) > "$harness_log" 2>&1; then
   printf 'FAIL  workflow authority acceptance harness failed:\n' >&2
@@ -169,11 +182,16 @@ printf 'OK    workflow authority acceptance harness executed %s cases (%s skippe
 grep -E '^  GAP  ' "$harness_log" || true
 
 installed_libfido2=""
+compatible_libfido2=0
 if [[ "$(uname -s)" == "Linux" ]] && command -v pkg-config >/dev/null 2>&1; then
   installed_libfido2="$(pkg-config --modversion libfido2 2>/dev/null || true)"
+  if pkg-config --atleast-version="$LIBFIDO2_MIN_VERSION" libfido2 && \
+     ! pkg-config --atleast-version="$LIBFIDO2_NEXT_MAJOR" libfido2; then
+    compatible_libfido2=1
+  fi
 fi
 
-if [[ "$(uname -s)" == "Linux" && "$installed_libfido2" == "$LIBFIDO2_VERSION" ]]; then
+if [[ "$(uname -s)" == "Linux" && "$compatible_libfido2" == "1" ]]; then
   (
     cd "$MODULE"
     GOTOOLCHAIN=auto GOCACHE="$GO_CACHE" "$GO_BIN" test -tags libfido2 ./...
@@ -181,11 +199,11 @@ if [[ "$(uname -s)" == "Linux" && "$installed_libfido2" == "$LIBFIDO2_VERSION" ]
     GOTOOLCHAIN=auto GOCACHE="$GO_CACHE" "$GO_BIN" vet -tags libfido2 ./...
     GOTOOLCHAIN=auto GOCACHE="$GO_CACHE" "$GO_BIN" build -tags libfido2 ./cmd/workflow-authority ./cmd/workflow-authorityd
   )
-  printf 'OK    workflow authority fixture and production libfido2 validation passed with %s and libfido2 %s\n' "$version" "$LIBFIDO2_VERSION"
+  printf 'OK    workflow authority fixture and production libfido2 validation passed with %s and libfido2 %s (required >=%s,<%s)\n' "$version" "$installed_libfido2" "$LIBFIDO2_MIN_VERSION" "$LIBFIDO2_NEXT_MAJOR"
 else
   if [[ "$REQUIRE_PRODUCTION_BUILD" == "1" ]]; then
-    printf 'FAIL  pinned production build requires Linux, pkg-config, and exactly libfido2 %s; host=%s libfido2=%s\n' "$LIBFIDO2_VERSION" "$(uname -s)" "${installed_libfido2:-unavailable}" >&2
+    printf 'FAIL  production build requires Linux, pkg-config, and libfido2 >=%s,<%s; host=%s libfido2=%s\n' "$LIBFIDO2_MIN_VERSION" "$LIBFIDO2_NEXT_MAJOR" "$(uname -s)" "${installed_libfido2:-unavailable}" >&2
     exit 1
   fi
-  printf 'COVERAGE-GAP workflow authority production build requires Linux and libfido2 %s; portable fixture validation passed with %s\n' "$LIBFIDO2_VERSION" "$version"
+  printf 'COVERAGE-GAP workflow authority production build requires Linux and libfido2 >=%s,<%s; portable fixture validation passed with %s\n' "$LIBFIDO2_MIN_VERSION" "$LIBFIDO2_NEXT_MAJOR" "$version"
 fi


### PR DESCRIPTION
Closes #39

## Outcome

Workflow Authority now builds reproducibly on NED using the trusted system Go launcher, the module-selected Go 1.26.5 toolchain, and Ubuntu libfido2 1.16.x. The validator accepts libfido2 `>=1.16.0,<2`, keeps its shell and C guards aligned, and can emit review-bound production artifacts and a build receipt.

## Exact head and host proof

- head: `651707a6e8d773867e0d12ddc6079f9c6473065c`
- launcher: `/usr/lib/go-1.26/bin/go` (resolved system path)
- selected toolchain: `go1.26.5`
- installed libfido2: `1.16.0`
- production gate executed 22 black-box cases with 1 skip, then passed tagged test, race, vet, and build lanes

## Verification

- focused validator suite: 9/9 passed
- `WORKFLOW_AUTHORITY_REQUIRE_PRODUCTION_BUILD=1 ./tools/validate-workflow-authority.sh` passed at exact head
- combined four-PR integration tree: `./tools/validate-composition.sh --all` passed
- `bash -n tools/validate-workflow-authority.sh`
- `git diff --check`

## Boundary

No broker binary or service was installed or started. No FIDO enrollment, provider credential, provider call, dm-review/pipeline routing, plugin manifest, or plugin version changed. Trusted-main installation and the human credential ceremony remain R3b.