### PR TITLE
fix(pipeline): isolate usage-probe fixtures from production

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -355,7 +355,7 @@
     {
       "name": "pipeline",
       "source": "./plugins/pipeline",
-      "version": "1.48.1",
+      "version": "1.48.2",
       "author": {
         "name": "Design Machines",
         "url": "https://designmachines.studio"

--- a/plugins/pipeline/.claude-plugin/plugin.json
+++ b/plugins/pipeline/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "pipeline",
   "description": "Autonomous feature development pipeline with fresh executable tiered verification, approved decision-depth profiles, bounded feedback, browser recovery, risk-tiered review, and isolated execution",
-  "version": "1.48.1",
+  "version": "1.48.2",
   "author": {
     "name": "Design Machines",
     "url": "https://designmachines.io"

--- a/plugins/pipeline/.codex-plugin/plugin.json
+++ b/plugins/pipeline/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pipeline",
-  "version": "1.48.1",
+  "version": "1.48.2",
   "description": "Autonomous feature development pipeline with fresh executable tiered verification, approved decision-depth profiles, bounded feedback, browser recovery, risk-tiered review, and isolated execution",
   "author": {
     "name": "Design Machines",

--- a/plugins/pipeline/references/usage-probe.sh
+++ b/plugins/pipeline/references/usage-probe.sh
@@ -24,18 +24,13 @@ PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
 export PATH
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-PROBE_SOURCE="live"
-if [ "${USAGE_PROBE_TEST_MODE:-0}" = "1" ]; then
-  PROBE_SOURCE="fixture"
-  echo "usage-probe: TEST FIXTURE MODE active; headroom is not live capacity evidence" >&2
-fi
 
 # Every emission path below builds JSON with jq. Without jq the script would
 # print a blank line and exit 0, and the consumer would see an unrecognized
 # shape rather than the mandated unknown object. Absent jq is exactly the
 # "tool is absent" case, so answer it in jq-free literal form and stop.
 if ! command -v jq >/dev/null 2>&1; then
-  printf '%s\n' "{\"probe_source\":\"$PROBE_SOURCE\",\"codex\":{\"state\":\"unknown\",\"remaining_pct\":0,\"window\":\"unknown\"},\"claude\":{\"state\":\"unknown\",\"remaining_pct\":0,\"window\":\"unknown\"},\"openrouter\":{\"state\":\"unknown\",\"balance_usd\":null}}"
+  printf '%s\n' '{"probe_source":"live","codex":{"state":"unknown","remaining_pct":0,"window":"unknown"},"claude":{"state":"unknown","remaining_pct":0,"window":"unknown"},"openrouter":{"state":"unknown","balance_usd":null}}'
   exit 0
 fi
 
@@ -97,58 +92,13 @@ aggregate_windows() {
     '
 }
 
-claude_statusline_input() {
-  # These three inputs are CALLER-SUPPLIED usage numbers, so they are test
-  # fixtures, not evidence. Accepting them in normal operation would let anyone
-  # who controls the environment assert used_percentage 0 for both required
-  # windows and report Claude "ok" while its real headroom is unknown or
-  # exhausted. That is the optimistic direction this file exists to prevent,
-  # so they are honoured only under an explicit test mode.
-  #
-  # Outside test mode this probe has no live Claude source: it is not a
-  # statusLine command and cannot see the runtime's rate_limits payload. It
-  # therefore reports Claude as unknown, which resolves to no headroom. That is
-  # the truthful answer, not a degradation.
-  [ "${USAGE_PROBE_TEST_MODE:-0}" = "1" ] || return 0
-  if [ -n "${USAGE_PROBE_CLAUDE_STATUSLINE_JSON:-}" ]; then
-    printf '%s' "$USAGE_PROBE_CLAUDE_STATUSLINE_JSON"
-  elif [ -n "${USAGE_PROBE_CLAUDE_STATUSLINE_FILE:-}" ] \
-       && [ -r "$USAGE_PROBE_CLAUDE_STATUSLINE_FILE" ]; then
-    command cat "$USAGE_PROBE_CLAUDE_STATUSLINE_FILE" 2>/dev/null || true
-  elif [ "${USAGE_PROBE_CLAUDE_STATUSLINE_STDIN:-0}" = "1" ] && [ ! -t 0 ]; then
-    # Only read stdin when the caller explicitly asks. Orchestrators routinely
-    # spawn scripts with an open-but-idle pipe on fd 0, and a bare `cat` there
-    # blocks until the writer closes -- hanging the probe rather than
-    # reporting unknown.
-    command cat 2>/dev/null || true
-  fi
-}
-
 claude_json() {
-  local statusline="" observations='[]'
-  statusline="$(claude_statusline_input)"
-  if [ -n "$statusline" ]; then
-    observations="$(printf '%s' "$statusline" | jq -c '
-      [ {window:"five_hour", value:(.rate_limits.five_hour // null)},
-        {window:"weekly", value:(.rate_limits.weekly // .rate_limits.seven_day // null)} ]
-      | map(select(.value != null and (.value.used_percentage | type) == "number")
-        | {window:.window, remaining_pct:([0, (100 - .value.used_percentage), 100] | sort | .[1])})
-    ' 2>/dev/null)" || observations='[]'
-  fi
-  [ -n "$observations" ] || observations='[]'
-
-  aggregate_windows '["five_hour","weekly"]' "$observations"
+  # This standalone probe cannot see Claude's runtime statusLine payload.
+  # Without a live source, both required windows remain conservatively unknown.
+  aggregate_windows '["five_hour","weekly"]' '[]'
 }
 
 codex_app_server_output() {
-  # The injected response is a deterministic parser fixture only. Production
-  # always obtains these bytes from the Codex app server itself.
-  if [ "${USAGE_PROBE_TEST_MODE:-0}" = "1" ] \
-     && [ -n "${USAGE_PROBE_CODEX_APP_SERVER_JSON:-}" ]; then
-    printf '%s\n' "$USAGE_PROBE_CODEX_APP_SERVER_JSON"
-    return 0
-  fi
-
   command -v codex >/dev/null 2>&1 || return 1
   {
     printf '%s\n' \
@@ -272,28 +222,18 @@ normalize_profile_probe() {
 
 operator_profile_path() {
   local root="" common_dir="" root_physical="" candidate="" candidate_parent=""
-  local resolved_parent="" expected_parent="" test_override=0
-  # An environment-selected profile path is a test fixture, not production
-  # input: the profile supplies argv this script executes, so letting the
-  # environment point it at any untracked file defeats the "developer-local
-  # config" boundary the contract claims. In normal operation only the
-  # canonical repository path is resolved.
-  if [ "${USAGE_PROBE_TEST_MODE:-0}" = "1" ] && [ -n "${DM_OPERATOR_PROFILE_FILE:-}" ]; then
-    candidate="$DM_OPERATOR_PROFILE_FILE"
-    test_override=1
-  else
-    # Resolve host-owned local configuration from the COMMON checkout, never
-    # from the ambient linked worktree. Pipeline chunk output lives in linked
-    # worktrees and must not be able to plant executable local configuration
-    # merely by writing an ignored `.dm` file there.
-    common_dir="$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null)" \
-      || common_dir=""
-    [ -n "$common_dir" ] && [ -d "$common_dir" ] || return 0
-    common_dir="$(cd "$common_dir" 2>/dev/null && pwd -P)" || return 0
-    [ "${common_dir##*/}" = ".git" ] || return 0
-    root="${common_dir%/.git}"
-    candidate="$root/.dm/operator-profile.local.json"
-  fi
+  local resolved_parent="" expected_parent=""
+  # Resolve host-owned local configuration from the COMMON checkout, never
+  # from the ambient linked worktree. Pipeline chunk output lives in linked
+  # worktrees and must not be able to plant executable local configuration
+  # merely by writing an ignored `.dm` file there.
+  common_dir="$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null)" \
+    || common_dir=""
+  [ -n "$common_dir" ] && [ -d "$common_dir" ] || return 0
+  common_dir="$(cd "$common_dir" 2>/dev/null && pwd -P)" || return 0
+  [ "${common_dir##*/}" = ".git" ] || return 0
+  root="${common_dir%/.git}"
+  candidate="$root/.dm/operator-profile.local.json"
   # A profile supplies probe argv that this script executes, so the file itself
   # is a trust boundary. It is legitimate only as untracked developer-local
   # config.
@@ -301,38 +241,32 @@ operator_profile_path() {
   # Refuse a symlink: it can redirect the read outside the checkout.
   [ -L "$candidate" ] && return 0
   [ -f "$candidate" ] || return 0
-  if [ "$test_override" -eq 0 ]; then
-    # `-L "$candidate"` checks only the final component. A tracked `.dm`
-    # symlink can otherwise redirect the regular profile file to a different
-    # repository path while the literal `.dm/operator-profile.local.json`
-    # path remains absent from the index. Compare physical parents so every
-    # intermediate component is covered without trusting `realpath(1)` to be
-    # present on stock macOS.
-    root_physical="$(cd "$root" 2>/dev/null && pwd -P)" || return 0
-    candidate_parent="$(dirname "$candidate")"
-    resolved_parent="$(cd "$candidate_parent" 2>/dev/null && pwd -P)" || return 0
-    expected_parent="$root_physical/.dm"
-    [ "$resolved_parent" = "$expected_parent" ] || return 0
-    candidate="$resolved_parent/operator-profile.local.json"
-  fi
+  # `-L "$candidate"` checks only the final component. A tracked `.dm`
+  # symlink can otherwise redirect the regular profile file to a different
+  # repository path while the literal `.dm/operator-profile.local.json`
+  # path remains absent from the index. Compare physical parents so every
+  # intermediate component is covered without trusting `realpath(1)` to be
+  # present on stock macOS.
+  root_physical="$(cd "$root" 2>/dev/null && pwd -P)" || return 0
+  candidate_parent="$(dirname "$candidate")"
+  resolved_parent="$(cd "$candidate_parent" 2>/dev/null && pwd -P)" || return 0
+  expected_parent="$root_physical/.dm"
+  [ "$resolved_parent" = "$expected_parent" ] || return 0
+  candidate="$resolved_parent/operator-profile.local.json"
   # Refuse a git-TRACKED profile. This is the live vector, not a theoretical
   # one: .gitignore is routinely defeated by `git add -f` in this repository
   # (several plans/ subtrees are ignored and tracked anyway), so a branch could
   # ship .dm/operator-profile.local.json and have every later run execute its
   # probes. An ignored-but-committed file is not developer-local config.
-  if [ "$test_override" -eq 0 ]; then
-    git -C "$root" ls-files --error-unmatch -- \
-      .dm/operator-profile.local.json >/dev/null 2>&1 && return 0
-  elif git ls-files --error-unmatch -- "$candidate" >/dev/null 2>&1; then
-    return 0
-  fi
+  git -C "$root" ls-files --error-unmatch -- \
+    .dm/operator-profile.local.json >/dev/null 2>&1 && return 0
   printf '%s\n' "$candidate"
 }
 
 profile="$(operator_profile_path)"
-result="$(jq -cn --arg source "$PROBE_SOURCE" --argjson codex "$(codex_json)" \
+result="$(jq -cn --argjson codex "$(codex_json)" \
   --argjson claude "$(claude_json)" --argjson openrouter "$(openrouter_json)" \
-  '{probe_source:$source,codex:$codex,claude:$claude,openrouter:$openrouter}')"
+  '{probe_source:"live",codex:$codex,claude:$claude,openrouter:$openrouter}')"
 
 if [ -n "$profile" ] && [ -r "$profile" ] \
    && jq -e 'type == "object"

--- a/tools/run-usage-probe-fixture.sh
+++ b/tools/run-usage-probe-fixture.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# run-usage-probe-fixture.sh -- deterministic, fixture-only usage-probe runner.
+#
+# Usage: run-usage-probe-fixture.sh [codex-app-server-fixture.json]
+# With no argument, fixture bytes are read from stdin. The fixture replaces only
+# the Codex app-server command output; the production probe owns all parsing,
+# aggregation, profile selection, and evidence construction.
+
+set -euo pipefail
+
+PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
+export PATH
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+USAGE_PROBE="$REPO_ROOT/plugins/pipeline/references/usage-probe.sh"
+
+if [ "$#" -gt 1 ]; then
+  echo "usage: $0 [codex-app-server-fixture.json]" >&2
+  exit 2
+fi
+if ! command -v jq >/dev/null 2>&1; then
+  echo "usage-probe fixture wrapper: jq required" >&2
+  exit 2
+fi
+
+fixture_root="$(mktemp -d "${TMPDIR:-/tmp}/usage-probe-fixture.XXXXXX")"
+fixture_tmp="$fixture_root/codex-app-server.json"
+fixture_repo="$fixture_root/repository"
+trap 'rm -rf "$fixture_root"' EXIT
+
+if [ "$#" -eq 1 ]; then
+  [ -f "$1" ] && [ ! -L "$1" ] && [ -r "$1" ] || {
+    echo "usage-probe fixture wrapper: fixture must be a readable regular file, not a symlink" >&2
+    exit 2
+  }
+  command cat "$1" > "$fixture_tmp"
+else
+  command cat > "$fixture_tmp"
+fi
+
+# Keep the deterministic interface small enough that an accidentally supplied
+# log or stream cannot turn a repository validator into an unbounded probe.
+fixture_bytes="$(wc -c < "$fixture_tmp" | tr -d '[:space:]')"
+case "$fixture_bytes" in
+  ''|*[!0-9]*) echo "usage-probe fixture wrapper: could not size fixture" >&2; exit 2 ;;
+esac
+if [ "$fixture_bytes" -gt 1048576 ]; then
+  echo "usage-probe fixture wrapper: fixture exceeds 1 MiB limit" >&2
+  exit 2
+fi
+
+echo "usage-probe fixture wrapper: FIXTURE-ONLY EVIDENCE; NOT LIVE CAPACITY" >&2
+
+# Bash exports functions to Bash children, so the real production probe sees a
+# fixed test double at `command -v codex` even after it resets PATH. The double
+# accepts only the production app-server invocation and treats fixture bytes as
+# data. It neither evaluates fixture content nor accepts an executable path.
+codex() {
+  [ "$#" -eq 2 ] && [ "$1" = "app-server" ] && [ "$2" = "--stdio" ] \
+    || return 2
+  command cat "$USAGE_PROBE_FIXTURE_BYTES_FILE"
+}
+export -f codex
+export USAGE_PROBE_FIXTURE_BYTES_FILE="$fixture_tmp"
+
+# No configured OpenRouter credential reaches the production child, so this
+# test-only runner cannot make the probe's one network request.
+unset OPENROUTER_API_KEY OPENROUTER_API_KEY_FILE OPENROUTER_BUNDLE_RESOLVED
+unset OPENROUTER_BUNDLE_REF OPENROUTER_BUNDLE_VERSION WORKFLOW_KERNEL
+
+# Run from a wrapper-owned empty checkout so a developer's real operator
+# profile cannot execute during deterministic fixture tests.
+git init -q "$fixture_repo"
+probe_output="$(cd "$fixture_repo" && bash "$USAGE_PROBE")"
+printf '%s\n' "$probe_output" | jq -ce '.probe_source = "fixture"'

--- a/tools/validate-dm-review-codex-perspective.sh
+++ b/tools/validate-dm-review-codex-perspective.sh
@@ -361,7 +361,7 @@ require_text "$REPO_ROOT/README.md" 'P3 stays advisory' "README describes propor
 reject_text "$REPO_ROOT/plugins/project-scaffolder/skills/scaffolding/references/claude-md-templates/dm-standard.md" '--allow-defer-p3' "scaffold template retires P3 deferral flag"
 require_text "$REPO_ROOT/plugins/dm-review/.claude-plugin/plugin.json" '"version": "1.60.1"' "canonical dm-review version is 1.60.1"
 require_text "$REPO_ROOT/plugins/dm-review/.codex-plugin/plugin.json" '"version": "1.60.1"' "generated dm-review version is 1.60.1"
-require_text "$REPO_ROOT/plugins/pipeline/.claude-plugin/plugin.json" '"version": "1.48.1"' "canonical Pipeline version is 1.48.1"
+require_text "$REPO_ROOT/plugins/pipeline/.claude-plugin/plugin.json" '"version": "1.48.2"' "canonical Pipeline version is 1.48.2"
 require_text "$REPO_ROOT/plugins/pipeline/.codex-plugin/plugin.json" '"dm-review": ">=1.60.1"' "generated Pipeline dependency floor is current"
 
 printf "Synthesis identity fixtures\n"

--- a/tools/validate-routing-economics.sh
+++ b/tools/validate-routing-economics.sh
@@ -138,6 +138,7 @@ promptcraft="$REPO_ROOT/plugins/pipeline/skills/promptcraft/SKILL.md"
 orchestrator="$REPO_ROOT/plugins/pipeline/agents/workflow/execution-orchestrator.md"
 cascade="$REPO_ROOT/plugins/pipeline/references/cascade-dispatch.sh"
 usage_probe="$REPO_ROOT/plugins/pipeline/references/usage-probe.sh"
+usage_probe_fixture="$REPO_ROOT/tools/run-usage-probe-fixture.sh"
 model_cascade="$REPO_ROOT/plugins/pipeline/references/model-cascade.json"
 harness="$REPO_ROOT/plugins/pipeline/references/harness-profile.json"
 runner="$REPO_ROOT/plugins/pipeline/references/openrouter-exec.sh"
@@ -165,13 +166,21 @@ require_text "$usage_probe" 'select($data.total_usage | type == "number")' "Open
 require_absent "$usage_probe" 'ccusage blocks --json' "Claude probe removes the incomplete ccusage fallback"
 require_absent "$usage_probe" 'suppresses the ccusage fallback' "Claude probe removes stale ccusage control-flow prose"
 require_text "$usage_probe" '.windowDurationMins == 10080' "Codex probe recognizes only the expected weekly duration"
-require_text "$usage_probe" 'TEST FIXTURE MODE active; headroom is not live capacity evidence' \
-  "usage probe visibly marks fixture-sourced capacity"
+require_absent "$usage_probe" 'USAGE_PROBE_TEST_MODE' "production usage probe has no fixture-mode switch"
+require_absent "$usage_probe" 'USAGE_PROBE_CODEX_APP_SERVER_JSON' "production usage probe has no Codex fixture input"
+require_absent "$usage_probe" 'USAGE_PROBE_CLAUDE_STATUSLINE_JSON' "production usage probe has no inline Claude fixture input"
+require_absent "$usage_probe" 'USAGE_PROBE_CLAUDE_STATUSLINE_FILE' "production usage probe has no file-based Claude fixture input"
+require_absent "$usage_probe" 'USAGE_PROBE_CLAUDE_STATUSLINE_STDIN' "production usage probe has no stdin Claude fixture input"
+require_absent "$usage_probe" 'DM_OPERATOR_PROFILE_FILE' "production usage probe has no environment-selected profile path"
+require_absent "$usage_probe" 'TEST FIXTURE MODE' "production usage probe has no fixture branch"
+require_text "$usage_probe_fixture" 'FIXTURE-ONLY EVIDENCE; NOT LIVE CAPACITY' \
+  "test wrapper conspicuously marks fixture-only execution"
+require_text "$usage_probe_fixture" 'bash "$USAGE_PROBE"' \
+  "test wrapper invokes the production usage probe"
 
 codex_expected_windows='{"id":7,"result":{"rateLimits":{"primary":{"usedPercent":10,"windowDurationMins":300},"secondary":{"usedPercent":20,"windowDurationMins":10080}}}}'
-codex_expected_result="$(USAGE_PROBE_TEST_MODE=1 \
-  USAGE_PROBE_CODEX_APP_SERVER_JSON="$codex_expected_windows" \
-  OPENROUTER_API_KEY='' bash "$usage_probe")"
+codex_expected_result="$(printf '%s\n' "$codex_expected_windows" \
+  | bash "$usage_probe_fixture")"
 if printf '%s' "$codex_expected_result" | jq -e '
   .probe_source == "fixture"
     and .codex.state == "ok"
@@ -209,6 +218,63 @@ else
   failures=1
 fi
 
+mkdir -p "$profile_fixture_root/tracked/.dm"
+cat > "$profile_fixture_root/tracked/.dm/operator-profile.local.json" <<'JSON'
+{"operator":"fixture","updated":"2026-08-10","familyPreferenceOrder":[],"neverUse":[],"subscriptions":[{"rail":"tracked","probe":["/usr/bin/printf","{\"state\":\"ok\",\"remaining_pct\":99,\"window\":\"weekly\"}"],"windows":["weekly"]}]}
+JSON
+(
+  cd "$profile_fixture_root/tracked"
+  git init -q
+  git add .dm/operator-profile.local.json
+)
+profile_tracked_result="$(cd "$profile_fixture_root/tracked" && \
+  OPENROUTER_API_KEY='' bash "$usage_probe")"
+if printf '%s' "$profile_tracked_result" | jq -e 'has("tracked") | not' >/dev/null; then
+  printf "  OK    tracked operator profiles are refused\n"
+else
+  printf "  FAIL  tracked operator profiles are refused\n"
+  failures=1
+fi
+
+mkdir -p "$profile_fixture_root/final-symlink/.dm" "$profile_fixture_root/final-symlink-target"
+cat > "$profile_fixture_root/final-symlink-target/operator-profile.local.json" <<'JSON'
+{"operator":"fixture","updated":"2026-08-10","familyPreferenceOrder":[],"neverUse":[],"subscriptions":[{"rail":"final_symlink","probe":["/usr/bin/printf","{\"state\":\"ok\",\"remaining_pct\":99,\"window\":\"weekly\"}"],"windows":["weekly"]}]}
+JSON
+ln -s "$profile_fixture_root/final-symlink-target/operator-profile.local.json" \
+  "$profile_fixture_root/final-symlink/.dm/operator-profile.local.json"
+git -C "$profile_fixture_root/final-symlink" init -q
+profile_final_symlink_result="$(cd "$profile_fixture_root/final-symlink" && \
+  OPENROUTER_API_KEY='' bash "$usage_probe")"
+if printf '%s' "$profile_final_symlink_result" | jq -e 'has("final_symlink") | not' >/dev/null; then
+  printf "  OK    symlinked operator profile files are refused\n"
+else
+  printf "  FAIL  symlinked operator profile files are refused\n"
+  failures=1
+fi
+
+cat > "$profile_fixture_root/retired-probe.sh" <<SH
+#!/bin/sh
+touch "$profile_fixture_root/retired-profile-executed"
+printf '%s\\n' '{"state":"ok","remaining_pct":99,"window":"weekly"}'
+SH
+chmod 755 "$profile_fixture_root/retired-probe.sh"
+cat > "$profile_fixture_root/retired-profile.json" <<'JSON'
+{"operator":"fixture","updated":"2026-08-10","familyPreferenceOrder":[],"neverUse":[],"subscriptions":[{"rail":"retired_env_escape","probe":["RETIRED_PROBE_PATH"],"windows":["weekly"]}]}
+JSON
+sed "s|RETIRED_PROBE_PATH|$profile_fixture_root/retired-probe.sh|" \
+  "$profile_fixture_root/retired-profile.json" > "$profile_fixture_root/retired-profile.ready.json"
+retired_env_result="$(USAGE_PROBE_TEST_MODE=1 \
+  DM_OPERATOR_PROFILE_FILE="$profile_fixture_root/retired-profile.ready.json" \
+  OPENROUTER_API_KEY='' bash "$usage_probe")"
+if printf '%s' "$retired_env_result" | jq -e '
+  .probe_source == "live" and (has("retired_env_escape") | not)
+' >/dev/null && [ ! -e "$profile_fixture_root/retired-profile-executed" ]; then
+  printf "  OK    retired environment pair cannot select or expose an arbitrary profile\n"
+else
+  printf "  FAIL  retired environment pair cannot select or expose an arbitrary profile\n"
+  failures=1
+fi
+
 # A linked worktree is pipeline output, not the owner of executable operator
 # configuration. The common checkout's untracked profile must win, and an
 # equally valid worktree-local profile must remain invisible.
@@ -233,11 +299,10 @@ cat > "$profile_fixture_root/chunk/.dm/operator-profile.local.json" <<JSON
 {"operator":"fixture","updated":"2026-08-10","familyPreferenceOrder":[],"neverUse":[],"subscriptions":[{"rail":"planted","probe":["$profile_fixture_root/probe.sh"],"windows":["weekly"]}]}
 JSON
 profile_worktree_result="$(cd "$profile_fixture_root/chunk" && \
-  USAGE_PROBE_TEST_MODE=1 \
-  USAGE_PROBE_CODEX_APP_SERVER_JSON="$codex_expected_windows" \
   OPENROUTER_API_KEY='' bash "$usage_probe")"
 if printf '%s' "$profile_worktree_result" | jq -e '
-  .common.state == "ok" and (has("planted") | not)
+  .probe_source == "live"
+    and .common.state == "ok" and (has("planted") | not)
 ' >/dev/null; then
   printf "  OK    operator profiles resolve from the common checkout, not chunk worktrees\n"
 else
@@ -246,9 +311,8 @@ else
 fi
 
 codex_unrecognized_window='{"id":7,"result":{"rateLimits":{"primary":{"usedPercent":10,"windowDurationMins":300},"secondary":{"usedPercent":20,"windowDurationMins":1440}}}}'
-codex_unrecognized_result="$(USAGE_PROBE_TEST_MODE=1 \
-  USAGE_PROBE_CODEX_APP_SERVER_JSON="$codex_unrecognized_window" \
-  OPENROUTER_API_KEY='' bash "$usage_probe")"
+codex_unrecognized_result="$(printf '%s\n' "$codex_unrecognized_window" \
+  | bash "$usage_probe_fixture")"
 if printf '%s' "$codex_unrecognized_result" | jq -e '
   .codex.state == "unknown"
     and .codex.window == "weekly"
@@ -258,6 +322,14 @@ if printf '%s' "$codex_unrecognized_result" | jq -e '
   printf "  OK    Codex probe leaves unrecognized durations conservatively unknown\n"
 else
   printf "  FAIL  Codex probe leaves unrecognized durations conservatively unknown\n"
+  failures=1
+fi
+
+production_live_result="$(OPENROUTER_API_KEY='' bash "$usage_probe")"
+if printf '%s' "$production_live_result" | jq -e '.probe_source == "live"' >/dev/null; then
+  printf "  OK    ordinary production usage output remains live evidence\n"
+else
+  printf "  FAIL  ordinary production usage output remains live evidence\n"
   failures=1
 fi
 


### PR DESCRIPTION
## Summary

- remove all fixture/test-mode and environment-selected profile inputs from production `usage-probe.sh`
- add a Bash 3.2-compatible fixture-only wrapper that reuses the production Codex parser and aggregation path
- expand routing-economics regressions for live/fixture provenance, window mapping, profile boundaries, and retired environment inputs
- bump Pipeline 1.48.1 -> 1.48.2 and regenerate the Codex manifest

Closes #25

## Delivery receipt

- Exact head: `d16fbce6374c2e3aba42620f6a628126f214d5c7`
- Requested implementation model: `deepseek/deepseek-v4-flash-0731`
- Requested OpenRouter fallback: `x-ai/grok-4.5`
- Actual implementation model: native Codex `gpt-5.6-sol`
- Implementation fallback: Codex fallback occurred after the bounded adapter rejected the OpenRouter response for missing required generation provenance; Grok fallback was not evidenced
- Implementation OpenRouter usage/cost: unavailable because the rejected response did not yield a valid receipt
- Native supervision: reviewed portability, production/live provenance, no-network fixture isolation, common-checkout selection, tracked/symlink refusal, and negative non-execution coverage; applied bounded repairs and completed delivery
- Kimi review model: `moonshotai/kimi-k3` (no fallback)
- Kimi review usage: 5,939 prompt tokens; 4,018 completion tokens; 9,957 total tokens; $0.0728812
- Kimi result: no findings on retired-variable influence, production profile protections, or simplification. Coverage caveat: the new wrapper was untracked when the review diff was materialized and was therefore omitted from the Kimi payload; native Codex reviewed the wrapper directly. No second paid review call was made.

## Verification

All passed:

- `bash -n plugins/pipeline/references/usage-probe.sh`
- `bash -n tools/run-usage-probe-fixture.sh`
- `git diff --check`
- focused `rg` search proving retired fixture variables are absent from production `usage-probe.sh`
- `./tools/validate-routing-economics.sh`
- `./tools/validate-openrouter-cascade.sh`
- `./tools/validate-openrouter-resolution.sh`
- `./tools/validate-workflow-contracts.sh`
- `./tools/validate-dm-review-codex-perspective.sh`
- `./tools/generate-codex-manifests.py --check`
- `./tools/generate-codex-command-skills.py --check`
- `./tools/validate-dual-compat.sh`
- `./tools/validate-composition.sh --all`

## NOT-COVERED

- Rendered/browser/visual/persona/Datastar verification: `not_applicable` (shell probing and repository test infrastructure only; no served route or rendered output)
- Kimi inspection of the new wrapper file: omitted from its diff payload as described above; covered by native supervision and behavioral validators

## COMMANDS-RUN

Repository setup and delivery included `git fetch --prune origin`, GitHub issue/PR/project inspection, dedicated worktree creation from `origin/main`, Project 1 issue updates, the bounded Pipeline OpenRouter adapter attempt, the focused Kimi review call, manifest generation, the verification commands above, commit, push, and PR creation.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Design-Machines-Studio/codesmith/depot/pr/49"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789192599&installation_model_id=428410&pr_number=49&repository=Design-Machines-Studio%2Fdepot&return_to=https%3A%2F%2Fgithub.com%2FDesign-Machines-Studio%2Fdepot%2Fpull%2F49&signature=11fa6f623e18035cf8b7b6b5e8aa373a4fbf65d480d4ecf87b315614dbff0459"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->