### PR TITLE
fix(ned): separate Docker operations preflight

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "ned",
       "source": "./plugins/ned",
-      "version": "1.8.0",
+      "version": "1.8.1",
       "author": {
         "name": "Design Machines"
       },

--- a/plugins/ned/.claude-plugin/plugin.json
+++ b/plugins/ned/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ned",
   "description": "Personal knowledge graph, NED operations, and session capture for Travis Gertz",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "author": {
     "name": "Design Machines"
   },

--- a/plugins/ned/.codex-plugin/plugin.json
+++ b/plugins/ned/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ned",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "Personal knowledge graph, NED operations, and session capture for Travis Gertz",
   "author": {
     "name": "Design Machines"

--- a/plugins/ned/skills/operate-ned/SKILL.md
+++ b/plugins/ned/skills/operate-ned/SKILL.md
@@ -71,24 +71,51 @@ Operations preflight:
 host="$(hostname -s)"
 user="$(id -un)"
 workdir="$(pwd -P)"
-docker_context="$(docker context show)"
-docker_host="${DOCKER_HOST-<unset>}"
-docker_root="$(docker info --format '{{.DockerRootDir}}')"
-docker_rootless="$(docker info --format '{{json .SecurityOptions}}' | grep -Fq 'name=rootless' && printf true || printf false)"
 if test "$host" != ned9000 || test "$user" != trav ||
    case "$workdir" in /home/trav|/home/trav/*|/etc|/etc/*|/srv|/srv/*) false ;; *) true ;; esac ||
-   ! sudo -n true || test "$docker_root" != /var/lib/docker ||
-   test "$docker_rootless" != false; then
-  printf 'host=%s\nuser=%s\nworkdir=%s\ndocker_context=%s\ndocker_host=%s\ndocker_root=%s\ndocker_rootless=%s\n' \
-    "$host" "$user" "$workdir" "$docker_context" "$docker_host" "$docker_root" "$docker_rootless" >&2
+   ! sudo -n true; then
+  printf 'host=%s\nuser=%s\nworkdir=%s\n' "$host" "$user" "$workdir" >&2
   exit 1
 fi
 ```
 
-Stop on any mismatch. Context and `DOCKER_HOST` are diagnostics only; effective daemon root and
-rootless security mode decide Docker authority. Report only the bounded facts shown above.
-Never repair a mismatch by weakening authentication, changing sudoers, or adding `ned` to the
-`docker` group.
+For an operation that uses the system Docker daemon, run the operations preflight above and then
+run this additional system-Docker preflight:
+
+```bash
+docker_socket=unix:///var/run/docker.sock
+if ! docker_root="$(sudo -n env \
+  -u DOCKER_HOST -u DOCKER_CONTEXT \
+  -u DOCKER_TLS_VERIFY -u DOCKER_CERT_PATH \
+  /usr/bin/docker --host "$docker_socket" info --format '{{.DockerRootDir}}')"; then
+  printf 'docker_socket=%s\nsystem_docker_probe=failed\n' "$docker_socket" >&2
+  exit 1
+fi
+if ! docker_security="$(sudo -n env \
+  -u DOCKER_HOST -u DOCKER_CONTEXT \
+  -u DOCKER_TLS_VERIFY -u DOCKER_CERT_PATH \
+  /usr/bin/docker --host "$docker_socket" info --format '{{json .SecurityOptions}}')"; then
+  printf 'docker_socket=%s\nsystem_docker_probe=failed\n' "$docker_socket" >&2
+  exit 1
+fi
+if printf '%s\n' "$docker_security" | grep -Fq 'name=rootless'; then
+  docker_rootless=true
+else
+  docker_rootless=false
+fi
+if test "$docker_root" != /var/lib/docker || test "$docker_rootless" != false; then
+  printf 'docker_socket=%s\ndocker_root=%s\ndocker_rootless=%s\n' \
+    "$docker_socket" "$docker_root" "$docker_rootless" >&2
+  exit 1
+fi
+```
+
+Stop on any mismatch. Do not require Docker access for operations that do not use Docker. The
+system-Docker preflight pins the root-owned socket and clears caller-controlled endpoint and TLS
+overrides before querying it through passwordless sudo. A failed Docker query is a failure, not
+evidence that the daemon is non-rootless. Report only the bounded facts shown above. Never repair a
+mismatch by weakening authentication, changing sudoers, or adding either account to the `docker`
+group.
 
 ## Split mixed development and operations
 
@@ -111,7 +138,10 @@ to `trav`, present the exact operations command and stop rather than manufacturi
 - Never run Codex, Claude, a pipeline, or general subagents as `trav`.
 - Never enter through `trav` and launch an agent with `sudo -iu ned`; connect directly as `ned`.
 - Never use `sudo docker` or the `default` Docker context for a development checkout.
-- Never add `ned` to the `docker` group. Membership is root-equivalent.
+- Never add `ned` or `trav` to the `docker` group. Membership is root-equivalent; keep the group
+  empty.
+- Never run Workflow Authority as `ned`; install and operate it only through its separately reviewed
+  privileged-service boundary.
 - Never collapse the two phases because a demo, deadline, or outage makes one privileged session
   seem faster.
 - Never store SSH keys, pairing tokens, API keys, or secret values in AI Memory, prompts, logs, or

--- a/plugins/ned/skills/operate-ned/SKILL.md
+++ b/plugins/ned/skills/operate-ned/SKILL.md
@@ -65,57 +65,69 @@ if test "$host" != ned9000 || test "$user" != ned ||
 fi
 ```
 
-Operations preflight:
+Operations preflight and system-Docker wrapper:
 
 ```bash
-host="$(hostname -s)"
-user="$(id -un)"
-workdir="$(pwd -P)"
-if test "$host" != ned9000 || test "$user" != trav ||
-   case "$workdir" in /home/trav|/home/trav/*|/etc|/etc/*|/srv|/srv/*) false ;; *) true ;; esac ||
-   ! sudo -n true; then
-  printf 'host=%s\nuser=%s\nworkdir=%s\n' "$host" "$user" "$workdir" >&2
-  exit 1
-fi
+operations_preflight() {
+  host="$(/usr/bin/hostname -s)"
+  user="$(/usr/bin/id -un)"
+  workdir="$(/bin/pwd -P)"
+  if test "$host" != ned9000 || test "$user" != trav ||
+     case "$workdir" in /home/trav|/home/trav/*|/etc|/etc/*|/srv|/srv/*) false ;; *) true ;; esac ||
+     ! /usr/bin/sudo -n true; then
+    printf 'host=%s\nuser=%s\nworkdir=%s\n' "$host" "$user" "$workdir" >&2
+    return 1
+  fi
+}
+
+system_docker() {
+  operations_preflight || return
+  if test "$#" -eq 0; then
+    printf 'system_docker requires an explicit Docker command\n' >&2
+    return 1
+  fi
+  case "$1" in
+    -*)
+      printf 'system_docker requires a Docker command before its arguments; global option refused: %s\n' "$1" >&2
+      return 1
+      ;;
+  esac
+
+  docker_socket=unix:///var/run/docker.sock
+  if ! docker_probe="$(/usr/bin/sudo -n /usr/bin/env -i \
+    HOME=/root DOCKER_CONFIG=/root/.docker \
+    PATH=/usr/bin:/bin:/usr/sbin:/sbin \
+    /usr/bin/docker --host "$docker_socket" info \
+    --format '{{printf "%s\t%s" .DockerRootDir (json .SecurityOptions)}}')"; then
+    printf 'docker_socket=%s\nsystem_docker_probe=failed\n' "$docker_socket" >&2
+    return 1
+  fi
+  IFS=$'\t' read -r docker_root docker_security <<< "$docker_probe"
+  if test "$docker_root" != /var/lib/docker ||
+     printf '%s\n' "$docker_security" | grep -Fq 'name=rootless'; then
+    printf 'docker_socket=%s\ndocker_root=%s\ndocker_rootless=%s\n' \
+      "$docker_socket" "$docker_root" \
+      "$(printf '%s\n' "$docker_security" | grep -Fq 'name=rootless' && printf true || printf false)" >&2
+    return 1
+  fi
+
+  /usr/bin/sudo -n /usr/bin/env -i \
+    HOME=/root DOCKER_CONFIG=/root/.docker \
+    PATH=/usr/bin:/bin:/usr/sbin:/sbin \
+    /usr/bin/docker --host "$docker_socket" "$@"
+}
+
+operations_preflight || exit 1
 ```
 
-For an operation that uses the system Docker daemon, run the operations preflight above and then
-run this additional system-Docker preflight:
-
-```bash
-docker_socket=unix:///var/run/docker.sock
-if ! docker_root="$(sudo -n env \
-  -u DOCKER_HOST -u DOCKER_CONTEXT \
-  -u DOCKER_TLS_VERIFY -u DOCKER_CERT_PATH \
-  /usr/bin/docker --host "$docker_socket" info --format '{{.DockerRootDir}}')"; then
-  printf 'docker_socket=%s\nsystem_docker_probe=failed\n' "$docker_socket" >&2
-  exit 1
-fi
-if ! docker_security="$(sudo -n env \
-  -u DOCKER_HOST -u DOCKER_CONTEXT \
-  -u DOCKER_TLS_VERIFY -u DOCKER_CERT_PATH \
-  /usr/bin/docker --host "$docker_socket" info --format '{{json .SecurityOptions}}')"; then
-  printf 'docker_socket=%s\nsystem_docker_probe=failed\n' "$docker_socket" >&2
-  exit 1
-fi
-if printf '%s\n' "$docker_security" | grep -Fq 'name=rootless'; then
-  docker_rootless=true
-else
-  docker_rootless=false
-fi
-if test "$docker_root" != /var/lib/docker || test "$docker_rootless" != false; then
-  printf 'docker_socket=%s\ndocker_root=%s\ndocker_rootless=%s\n' \
-    "$docker_socket" "$docker_root" "$docker_rootless" >&2
-  exit 1
-fi
-```
-
-Stop on any mismatch. Do not require Docker access for operations that do not use Docker. The
-system-Docker preflight pins the root-owned socket and clears caller-controlled endpoint and TLS
-overrides before querying it through passwordless sudo. A failed Docker query is a failure, not
-evidence that the daemon is non-rootless. Report only the bounded facts shown above. Never repair a
-mismatch by weakening authentication, changing sudoers, or adding either account to the `docker`
-group.
+Stop on any mismatch. Non-Docker operations need only `operations_preflight`. For every system
+Docker command, call `system_docker` with the reviewed Docker arguments; never follow the check with
+an ambient `docker` or `sudo docker` command. The wrapper checks the `trav` operations boundary,
+pins the root-owned socket, uses a clean environment and root-owned Docker configuration, rejects
+all caller-supplied Docker global options, verifies the daemon,
+and runs the operation through that same boundary. A failed query is a failure, not evidence that the
+daemon is non-rootless. Report only the bounded facts shown above. Never weaken authentication,
+change sudoers, or add either account to the `docker` group.
 
 ## Split mixed development and operations
 
@@ -140,8 +152,10 @@ to `trav`, present the exact operations command and stop rather than manufacturi
 - Never use `sudo docker` or the `default` Docker context for a development checkout.
 - Never add `ned` or `trav` to the `docker` group. Membership is root-equivalent; keep the group
   empty.
-- Never run Workflow Authority as `ned`; install and operate it only through its separately reviewed
-  privileged-service boundary.
+- Never run `workflow-authorityd`, installation, enrollment, credential provisioning, recovery, or
+  administrative commands as `ned`; those belong to the reviewed root-owned service boundary.
+  `ned` may invoke only the installed unprivileged `workflow-authority` client, and only after a
+  separate review explicitly grants it membership in the restricted socket group.
 - Never collapse the two phases because a demo, deadline, or outage makes one privileged session
   seem faster.
 - Never store SSH keys, pairing tokens, API keys, or secret values in AI Memory, prompts, logs, or

--- a/tests/test_operate_ned_skill.py
+++ b/tests/test_operate_ned_skill.py
@@ -1,0 +1,175 @@
+"""Behavioral checks for the executable preflights in ned:operate-ned."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import shlex
+import subprocess
+import tempfile
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SKILL = ROOT / "plugins/ned/skills/operate-ned/SKILL.md"
+
+
+class OperateNEDSkillTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        text = SKILL.read_text(encoding="utf-8")
+        heading = "Operations preflight and system-Docker wrapper:\n\n```bash\n"
+        start = text.index(heading) + len(heading)
+        cls.block = text[start : text.index("\n```", start)]
+
+    def setUp(self):
+        self.temporary = tempfile.TemporaryDirectory(prefix="operate-ned-")
+        self.root = Path(self.temporary.name)
+        self.bin = self.root / "bin"
+        self.log = self.root / "docker.log"
+        self.bin.mkdir()
+        self._write_stub("hostname", "printf '%s\\n' \"${STUB_HOST:-ned9000}\"\n")
+        self._write_stub("id", "printf '%s\\n' \"${STUB_USER:-trav}\"\n")
+        self._write_stub("pwd", "printf '%s\\n' \"${STUB_WORKDIR:-/srv/review}\"\n")
+        self._write_stub(
+            "sudo",
+            """if [[ "${1:-}" == "-n" ]]; then shift; fi
+if [[ "${1:-}" == "true" ]]; then [[ "${STUB_SUDO_FAIL:-0}" != 1 ]]; exit; fi
+exec "$@"
+""",
+        )
+        self._write_stub(
+            "docker",
+            """for name in DOCKER_HOST DOCKER_CONTEXT DOCKER_TLS_VERIFY DOCKER_CERT_PATH EVIL_DOCKER_PLUGIN; do
+  if [[ -v "$name" ]]; then printf 'leaked:%s\\n' "$name" >> "$STUB_DOCKER_LOG"; fi
+done
+printf 'call:%s\\n' "$*" >> "$STUB_DOCKER_LOG"
+if [[ "$*" == *" info "* ]]; then
+  [[ "${STUB_DOCKER_FAIL:-0}" == "1" ]] && exit 42
+  expected='{{printf "%s\\t%s" .DockerRootDir (json .SecurityOptions)}}'
+  [[ "$*" == *"--format $expected"* ]] || { printf 'bad format: %s\\n' "$*" >&2; exit 43; }
+  printf '%s\\t%s\\n' "${STUB_DOCKER_ROOT:-/var/lib/docker}" "${STUB_DOCKER_SECURITY:-[\"name=seccomp\"]}"
+fi
+""",
+        )
+
+    def tearDown(self):
+        self.temporary.cleanup()
+
+    def _write_stub(self, name: str, body: str) -> None:
+        path = self.bin / name
+        path.write_text("#!/usr/bin/env bash\nset -euo pipefail\n" + body, encoding="utf-8")
+        path.chmod(0o755)
+
+    def _run(self, command: str, **overrides: str) -> subprocess.CompletedProcess[str]:
+        block = self.block
+        replacements = {
+            "/usr/bin/hostname": self.bin / "hostname",
+            "/usr/bin/id": self.bin / "id",
+            "/bin/pwd": self.bin / "pwd",
+            "/usr/bin/sudo": self.bin / "sudo",
+            "/usr/bin/docker": self.bin / "docker",
+        }
+        for source, target in replacements.items():
+            block = block.replace(source, str(target))
+        stub_environment = {"STUB_DOCKER_LOG": str(self.log), **overrides}
+        assignments = " ".join(
+            "{}={}".format(name, shlex.quote(value))
+            for name, value in stub_environment.items()
+            if name.startswith("STUB_")
+        )
+        block = block.replace("/usr/bin/env -i", "/usr/bin/env -i " + assignments)
+        environment = dict(os.environ)
+        environment.update(
+            {
+                "STUB_DOCKER_LOG": str(self.log),
+                "DOCKER_HOST": "tcp://attacker.invalid:2375",
+                "DOCKER_CONTEXT": "attacker",
+                "DOCKER_TLS_VERIFY": "1",
+                "DOCKER_CERT_PATH": "/tmp/attacker-certs",
+                "DOCKER_CONFIG": "/tmp/attacker-config",
+                "EVIL_DOCKER_PLUGIN": "/tmp/attacker-plugin",
+                **overrides,
+            }
+        )
+        return subprocess.run(
+            ["bash", "-c", block + "\n" + command],
+            cwd=self.root,
+            env=environment,
+            text=True,
+            capture_output=True,
+        )
+
+    def test_non_docker_operation_does_not_probe_docker(self):
+        completed = self._run("operations_preflight")
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        self.assertFalse(self.log.exists())
+
+    def test_system_docker_pins_and_reuses_the_verified_socket(self):
+        completed = self._run("system_docker ps")
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        log = self.log.read_text(encoding="utf-8")
+        self.assertNotIn("leaked:", log)
+        self.assertEqual(log.count("--host unix:///var/run/docker.sock"), 2)
+        self.assertIn(" info ", log)
+        self.assertIn("call:--host unix:///var/run/docker.sock ps", log)
+
+    def test_system_docker_rejects_leading_global_options(self):
+        for argument in ("--config=/tmp/evil", "--context=evil", "-Htcp://evil", "--tlsverify=false"):
+            with self.subTest(argument=argument):
+                self.log.unlink(missing_ok=True)
+                completed = self._run("system_docker " + argument + " ps")
+                self.assertNotEqual(completed.returncode, 0)
+                self.assertIn("global option refused", completed.stderr)
+                self.assertFalse(self.log.exists())
+
+    def test_system_docker_forwards_subcommand_options(self):
+        completed = self._run("system_docker run image --config=/app/x")
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        self.assertIn(
+            "call:--host unix:///var/run/docker.sock run image --config=/app/x",
+            self.log.read_text(encoding="utf-8"),
+        )
+
+    def test_operations_preflight_rejects_wrong_boundary_before_docker(self):
+        for overrides in (
+            {"STUB_HOST": "other"},
+            {"STUB_USER": "ned"},
+            {"STUB_WORKDIR": "/tmp"},
+            {"STUB_SUDO_FAIL": "1"},
+        ):
+            with self.subTest(overrides=overrides):
+                self.log.unlink(missing_ok=True)
+                completed = self._run("system_docker ps", **overrides)
+                self.assertNotEqual(completed.returncode, 0)
+                self.assertFalse(self.log.exists())
+
+    def test_failed_probe_stops_before_the_operation(self):
+        completed = self._run("system_docker ps", STUB_DOCKER_FAIL="1")
+        self.assertNotEqual(completed.returncode, 0)
+        self.assertIn("system_docker_probe=failed", completed.stderr)
+        self.assertEqual(self.log.read_text(encoding="utf-8").count("call:"), 1)
+
+    def test_wrong_root_stops_before_the_operation(self):
+        completed = self._run("system_docker ps", STUB_DOCKER_ROOT="/tmp/rootless")
+        self.assertNotEqual(completed.returncode, 0)
+        self.assertIn("docker_root=/tmp/rootless", completed.stderr)
+        self.assertEqual(self.log.read_text(encoding="utf-8").count("call:"), 1)
+
+    def test_rootless_daemon_stops_before_the_operation(self):
+        completed = self._run(
+            "system_docker ps", STUB_DOCKER_SECURITY='["name=rootless"]'
+        )
+        self.assertNotEqual(completed.returncode, 0)
+        self.assertIn("docker_rootless=true", completed.stderr)
+        self.assertEqual(self.log.read_text(encoding="utf-8").count("call:"), 1)
+
+    def test_system_docker_requires_an_explicit_command(self):
+        completed = self._run("system_docker")
+        self.assertNotEqual(completed.returncode, 0)
+        self.assertIn("requires an explicit Docker command", completed.stderr)
+        self.assertFalse(self.log.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/validate-composition.sh
+++ b/tools/validate-composition.sh
@@ -658,6 +658,11 @@ run_composition_checks() {
     any_failed=1
   fi
 
+  printf "\n${BOLD}NED operations preflight:${RESET}\n"
+  if ! python3 "$REPO_ROOT/tests/test_operate_ned_skill.py"; then
+    any_failed=1
+  fi
+
   printf "\n${BOLD}SKILL.md frontmatter integrity:${RESET}\n"
   if ! check_skill_frontmatter; then
     any_failed=1


### PR DESCRIPTION
## Outcome

- separate ordinary bounded `trav` operations from the additional system-Docker authority check
- pin system Docker to `/var/run/docker.sock` through a clean passwordless-sudo boundary
- keep both accounts out of the Docker group and reserve Workflow Authority operations for the reviewed root-owned service boundary
- bump `ned` to 1.8.1 and regenerate its Codex manifest

## Exact head

`e6e4ffcb2259c3e78563d52bec2ccc32e8bc2a83`

## Verification

- `python3 tests/test_operate_ned_skill.py` — 9/9 passed
- `./tools/generate-codex-manifests.py --check`
- `git diff --check`
- combined four-PR integration tree: `./tools/validate-composition.sh --all` passed

The earlier release/version gap is resolved in this head: canonical marketplace, Claude manifest, and generated Codex manifest all declare `ned` 1.8.1.