### PR TITLE
Fix direct OpenRouter envelope authorization

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -429,7 +429,7 @@
     {
       "name": "openrouter",
       "source": "./plugins/openrouter",
-      "version": "1.11.5",
+      "version": "1.11.6",
       "author": {
         "name": "Design Machines",
         "url": "https://designmachines.studio"

--- a/plugins/openrouter/.claude-plugin/plugin.json
+++ b/plugins/openrouter/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "openrouter",
   "description": "OpenRouter provider plugin with exact-digest direct interactive use, broker-pending automated routing, Kimi K3-led security and bulk analysis, Terra quality fallback, Luna economical mechanical routing, and an optional official MCP control plane.",
-  "version": "1.11.5",
+  "version": "1.11.6",
   "author": {
     "name": "Design Machines",
     "url": "https://designmachines.studio"

--- a/plugins/openrouter/.codex-plugin/plugin.json
+++ b/plugins/openrouter/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "openrouter",
-  "version": "1.11.5",
+  "version": "1.11.6",
   "description": "OpenRouter provider plugin with exact-digest direct interactive use, broker-pending automated routing, Kimi K3-led security and bulk analysis, Terra quality fallback, Luna economical mechanical routing, and an optional official MCP control plane.",
   "author": {
     "name": "Design Machines",

--- a/plugins/openrouter/README.md
+++ b/plugins/openrouter/README.md
@@ -50,7 +50,7 @@ Every live caller selects one coherent installed plugin root with workflow-kerne
 
 ## Requirements
 
-- `OPENROUTER_API_KEY` is required for every live wrapper transmission,
+- `OPENROUTER_API_KEY` or a validated `OPENROUTER_API_KEY_FILE` is required for every live wrapper transmission,
   including an authorized dm-review operator-batch dispatch. Its presence alone
   never activates automated coding or review lanes.
 - `OPENROUTER_ZDR=1` opt-in to pin zero-data-retention providers for genuinely sensitive material (privacy demoted by default: Quality > Price > Speed > Provider privacy).
@@ -58,6 +58,6 @@ Every live caller selects one coherent installed plugin root with workflow-kerne
   default provider-routing strategy; explicit provider sort/order overrides it.
 - Canonical disclosure scanning rejects ineligible bytes before direct
   interactive authorization. `/openrouter` requires approval of the unchanged
-  exact digest; automated child modes remain disabled regardless of
+  exact rendered request-envelope digest; automated child modes remain disabled regardless of
   `OPENROUTER_PAYLOAD_AUTHORIZATION`.
 - Optional OpenRouter MCP: `codex mcp add openrouter --url https://mcp.openrouter.ai/mcp`, then `codex mcp login openrouter`. Its expiring OAuth key does not replace the persistent team API key.

--- a/plugins/openrouter/commands/openrouter.md
+++ b/plugins/openrouter/commands/openrouter.md
@@ -34,11 +34,13 @@ Extract the prompt and optional `--model` flag from the user's input.
 
 ### Step 2: Check Prerequisites
 
-Verify `OPENROUTER_API_KEY` is set:
+Verify either `OPENROUTER_API_KEY` or `OPENROUTER_API_KEY_FILE` is set. The
+file form is preferred for non-interactive harnesses and is validated by the
+wrapper as a non-symlink regular file owned by the current UID with mode 0600:
 
 ```bash
-if [ -z "${OPENROUTER_API_KEY:-}" ]; then
-  echo "OPENROUTER_API_KEY not set. Export it before using /openrouter."
+if [ -z "${OPENROUTER_API_KEY:-}" ] && [ -z "${OPENROUTER_API_KEY_FILE:-}" ]; then
+  echo "OPENROUTER_API_KEY or OPENROUTER_API_KEY_FILE required."
   exit 1
 fi
 ```
@@ -90,7 +92,8 @@ PROMPT_FILE=$(mktemp)
 SYSTEM_FILE=$(mktemp)
 RECEIPT_FILE=$(mktemp)
 AUTHORIZATION_FILE=$(mktemp)
-trap 'rm -f "$PROMPT_FILE" "$SYSTEM_FILE" "$RECEIPT_FILE" "$AUTHORIZATION_FILE"' EXIT
+REQUEST_ENVELOPE_FILE=$(mktemp)
+trap 'rm -f "$PROMPT_FILE" "$SYSTEM_FILE" "$RECEIPT_FILE" "$AUTHORIZATION_FILE" "$REQUEST_ENVELOPE_FILE"' EXIT
 printf '%s' "$USER_PROMPT" > "$PROMPT_FILE"
 printf '%s' "${OPENROUTER_SYSTEM:-You are a terse, precise coding assistant. Output only what was asked.}" > "$SYSTEM_FILE"
 if ! "$BOUNDARY_PATH" --mode artifact-delegation \
@@ -100,33 +103,38 @@ if ! "$BOUNDARY_PATH" --mode artifact-delegation \
   exit 1
 fi
 
-PAYLOAD_SHA256=$("$AUTHORIZATION_PATH" snapshot \
-  --output "$AUTHORIZATION_FILE" \
-  --content-file "$SYSTEM_FILE" --content-file "$PROMPT_FILE")
+env -u OPENROUTER_SYSTEM OPENROUTER_SYSTEM_FILE="$SYSTEM_FILE" \
+  OPENROUTER_AUTHORIZATION_MODE=exact-digest \
+  OPENROUTER_WORKLOAD=direct \
+  OPENROUTER_RECEIPT_FILE="$RECEIPT_FILE" \
+  OPENROUTER_REQUEST_ENVELOPE_OUTPUT="$REQUEST_ENVELOPE_FILE" \
+  bash "$WRAPPER_PATH" "${MODEL}" - "${TIMEOUT}" "${FALLBACK_MODEL:-}" < "$PROMPT_FILE"
+REQUEST_ENVELOPE_SHA256=$("$AUTHORIZATION_PATH" snapshot-envelope \
+  --output "$AUTHORIZATION_FILE" --request-file "$REQUEST_ENVELOPE_FILE")
 ```
 
 Direct interactive `/openrouter` supports only `exact-digest` until the
 external Workflow Authority Broker is installed and integrated. Immediately
-before calling the wrapper, authorize the unchanged payload through the
-payload-specific human gate. Caller-selected `trusted-boundary` is unavailable
+before provider contact, authorize the exact rendered request envelope through
+the payload-specific human gate. The envelope binds the system/user bytes,
+model candidates, provider routing, and streaming parameters. Caller-selected `trusted-boundary` is unavailable
 and must not be treated as authority.
 
 In `exact-digest` mode this is a two-pass workflow:
 
-1. **Preparation pass:** Materialize, disclosure-screen, and snapshot the exact
-   ordered bytes. If no recorded human decision exists for that digest, emit
+1. **Preparation pass:** Materialize, disclosure-screen, render, and snapshot
+   the exact request-envelope bytes. If no recorded human decision exists, emit
    `approval_required` with status/exit `78`, stop before the wrapper, and ask
-   the human with `AskUserQuestion` (or a normal chat question when that tool is
-   unavailable) to approve or decline that exact digest. End the current turn;
+   the human with `AskUserQuestion` (or a normal chat question when unavailable)
+   to approve or decline that `requestEnvelopeSha256`. End the current turn;
    approval pending is neither success nor provider failure.
 2. **Resume/re-dispatch pass:** Continue only after a recorded human response.
    A decline records `host_disclosure_declined`, returns status/exit `77`, and
    sends nothing. On approval, copy only the digest from that human response
-   into `approved_payload_sha256`, then rerun Step 4 from payload
-   materialization. Rebuild, rescan, and snapshot the same ordered bytes and
-   verify them against the recorded approved digest immediately before contact.
+   into `approved_request_envelope_sha256`, then rerun Step 4. Rebuild, rescan,
+   rerender, and verify the envelope immediately before contact.
 
-Never self-populate `approved_payload_sha256` from `PAYLOAD_SHA256`, infer
+Never self-populate `approved_request_envelope_sha256` from the rendered digest, infer
 approval from general OpenRouter permission, or continue to the wrapper during
 the preparation pass. The recorded human response, not the command or child
 runner, is the authority.
@@ -135,20 +143,21 @@ runner, is the authority.
 AUTHORIZATION_MODE=exact-digest
 case "$AUTHORIZATION_MODE" in
   exact-digest)
-    [ -n "${approved_payload_sha256:-}" ] || {
-      printf '{"status":"approval_required","payloadSha256":"%s","authority":"user"}\n' \
-        "$PAYLOAD_SHA256"
+    [ -n "${approved_request_envelope_sha256:-}" ] || {
+      printf '{"status":"approval_required","requestEnvelopeSha256":"%s","authority":"user"}\n' \
+        "$REQUEST_ENVELOPE_SHA256"
       exit 78
     }
-    "$AUTHORIZATION_PATH" verify --manifest "$AUTHORIZATION_FILE" \
-      --approved-sha256 "$approved_payload_sha256" \
-      --content-file "$SYSTEM_FILE" --content-file "$PROMPT_FILE"
+    "$AUTHORIZATION_PATH" verify-envelope --manifest "$AUTHORIZATION_FILE" \
+      --approved-sha256 "$approved_request_envelope_sha256" \
+      --request-file "$REQUEST_ENVELOPE_FILE"
     ;;
   *) echo "OpenRouter host authority unavailable" >&2; exit 77 ;;
 esac
 
 RESULT=$(env -u OPENROUTER_SYSTEM OPENROUTER_SYSTEM_FILE="$SYSTEM_FILE" \
   OPENROUTER_AUTHORIZATION_MODE="$AUTHORIZATION_MODE" \
+  OPENROUTER_APPROVED_REQUEST_ENVELOPE_SHA256="$approved_request_envelope_sha256" \
   OPENROUTER_WORKLOAD=direct \
   OPENROUTER_RECEIPT_FILE="$RECEIPT_FILE" \
   bash "$WRAPPER_PATH" "${MODEL}" - "${TIMEOUT}" "${FALLBACK_MODEL:-}" < "$PROMPT_FILE")

--- a/plugins/openrouter/skills/openrouter-delegate/references/invocation-protocol.md
+++ b/plugins/openrouter/skills/openrouter-delegate/references/invocation-protocol.md
@@ -88,7 +88,11 @@ Payload-Specific Host Authorization before invoking it.
 
 ## Environment Variables
 
-- `OPENROUTER_API_KEY` (required): your OpenRouter API key. Never commit it.
+- `OPENROUTER_API_KEY`: your OpenRouter API key. Never commit it. Mutually
+  exclusive with `OPENROUTER_API_KEY_FILE`.
+- `OPENROUTER_API_KEY_FILE`: preferred for non-interactive harnesses. The
+  wrapper accepts only a non-symlink regular file owned by the current UID with
+  mode 0600 and a single non-empty UTF-8 line.
 - `OPENROUTER_SYSTEM` (default: terse coding assistant): inline system prompt.
 - `OPENROUTER_SYSTEM_FILE`: readable regular file containing the exact system
   prompt bytes. It is mutually exclusive with `OPENROUTER_SYSTEM`; authorized
@@ -140,16 +144,19 @@ the direct API key's workspace.
 ## Host Authorization
 
 Direct interactive `/openrouter` requires user disclosure approval for the
-exact outbound payload. Treat it as byte-bound authority, separate from network
+exact outbound request envelope. Treat it as byte-bound authority, separate from network
 permission:
 
 1. Run `delegation-boundary.sh` first and materialize the exact eligible system
    and user prompt bytes in private temporary files.
-2. Run `payload-authorization.sh snapshot` over the ordered files and request
-   approval for its content-free combined `payloadSha256`.
-3. Immediately before transmission, run `payload-authorization.sh verify` with
-   the user-approved digest and the same ordered files. Any mutation,
-   reordering, or membership change requires fresh authorization.
+2. Run the wrapper with `OPENROUTER_REQUEST_ENVELOPE_OUTPUT` to render without
+   provider contact, then run `payload-authorization.sh snapshot-envelope` and
+   request approval for its content-free `requestEnvelopeSha256`.
+3. On resume, repeat the boundary check and rendering, then run
+   `payload-authorization.sh verify-envelope` with the user-approved digest.
+   Pass that digest as `OPENROUTER_APPROVED_REQUEST_ENVELOPE_SHA256`; the wrapper
+   compares it with the exact bytes supplied to curl immediately before contact.
+   Any prompt, model, fallback, routing, or stream-option change requires fresh authorization.
 4. Never retry around a denial or broaden a file-specific authorization. Record
    `host_disclosure_declined` and fall back to Codex.
 

--- a/plugins/openrouter/skills/openrouter-delegate/references/openrouter-wrapper.sh
+++ b/plugins/openrouter/skills/openrouter-delegate/references/openrouter-wrapper.sh
@@ -10,7 +10,11 @@
 #     <prompt|->  literal prompt, or "-" to read prompt from stdin
 #
 # Env:
-#   OPENROUTER_API_KEY   required
+#   OPENROUTER_API_KEY   required unless OPENROUTER_API_KEY_FILE is used
+#   OPENROUTER_API_KEY_FILE
+#                       optional regular, non-symlink key file owned by the
+#                       current UID with mode 0600; mutually exclusive with
+#                       OPENROUTER_API_KEY
 #   OPENROUTER_SYSTEM    optional system prompt (default: terse coding assistant)
 #   OPENROUTER_SYSTEM_FILE
 #                       optional byte-preserving system prompt file; mutually
@@ -132,10 +136,55 @@ for candidate in "$MODEL" "$FALLBACK"; do
       ;;
   esac
 done
-[ -z "${OPENROUTER_API_KEY:-}" ] && {
-  echo "### RUNNER FAILURE: OPENROUTER_API_KEY unset" >&2
-  exit 1
-}
+if [ -n "${OPENROUTER_API_KEY:-}" ] && [ -n "${OPENROUTER_API_KEY_FILE:-}" ]; then
+  echo "### RUNNER FAILURE: OPENROUTER_API_KEY and OPENROUTER_API_KEY_FILE are mutually exclusive" >&2
+  exit 2
+fi
+if [ -z "${OPENROUTER_API_KEY:-}" ]; then
+  [ -n "${OPENROUTER_API_KEY_FILE:-}" ] || {
+    echo "### RUNNER FAILURE: OPENROUTER_API_KEY or OPENROUTER_API_KEY_FILE required" >&2
+    exit 1
+  }
+  [ -x /usr/bin/python3 ] || {
+    echo "### RUNNER FAILURE: /usr/bin/python3 required to validate OPENROUTER_API_KEY_FILE" >&2
+    exit 1
+  }
+  OPENROUTER_API_KEY="$(/usr/bin/python3 -I - "$OPENROUTER_API_KEY_FILE" <<'PY'
+import os
+import stat
+import sys
+
+path = sys.argv[1]
+try:
+    metadata = os.lstat(path)
+    if not stat.S_ISREG(metadata.st_mode) or stat.S_ISLNK(metadata.st_mode):
+        raise ValueError
+    if metadata.st_uid != os.getuid() or stat.S_IMODE(metadata.st_mode) != 0o600:
+        raise ValueError
+    descriptor = os.open(path, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0))
+    try:
+        opened = os.fstat(descriptor)
+        if (opened.st_dev, opened.st_ino) != (metadata.st_dev, metadata.st_ino):
+            raise ValueError
+        value = os.read(descriptor, 8193)
+    finally:
+        os.close(descriptor)
+    if value.endswith(b"\r\n"):
+        value = value[:-2]
+    elif value.endswith(b"\n"):
+        value = value[:-1]
+    if not value or len(value) > 8192 or b"\n" in value or b"\r" in value or b"\0" in value:
+        raise ValueError
+    sys.stdout.write(value.decode("utf-8"))
+except (OSError, UnicodeDecodeError, ValueError):
+    raise SystemExit(1)
+PY
+)" || {
+    echo "### RUNNER FAILURE: OPENROUTER_API_KEY_FILE must be a non-symlink regular file owned by the current UID with mode 0600 and one non-empty line" >&2
+    exit 1
+  }
+fi
+export OPENROUTER_API_KEY
 
 PRODUCTION_BASE="https://openrouter.ai/api/v1"
 BASE="${OPENROUTER_BASE:-$PRODUCTION_BASE}"

--- a/plugins/openrouter/skills/openrouter/SKILL.md
+++ b/plugins/openrouter/skills/openrouter/SKILL.md
@@ -49,11 +49,13 @@ Extract the prompt and optional `--model` flag from the user's input.
 
 ### Step 2: Check Prerequisites
 
-Verify `OPENROUTER_API_KEY` is set:
+Verify either `OPENROUTER_API_KEY` or `OPENROUTER_API_KEY_FILE` is set. The
+file form is preferred for non-interactive harnesses and is validated by the
+wrapper as a non-symlink regular file owned by the current UID with mode 0600:
 
 ```bash
-if [ -z "${OPENROUTER_API_KEY:-}" ]; then
-  echo "OPENROUTER_API_KEY not set. Export it before using /openrouter."
+if [ -z "${OPENROUTER_API_KEY:-}" ] && [ -z "${OPENROUTER_API_KEY_FILE:-}" ]; then
+  echo "OPENROUTER_API_KEY or OPENROUTER_API_KEY_FILE required."
   exit 1
 fi
 ```
@@ -105,7 +107,8 @@ PROMPT_FILE=$(mktemp)
 SYSTEM_FILE=$(mktemp)
 RECEIPT_FILE=$(mktemp)
 AUTHORIZATION_FILE=$(mktemp)
-trap 'rm -f "$PROMPT_FILE" "$SYSTEM_FILE" "$RECEIPT_FILE" "$AUTHORIZATION_FILE"' EXIT
+REQUEST_ENVELOPE_FILE=$(mktemp)
+trap 'rm -f "$PROMPT_FILE" "$SYSTEM_FILE" "$RECEIPT_FILE" "$AUTHORIZATION_FILE" "$REQUEST_ENVELOPE_FILE"' EXIT
 printf '%s' "$USER_PROMPT" > "$PROMPT_FILE"
 printf '%s' "${OPENROUTER_SYSTEM:-You are a terse, precise coding assistant. Output only what was asked.}" > "$SYSTEM_FILE"
 if ! "$BOUNDARY_PATH" --mode artifact-delegation \
@@ -115,33 +118,38 @@ if ! "$BOUNDARY_PATH" --mode artifact-delegation \
   exit 1
 fi
 
-PAYLOAD_SHA256=$("$AUTHORIZATION_PATH" snapshot \
-  --output "$AUTHORIZATION_FILE" \
-  --content-file "$SYSTEM_FILE" --content-file "$PROMPT_FILE")
+env -u OPENROUTER_SYSTEM OPENROUTER_SYSTEM_FILE="$SYSTEM_FILE" \
+  OPENROUTER_AUTHORIZATION_MODE=exact-digest \
+  OPENROUTER_WORKLOAD=direct \
+  OPENROUTER_RECEIPT_FILE="$RECEIPT_FILE" \
+  OPENROUTER_REQUEST_ENVELOPE_OUTPUT="$REQUEST_ENVELOPE_FILE" \
+  bash "$WRAPPER_PATH" "${MODEL}" - "${TIMEOUT}" "${FALLBACK_MODEL:-}" < "$PROMPT_FILE"
+REQUEST_ENVELOPE_SHA256=$("$AUTHORIZATION_PATH" snapshot-envelope \
+  --output "$AUTHORIZATION_FILE" --request-file "$REQUEST_ENVELOPE_FILE")
 ```
 
 Direct interactive `/openrouter` supports only `exact-digest` until the
 external Workflow Authority Broker is installed and integrated. Immediately
-before calling the wrapper, authorize the unchanged payload through the
-payload-specific human gate. Caller-selected `trusted-boundary` is unavailable
+before provider contact, authorize the exact rendered request envelope through
+the payload-specific human gate. The envelope binds the system/user bytes,
+model candidates, provider routing, and streaming parameters. Caller-selected `trusted-boundary` is unavailable
 and must not be treated as authority.
 
 In `exact-digest` mode this is a two-pass workflow:
 
-1. **Preparation pass:** Materialize, disclosure-screen, and snapshot the exact
-   ordered bytes. If no recorded human decision exists for that digest, emit
+1. **Preparation pass:** Materialize, disclosure-screen, render, and snapshot
+   the exact request-envelope bytes. If no recorded human decision exists, emit
    `approval_required` with status/exit `78`, stop before the wrapper, and ask
-   the human with `AskUserQuestion` (or a normal chat question when that tool is
-   unavailable) to approve or decline that exact digest. End the current turn;
+   the human with `AskUserQuestion` (or a normal chat question when unavailable)
+   to approve or decline that `requestEnvelopeSha256`. End the current turn;
    approval pending is neither success nor provider failure.
 2. **Resume/re-dispatch pass:** Continue only after a recorded human response.
    A decline records `host_disclosure_declined`, returns status/exit `77`, and
    sends nothing. On approval, copy only the digest from that human response
-   into `approved_payload_sha256`, then rerun Step 4 from payload
-   materialization. Rebuild, rescan, and snapshot the same ordered bytes and
-   verify them against the recorded approved digest immediately before contact.
+   into `approved_request_envelope_sha256`, then rerun Step 4. Rebuild, rescan,
+   rerender, and verify the envelope immediately before contact.
 
-Never self-populate `approved_payload_sha256` from `PAYLOAD_SHA256`, infer
+Never self-populate `approved_request_envelope_sha256` from the rendered digest, infer
 approval from general OpenRouter permission, or continue to the wrapper during
 the preparation pass. The recorded human response, not the command or child
 runner, is the authority.
@@ -150,20 +158,21 @@ runner, is the authority.
 AUTHORIZATION_MODE=exact-digest
 case "$AUTHORIZATION_MODE" in
   exact-digest)
-    [ -n "${approved_payload_sha256:-}" ] || {
-      printf '{"status":"approval_required","payloadSha256":"%s","authority":"user"}\n' \
-        "$PAYLOAD_SHA256"
+    [ -n "${approved_request_envelope_sha256:-}" ] || {
+      printf '{"status":"approval_required","requestEnvelopeSha256":"%s","authority":"user"}\n' \
+        "$REQUEST_ENVELOPE_SHA256"
       exit 78
     }
-    "$AUTHORIZATION_PATH" verify --manifest "$AUTHORIZATION_FILE" \
-      --approved-sha256 "$approved_payload_sha256" \
-      --content-file "$SYSTEM_FILE" --content-file "$PROMPT_FILE"
+    "$AUTHORIZATION_PATH" verify-envelope --manifest "$AUTHORIZATION_FILE" \
+      --approved-sha256 "$approved_request_envelope_sha256" \
+      --request-file "$REQUEST_ENVELOPE_FILE"
     ;;
   *) echo "OpenRouter host authority unavailable" >&2; exit 77 ;;
 esac
 
 RESULT=$(env -u OPENROUTER_SYSTEM OPENROUTER_SYSTEM_FILE="$SYSTEM_FILE" \
   OPENROUTER_AUTHORIZATION_MODE="$AUTHORIZATION_MODE" \
+  OPENROUTER_APPROVED_REQUEST_ENVELOPE_SHA256="$approved_request_envelope_sha256" \
   OPENROUTER_WORKLOAD=direct \
   OPENROUTER_RECEIPT_FILE="$RECEIPT_FILE" \
   bash "$WRAPPER_PATH" "${MODEL}" - "${TIMEOUT}" "${FALLBACK_MODEL:-}" < "$PROMPT_FILE")

--- a/tools/test-openrouter-runner-policy.sh
+++ b/tools/test-openrouter-runner-policy.sh
@@ -16,6 +16,7 @@ BOUNDARY="$REPO_ROOT/plugins/openrouter/skills/openrouter-delegate/references/de
 WRAPPER="$REPO_ROOT/plugins/openrouter/skills/openrouter-delegate/references/openrouter-wrapper.sh"
 AUTHORIZATION="$REPO_ROOT/plugins/openrouter/skills/openrouter-delegate/references/payload-authorization.sh"
 RUNNER_BATCH_AUTHORIZATION="$REPO_ROOT/plugins/openrouter/skills/openrouter-delegate/references/runner-batch-authorization.sh"
+DIRECT_COMMAND="$REPO_ROOT/plugins/openrouter/commands/openrouter.md"
 
 FIXTURE_ROOT="$(mktemp -d)"
 FIXTURE_ROOT="$(cd "$FIXTURE_ROOT" && pwd -P)"
@@ -100,6 +101,25 @@ expect_rc 2 'native-vendor-origin invariant' 'mixed-case wrapper origin' \
   env OPENROUTER_API_KEY=fixture "$WRAPPER" Anthropic/claude-test prompt
 expect_rc 2 'native-vendor-origin invariant' 'mixed-case exec origin' \
   "$EXEC_RUNNER" --dry-run --model Anthropic/claude-test
+
+printf '%s\n' test > "$FIXTURE_ROOT/openrouter-api-key"
+chmod 600 "$FIXTURE_ROOT/openrouter-api-key"
+expect_rc 1 'transport error' 'secure API key file reaches the transport boundary' \
+  env -u OPENROUTER_API_KEY OPENROUTER_API_KEY_FILE="$FIXTURE_ROOT/openrouter-api-key" \
+    OPENROUTER_BASE=http://127.0.0.1:9/v1 \
+    "$WRAPPER" moonshotai/kimi-k3 prompt
+expect_rc 2 'mutually exclusive' 'inline and file API keys cannot conflict' \
+  env OPENROUTER_API_KEY=test OPENROUTER_API_KEY_FILE="$FIXTURE_ROOT/openrouter-api-key" \
+    "$WRAPPER" moonshotai/kimi-k3 prompt
+chmod 644 "$FIXTURE_ROOT/openrouter-api-key"
+expect_rc 1 'mode 0600' 'API key file rejects broad permissions' \
+  env -u OPENROUTER_API_KEY OPENROUTER_API_KEY_FILE="$FIXTURE_ROOT/openrouter-api-key" \
+    "$WRAPPER" moonshotai/kimi-k3 prompt
+chmod 600 "$FIXTURE_ROOT/openrouter-api-key"
+ln -s "$FIXTURE_ROOT/openrouter-api-key" "$FIXTURE_ROOT/openrouter-api-key-link"
+expect_rc 1 'non-symlink regular file' 'API key file rejects symlinks' \
+  env -u OPENROUTER_API_KEY OPENROUTER_API_KEY_FILE="$FIXTURE_ROOT/openrouter-api-key-link" \
+    "$WRAPPER" moonshotai/kimi-k3 prompt
 
 printf '%s\n' 'plugins/openrouter/README.md' > "$FIXTURE_ROOT/safe-files"
 printf '%s\n' 'plugins/openrouter/README.md' '.airlift/uncommitted.patch' > "$FIXTURE_ROOT/mixed-files"
@@ -1167,6 +1187,38 @@ SH
     echo 'runner preparation did not produce a usable envelope and manifest' >&2
     exit 1
   }
+  jq -e '.stream == true and .stream_options.include_usage == true' \
+    "$ENVELOPE_REQUEST" >/dev/null || {
+    echo 'canonical envelope omitted fixed streaming parameters' >&2
+    exit 1
+  }
+
+  for mutation in prompt system fallback routing; do
+    MUTATED_REQUEST="$FIXTURE_ROOT/envelope-$mutation.json"
+    case "$mutation" in
+      prompt)
+        MUTATED_SYSTEM="$ENVELOPE_SYSTEM"; MUTATED_PROMPT="$ENVELOPE_PROMPT changed"
+        MUTATED_FALLBACK=""; MUTATED_SORT="" ;;
+      system)
+        MUTATED_SYSTEM="$ENVELOPE_SYSTEM changed"; MUTATED_PROMPT="$ENVELOPE_PROMPT"
+        MUTATED_FALLBACK=""; MUTATED_SORT="" ;;
+      fallback)
+        MUTATED_SYSTEM="$ENVELOPE_SYSTEM"; MUTATED_PROMPT="$ENVELOPE_PROMPT"
+        MUTATED_FALLBACK="z-ai/glm-5.2"; MUTATED_SORT="" ;;
+      routing)
+        MUTATED_SYSTEM="$ENVELOPE_SYSTEM"; MUTATED_PROMPT="$ENVELOPE_PROMPT"
+        MUTATED_FALLBACK=""; MUTATED_SORT="latency" ;;
+    esac
+    env OPENROUTER_API_KEY=test OPENROUTER_BASE=http://127.0.0.1:9/v1 \
+      OPENROUTER_SYSTEM="$MUTATED_SYSTEM" OPENROUTER_PROVIDER_SORT="$MUTATED_SORT" \
+      OPENROUTER_REQUEST_ENVELOPE_OUTPUT="$MUTATED_REQUEST" \
+      "$CLOCK_WRAPPER" moonshotai/kimi-k3 "$MUTATED_PROMPT" 3600 "$MUTATED_FALLBACK"
+    expect_rc 2 'request envelope changed after authorization snapshot' \
+      "exact-digest rejects a $mutation mutation" \
+      "$CLOCK_AUTHORIZATION" verify-envelope \
+        --manifest "$ENVELOPE_MANIFEST" --approved-sha256 "$ENVELOPE_DIGEST" \
+        --request-file "$MUTATED_REQUEST"
+  done
   ENVELOPE_INSPECTION="$(jq -er '.inspectionPath | select(type == "string" and length > 0)' \
     "$ENVELOPE_MANIFEST")" || {
     echo 'canonical envelope manifest did not retain an operator inspection path' >&2
@@ -2325,5 +2377,13 @@ fi
 # empty or unexpected state is not an absent broker.
 grep -Fq 'broker state unresolved; interim mode withheld' "$WRAPPER"
 grep -Fq 'broker state unresolved; interim mode withheld' "$AUTHORIZATION"
+grep -Fq 'OPENROUTER_REQUEST_ENVELOPE_OUTPUT="$REQUEST_ENVELOPE_FILE"' "$DIRECT_COMMAND"
+grep -Fq 'snapshot-envelope' "$DIRECT_COMMAND"
+grep -Fq 'verify-envelope' "$DIRECT_COMMAND"
+grep -Fq 'OPENROUTER_APPROVED_REQUEST_ENVELOPE_SHA256="$approved_request_envelope_sha256"' "$DIRECT_COMMAND"
+if grep -Fq 'approved_payload_sha256' "$DIRECT_COMMAND"; then
+  echo 'direct OpenRouter command still documents the obsolete prompt-only approval' >&2
+  exit 1
+fi
 
 printf '  OK    OpenRouter threat/content and output-boundary fixtures pass\n'


### PR DESCRIPTION
## Outcome

- authorize one exact rendered OpenRouter request envelope, binding messages, models, fallback, provider routing, and streaming parameters
- support a validated owner-only `OPENROUTER_API_KEY_FILE` for non-interactive harnesses
- add drift and key-file security regressions
- bump OpenRouter to 1.11.6 and regenerate Codex surfaces

## Exact head

`a79fc936f395bd3598e36609747f1f845946b3af`

## Verification

- `bash -n` on the wrapper
- `./tools/test-openrouter-runner-policy.sh`
- manifest and command-alias generation checks
- dual compatibility and dependency checks
- combined four-PR integration tree: `./tools/validate-composition.sh --all` passed
- live exact-envelope smoke evidence recorded by the implementation session

## Boundary

The key remains owner-only and is never printed. Exact-digest mode refuses prompt, system, model, fallback, or routing drift before provider contact.