### PR TITLE
fix(workflow-authority): accept packaged production root mode

### DIFF
--- a/native/workflow-authority/internal/provider/credential.go
+++ b/native/workflow-authority/internal/provider/credential.go
@@ -123,7 +123,11 @@ func (r FileCredentialReader) Read(ctx context.Context) (*Credential, error) {
 }
 
 func openProductionRoot(owner uint32) (*os.Root, error) {
-	root, err := os.OpenRoot(productionRootPath)
+	return openProductionRootAt(productionRootPath, owner)
+}
+
+func openProductionRootAt(path string, owner uint32) (*os.Root, error) {
+	root, err := os.OpenRoot(path)
 	if err != nil {
 		return nil, ErrStartup
 	}
@@ -134,7 +138,9 @@ func openProductionRoot(owner uint32) (*os.Root, error) {
 	}
 	info, statErr := f.Stat()
 	_ = f.Close()
-	if statErr != nil || !info.IsDir() || info.Mode().Perm() != 0o700 || !ownedBy(info, owner) {
+	// Public trust below this root must remain traversable; secret descendants
+	// retain their separate 0700 directory and 0600 file requirements.
+	if statErr != nil || info.Mode() != os.ModeDir|0o755 || !ownedBy(info, owner) {
 		root.Close()
 		return nil, ErrStartup
 	}

--- a/native/workflow-authority/internal/provider/credential_test.go
+++ b/native/workflow-authority/internal/provider/credential_test.go
@@ -1,0 +1,48 @@
+package provider
+
+import (
+	"os"
+	"testing"
+)
+
+func TestOpenProductionRootAtRequiresPackagedModeAndOwner(t *testing.T) {
+	path := t.TempDir()
+	owner := uint32(os.Geteuid())
+
+	if err := os.Chmod(path, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	root, err := openProductionRootAt(path, owner)
+	if err != nil {
+		t.Fatalf("root-owned 0755 directory rejected: %v", err)
+	}
+	if err := root.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	for name, mode := range map[string]os.FileMode{
+		"private":        0o700,
+		"group-writable": 0o775,
+		"other-writable": 0o757,
+		"sticky":         os.ModeSticky | 0o755,
+	} {
+		t.Run(name, func(t *testing.T) {
+			if err := os.Chmod(path, mode); err != nil {
+				t.Fatal(err)
+			}
+			if root, err := openProductionRootAt(path, owner); err == nil {
+				_ = root.Close()
+				t.Fatalf("mode %04o accepted", mode)
+			}
+		})
+	}
+
+	if err := os.Chmod(path, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	wrongOwner := owner + 1
+	if root, err := openProductionRootAt(path, wrongOwner); err == nil {
+		_ = root.Close()
+		t.Fatal("wrong ownership accepted")
+	}
+}


### PR DESCRIPTION
## Summary

- align production-root validation with the packaged root-owned exact 0755 contract
- keep fixed production paths and stricter 0700/0600 protections on credential descendants
- add focused regression coverage for accepted ownership/mode and rejected incompatible, writable, special-bit, and ownership cases

## Verification

- `git diff --check`
- `WORKFLOW_AUTHORITY_REQUIRE_PRODUCTION_BUILD=1 ./tools/validate-workflow-authority.sh`
- `./tools/validate-composition.sh --all`
- dm-review security-sensitive review: three P3 findings fixed; final local lanes clean
- independent-family security sign-off was unavailable because no separately authorized provider payload was available

## Operational scope

No binaries or units were installed, no users or groups were created, no authenticator or credential was provisioned, no services were enabled or started, and no live provider calls were made.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Design-Machines-Studio/codesmith/depot/pr/44"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789132774&installation_model_id=428410&pr_number=44&repository=Design-Machines-Studio%2Fdepot&return_to=https%3A%2F%2Fgithub.com%2FDesign-Machines-Studio%2Fdepot%2Fpull%2F44&signature=880a00c6b45e512154264d3e067e954ccde39d6a1b85d5c18820755057aa6d74"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->