### PR TITLE
feat: clarify human-facing workflow output

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -187,7 +187,7 @@
     {
       "name": "ghostwriter",
       "source": "./plugins/ghostwriter",
-      "version": "3.9.1",
+      "version": "3.10.0",
       "author": {
         "name": "Design Machines"
       },
@@ -281,7 +281,7 @@
     {
       "name": "dm-review",
       "source": "./plugins/dm-review",
-      "version": "1.61.0",
+      "version": "1.62.0",
       "author": {
         "name": "Design Machines",
         "url": "https://designmachines.studio"
@@ -359,7 +359,7 @@
     {
       "name": "pipeline",
       "source": "./plugins/pipeline",
-      "version": "1.50.0",
+      "version": "1.51.0",
       "author": {
         "name": "Design Machines",
         "url": "https://designmachines.studio"

--- a/docs/dependency-graph.md
+++ b/docs/dependency-graph.md
@@ -66,7 +66,7 @@ graph LR
 | dm-review | openrouter | optional | `>=1.14.2` |
 | ghostwriter | design-machines | optional | `>=1.5.0` |
 | ned | superpowers | optional | `>=1.0.0` |
-| pipeline | dm-review | required | `>=1.61.0` |
+| pipeline | dm-review | required | `>=1.62.0` |
 | pipeline | ned | required | `>=1.4.0` |
 | pipeline | workflow-kernel | required | `>=0.16.0` |
 | pipeline | design-machines | optional | `>=1.3.0` |

--- a/plans/depot-efficiency-program.md
+++ b/plans/depot-efficiency-program.md
@@ -10,13 +10,13 @@ external handoff only; it does not duplicate Baseplate's production roadmap.
 
 The current priority order is:
 
-1. **P1 -- proportional scope and review convergence.** Correct Pipeline intake,
-   minimum-adequate planning, adversarial review, and dm-review severity so
-   requested mechanisms do not become architecture by default and supported
-   P1/P2 repairs converge in one batch plus one affected-lane recheck.
-2. **P1 -- clear operator output.** Immediately after the policy correction,
-   ship the smallest usable Publish Preview workflow that gives an operator a
-   clear publication result without reviving its two six-chunk campaigns.
+1. **P1 -- clear human output.** Separate compact operator handoffs from durable
+   voice-check, dm-review, and Pipeline evidence without weakening gates or
+   discarding receipts.
+2. **Successor -- one real cheap-path canary.** Use the next non-sensitive
+   plugin capability/index maintenance change to compare the configured cheap
+   route against native execution with a measured time, cost, and quality
+   receipt before changing routing policy.
 3. **Evidence-gated follow-ons.** Workflow Kernel changes, R4, R5, new routing,
    and speculative harness/platform tooling stay parked until a current failure
    or measured workload proves the need.
@@ -25,9 +25,13 @@ The current priority order is:
 
 ### Single next Depot chunk
 
-Current trusted main for this correction is
-`345b1d44aa34d1209e33977295f7c60c9846d8ea`. Publish Preview is checkpointed in
-draft PR #51 so this branch can proceed without touching that session.
+Current trusted main for this chunk is
+`ed59991aa37c1df315b9df6be1ea1eea4dbf9a46`. PR #51's exact head
+`6da69ba96c9fff470ba0bc786d1c82b15c61e958` landed in main through merge
+`3c2a27627ebf96124bf60671a9d4f26256fb88ec`. PR #52 merged as
+`ed59991aa37c1df315b9df6be1ea1eea4dbf9a46` (exact head
+`f843d89ae4b148f3f5ae673ebbb2caf2f1597dbf`). The proportional-scope and
+Publish Preview chunks are done.
 
 R2 is closed **DONE / NO CODE**. Current `plan-verification` and
 `run-verification` already put repository proof before model review, keep passing
@@ -37,15 +41,11 @@ results. No measured workload justifies adding the authored caller-supplied
 `mechanical_globs` policy, so the old untracked R2 prompts are historical inputs,
 not executable work.
 
-The immediate P1 is this proportional-scope correction. Its acceptance
-specimens are **Publish Preview** (a 2,231-word mechanism-heavy request expanded
-into two six-chunk campaigns and 12,586 words of prompts before testing a
-smaller publication workflow) and **Assembly Baseplate FIX-01** (PRs #657 and
-#662 / Issue #659, where trusted first-party Fixture code was modeled as a
-hostile marketplace and thousands of unnecessary lines followed). Passing means
-both preserve the real desired outcome and trust boundary while selecting the
-smallest adequate implementation; no specimen source tree or receipt is copied
-into Depot.
+The immediate P1 is clear human output for voice-check, dm-review, and Pipeline.
+Passing means the operator sees outcome, required attention, and one next action
+first, while complete findings, coverage gaps, browser evidence, cleanup truth,
+provenance, receipts, and raw reports remain available in existing durable
+artifacts.
 
 ### Ordered Depot queue
 
@@ -56,22 +56,23 @@ into Depot.
 | 2 | R2 pre-gates and evidence reuse | **DONE / NO CODE** | merged verification ordering, bounded receipts, and exact reuse cover the residual; no observed mechanical-glob class warrants another policy layer |
 | 3 | [#39](https://github.com/Design-Machines-Studio/depot/issues/39) / PR 40 R3a Linux portability proof | **DONE** | production-tag build passed on NED; no service was installed |
 | 4 | PR 44 production-root contract repair | **REVIEW / OPTIONAL** | exact-head review and owner merge decision; it does not block the new path and authorizes no broker continuation |
-| 5 | Proportional scope, threat model, and review convergence | **NEXT / P1** | Publish Preview and FIX-01 policy specimens select the smallest adequate outcome while real boundaries remain blocking |
-| 6 | Clear Publish Preview operator output | **NEXT AFTER P1** | smallest usable publication path returns an unambiguous operator result without campaign expansion |
-| 7 | One real cheap-path canary | HOLD | measured time/cost/quality receipt from a non-sensitive workload proves a current routing need |
-| 8 | Minimal worker/advisor routing adjustment | HOLD / REASSESS | canary shows a concrete routing miss; otherwise current matrix stands |
-| 9 | Baseplate verifier -> canonical Jig Fixture handoff | EXTERNAL / P2 | producer checks and consumer proof clear in their owning repositories |
-| 10 | R4 static run report | LATER / EVIDENCE-GATED | a current failed run supplies a diagnosis specimen |
-| 11 | R5 Agent Plugins interop | PARK / EVIDENCE-GATED | a named client or distribution target exists |
-| 12 | Workflow Kernel or speculative harness/platform changes | HOLD / EVIDENCE-GATED | a current reachable failure proves the smallest required change |
-| 13 | Workflow Authority install, integration, and Darwin port | **REMOVED** | reintroduction requires a new owner decision backed by a demonstrated threat or operational need |
+| 5 | Proportional scope, threat model, and review convergence | **DONE** | PR #52 exact head `f843d89` merged as `ed59991`; supported repairs converge proportionally |
+| 6 | Clear Publish Preview operator output | **DONE** | PR #51 exact head `6da69ba` landed through `3c2a276`; the playbook returns explicit publication status |
+| 7 | Clear human output for voice-check, dm-review, and Pipeline | **NEXT / P1** | compact handoffs lead with outcome and action while existing durable evidence remains complete |
+| 8 | One real cheap-path canary on the next non-sensitive capability/index maintenance change | **NEXT AFTER P1** | measured time/cost/quality receipt tests the cheap route before any routing adjustment |
+| 9 | Minimal worker/advisor routing adjustment | HOLD / REASSESS | canary shows a concrete routing miss; otherwise current matrix stands |
+| 10 | Baseplate verifier -> canonical Jig Fixture handoff | EXTERNAL / P2 | producer checks and consumer proof clear in their owning repositories; roadmap remains external |
+| 11 | R4 static run report | LATER / EVIDENCE-GATED | a current failed run supplies a diagnosis specimen |
+| 12 | R5 Agent Plugins interop | PARK / EVIDENCE-GATED | a named client or distribution target exists |
+| 13 | Workflow Kernel or speculative harness/platform changes | HOLD / EVIDENCE-GATED | a current reachable failure proves the smallest required change |
+| 14 | Workflow Authority install, integration, and Darwin port | **REMOVED** | reintroduction requires a new owner decision backed by a demonstrated threat or operational need |
 
 The Fixture-development handoff remains an external P2 lane and may advance in
 parallel when its Baseplate/Jig dependency chain clears; it does not displace
 the single `NEXT` Depot chunk.
 
 Only the immediate P1 authorizes this Depot execution session. `NEXT AFTER P1`
-requires the correction to merge first. DONE, HOLD, EXTERNAL, LATER, FUTURE,
+requires the clear-output chunk to merge first. DONE, HOLD, EXTERNAL, LATER, FUTURE,
 and PARK are not execution prompts.
 
 ### Cross-repository handoff

--- a/plugins/dm-review/.claude-plugin/plugin.json
+++ b/plugins/dm-review/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dm-review",
   "description": "Code review orchestrator with reachable-threat P1/P2 evidence, minimum-adequate repairs, proportional convergence, full security and browser coverage, and stable finding receipts",
-  "version": "1.61.0",
+  "version": "1.62.0",
   "author": {
     "name": "Design Machines",
     "url": "https://designmachines.io"

--- a/plugins/dm-review/.codex-plugin/plugin.json
+++ b/plugins/dm-review/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dm-review",
-  "version": "1.61.0",
+  "version": "1.62.0",
   "description": "Code review orchestrator with reachable-threat P1/P2 evidence, minimum-adequate repairs, proportional convergence, full security and browser coverage, and stable finding receipts",
   "author": {
     "name": "Design Machines",

--- a/plugins/dm-review/agents/workflow/review-consolidator.md
+++ b/plugins/dm-review/agents/workflow/review-consolidator.md
@@ -187,15 +187,16 @@ Apply the merge recommendation logic from `${CLAUDE_SKILL_DIR}/references/output
 
 ### Step 5: Generate Report
 
-Follow the exact templates in `references/output-format.md`. Generate the
-complete report first, preserving the header, merge recommendation, P1/P2/P3
-findings, `Synthesis Decisions`, agent summary, cleanup truth, and raw reports.
-Write that report to `.claude/ux-review/report.md`, then project its compact
-human handoff: exact verdict, one plain sentence, actionable P1/P2 findings,
-human-action coverage gaps, one recommended next action, and a pointer to the
-complete evidence. Every
-retained canonical finding keeps its stable ID and all contributing source IDs,
-agents, providers, models, evidence, and raw refs in the complete report.
+Follow the complete-report template in `references/output-format.md`. Produce a
+provisional report body preserving the header, merge recommendation, P1/P2/P3
+findings, `Synthesis Decisions`, agent summary, and raw reports. Leave the
+repository-cleanup section pending for the top-level skill to fill from Phase 8
+authority. Every retained canonical finding keeps its stable ID and all
+contributing source IDs, agents, providers, models, evidence, and raw refs.
+
+Do not write `.claude/ux-review/report.md` and do not deliver or project the
+compact human handoff. The top-level review skill owns both actions after
+mandatory cleanup.
 
 ### Step 5.5: Coverage Gaps
 
@@ -205,6 +206,9 @@ Add a **Coverage Gaps** section (immediately below the agent summary table) that
 - Every dead/absent agent (see Dead / Missing Agent Handling), with what it was responsible for.
 
 If there are no gaps, state `Coverage Gaps: none -- all lanes completed within budget.` An empty or omitted section must never be used to imply full coverage; absence of the section is treated as an authoring error, not as "clean".
+
+Return the provisional report body only after this Coverage Gaps section is
+complete.
 
 ## Rules
 

--- a/plugins/dm-review/agents/workflow/review-consolidator.md
+++ b/plugins/dm-review/agents/workflow/review-consolidator.md
@@ -187,7 +187,15 @@ Apply the merge recommendation logic from `${CLAUDE_SKILL_DIR}/references/output
 
 ### Step 5: Generate Report
 
-Follow the exact template in `references/output-format.md`. Include all required sections: header, merge recommendation, P1/P2/P3 findings, the compact `Synthesis Decisions` ledger, agent summary table, and detailed raw agent reports in collapsible sections. Every retained canonical finding includes its stable ID and all contributing source IDs, agents, providers, models, evidence, and raw refs.
+Follow the exact templates in `references/output-format.md`. Generate the
+complete report first, preserving the header, merge recommendation, P1/P2/P3
+findings, `Synthesis Decisions`, agent summary, cleanup truth, and raw reports.
+Write that report to `.claude/ux-review/report.md`, then project its compact
+human handoff: exact verdict, one plain sentence, actionable P1/P2 findings,
+human-action coverage gaps, one recommended next action, and a pointer to the
+complete evidence. Every
+retained canonical finding keeps its stable ID and all contributing source IDs,
+agents, providers, models, evidence, and raw refs in the complete report.
 
 ### Step 5.5: Coverage Gaps
 
@@ -218,3 +226,8 @@ If there are no gaps, state `Coverage Gaps: none -- all lanes completed within b
 13. **Provenance is literal** -- if a requested provider falls back, retain the
     requested, attempted, and implemented-by values. Never silently relabel a
     Codex fallback as OpenRouter work.
+14. **The handoff is bounded** -- list every P1/P2 once when there are at most
+    eight; otherwise show the highest-impact eight, the exact remaining count,
+    and the complete-report pointer. Show P3 only as a count plus evidence
+    pointer there. Never expand provider tables, transcripts, synthesis ledgers,
+    cleanup tables, or raw reports in the visible handoff.

--- a/plugins/dm-review/commands/dm-review-loop.md
+++ b/plugins/dm-review/commands/dm-review-loop.md
@@ -10,7 +10,7 @@ Automates the cycle of reviewing code, fixing required findings, and re-reviewin
 
 ## Finding Policy
 
-P1 blocks merge and P2 must be fixed before merge. P3 remains fully visible advisory evidence but never enters the fix queue, triggers another iteration, or blocks convergence. The loop is clean when no P1/P2 findings remain and all required verification and coverage gates are complete.
+P1 blocks merge and P2 must be fixed before merge. P3 remains fully retained advisory evidence but never enters the fix queue, triggers another iteration, or blocks convergence; the compact handoff shows its exact count and evidence pointer. The loop is clean when no P1/P2 findings remain and all required verification and coverage gates are complete.
 
 The default convergence path is one repair batch followed by one affected-lane recheck. Repeat broad review only when the original required review was incomplete or the repair changed a real sensitive boundary.
 

--- a/plugins/dm-review/commands/dm-review.md
+++ b/plugins/dm-review/commands/dm-review.md
@@ -15,7 +15,7 @@ P1 blocks merge and P2 must be fixed before merge. P3 is advisory: retain its co
 The merge recommendation reflects this policy:
 
 - **Zero findings:** `CLEAN` -- safe to merge.
-- **P3 only (no P1/P2):** `CLEAN` -- retain every P3 as a visible advisory.
+- **P3 only (no P1/P2):** `CLEAN` -- retain every P3 in complete evidence; show only the exact count and evidence pointer in the compact handoff.
 - **P2 present:** `APPROVE WITH FIXES`. Must fix.
 - **P1 present:** `BLOCKS MERGE`. Must fix.
 

--- a/plugins/dm-review/skills/dm-review-loop/SKILL.md
+++ b/plugins/dm-review/skills/dm-review-loop/SKILL.md
@@ -25,7 +25,7 @@ Automates the cycle of reviewing code, fixing required findings, and re-reviewin
 
 ## Finding Policy
 
-P1 blocks merge and P2 must be fixed before merge. P3 remains fully visible advisory evidence but never enters the fix queue, triggers another iteration, or blocks convergence. The loop is clean when no P1/P2 findings remain and all required verification and coverage gates are complete.
+P1 blocks merge and P2 must be fixed before merge. P3 remains fully retained advisory evidence but never enters the fix queue, triggers another iteration, or blocks convergence; the compact handoff shows its exact count and evidence pointer. The loop is clean when no P1/P2 findings remain and all required verification and coverage gates are complete.
 
 The default convergence path is one repair batch followed by one affected-lane recheck. Repeat broad review only when the original required review was incomplete or the repair changed a real sensitive boundary.
 

--- a/plugins/dm-review/skills/dm-review/SKILL.md
+++ b/plugins/dm-review/skills/dm-review/SKILL.md
@@ -30,7 +30,7 @@ P1 blocks merge and P2 must be fixed before merge. P3 is advisory: retain its co
 The merge recommendation reflects this policy:
 
 - **Zero findings:** `CLEAN` -- safe to merge.
-- **P3 only (no P1/P2):** `CLEAN` -- retain every P3 as a visible advisory.
+- **P3 only (no P1/P2):** `CLEAN` -- retain every P3 in complete evidence; show only the exact count and evidence pointer in the compact handoff.
 - **P2 present:** `APPROVE WITH FIXES`. Must fix.
 - **P1 present:** `BLOCKS MERGE`. Must fix.
 

--- a/plugins/dm-review/skills/review/SKILL.md
+++ b/plugins/dm-review/skills/review/SKILL.md
@@ -1012,14 +1012,10 @@ lane, including lanes with zero findings. Never hand-author
 coverage receipts. A zero-finding synthesis still runs the command with count
 zero and all required lane receipts so missing producer coverage is observable.
 
-Deliver the compact human handoff first, following
-`references/output-format.md`. Preserve the complete unified report and all
-machine-readable companions in the established evidence flow. Before delivery,
-write the complete report to `.claude/ux-review/report.md`; this is the existing
-dm-review artifact flow, not a new report subsystem. The compact handoff links
-that path. Do not dump the expanded report, provider tables, agent transcripts,
-synthesis ledger, cleanup inventory, or raw reports directly into visible chat
-by default.
+Keep the consolidated report body provisional through the remaining phases.
+Do not write `.claude/ux-review/report.md` or deliver the compact human handoff
+yet: mandatory repository cleanup in Phase 8 supplies the report's final
+cleanup truth. The finalization and delivery boundary follows Phase 8.
 
 #### Coverage receipt and shadow observation
 
@@ -1240,6 +1236,22 @@ Never execute proposed cleanup argv separately or cross-use the two plan authori
 The cleanup report includes Docker before/after inventories and `removed|missing|retained|blocked|unmanaged` dispositions alongside Git. Cleanup runs on every terminal path. A cleanup failure never becomes a clean disposition or changes the authoritative code-review finding result.
 
 Never delete the feature branch under review. There is no condition under which a code review deletes the branch it was asked to review.
+
+---
+
+### Finalize Report and Deliver Handoff
+
+Only after Phase 8 has completed, add its authoritative repository and Docker
+cleanup results to the provisional unified report. Then write the complete report to `.claude/ux-review/report.md`.
+This is the existing dm-review artifact flow, not a new report subsystem.
+
+Deliver the compact human handoff after that write, following
+`references/output-format.md`. Preserve the complete unified report and all
+machine-readable companions in the established evidence flow. The compact
+handoff links `.claude/ux-review/report.md` and names any blocked cleanup that
+requires operator action. Do not dump the expanded report, provider tables,
+agent transcripts, synthesis ledger, cleanup inventory, or raw reports directly
+into visible chat by default.
 
 ---
 

--- a/plugins/dm-review/skills/review/SKILL.md
+++ b/plugins/dm-review/skills/review/SKILL.md
@@ -978,7 +978,7 @@ Read from `$CONSOLIDATOR_PATH` and follow the instructions exactly:
 5. **Determine merge recommendation** using `${CLAUDE_SKILL_DIR}/references/output-format.md` §Merge Recommendation Logic. In summary:
    - Any P1 -> "BLOCKS MERGE"
    - Any P2 -> "APPROVE WITH FIXES"
-   - P3 only -> "CLEAN" with every P3 retained as a visible advisory
+   - P3 only -> "CLEAN" with every P3 retained in complete evidence and an exact count plus pointer in the compact handoff
    - Zero findings -> "CLEAN"
 6. **Generate the unified report** following the template in `${CLAUDE_SKILL_DIR}/references/output-format.md`, including the compact required `Synthesis Decisions` section and full raw agent reports.
 
@@ -1012,7 +1012,14 @@ lane, including lanes with zero findings. Never hand-author
 coverage receipts. A zero-finding synthesis still runs the command with count
 zero and all required lane receipts so missing producer coverage is observable.
 
-Output the full report to the user.
+Deliver the compact human handoff first, following
+`references/output-format.md`. Preserve the complete unified report and all
+machine-readable companions in the established evidence flow. Before delivery,
+write the complete report to `.claude/ux-review/report.md`; this is the existing
+dm-review artifact flow, not a new report subsystem. The compact handoff links
+that path. Do not dump the expanded report, provider tables, agent transcripts,
+synthesis ledger, cleanup inventory, or raw reports directly into visible chat
+by default.
 
 #### Coverage receipt and shadow observation
 

--- a/plugins/dm-review/skills/review/SKILL.md
+++ b/plugins/dm-review/skills/review/SKILL.md
@@ -1056,7 +1056,7 @@ The `[ -n "$ENGINE" ]` guard covers "airlift not installed"; the `[ -x "$ENGINE"
 
 **Skip this phase in Quick mode.**
 
-After outputting the report, determine tracking method automatically:
+After consolidation, determine tracking method automatically:
 
 **1. If `todos/` directory exists** in the project root -- use text file tracking automatically. Do NOT ask the user. Create todo files for P1 and P2 findings only. P3 advisories remain in the report and receipts.
 

--- a/plugins/dm-review/skills/review/references/output-format.md
+++ b/plugins/dm-review/skills/review/references/output-format.md
@@ -1,10 +1,83 @@
 # Review Output Format
 
-The canonical unified report format produced by the review-consolidator after all agents complete.
+The canonical unified report and compact human handoff produced by the
+review-consolidator after all agents complete. The handoff is a projection of
+the complete report, never a replacement for it.
 
 ---
 
-## Report Template
+## Compact Human Handoff
+
+Every visible result begins with this compact handoff. Use the exact mechanical
+verdict from the complete report. Keep the explanation to one plain sentence.
+
+```markdown
+## <CLEAN | APPROVE WITH FIXES | BLOCKS MERGE | REVIEW INCOMPLETE>
+
+<One plain sentence explaining the verdict.>
+
+### Actionable findings
+<For each retained P1/P2, once only: `path:anchor -- problem -- smallest adequate fix`>
+<If none: `None.`>
+
+### Coverage gap requiring action
+<Only gaps that require human action. If none: `None.`>
+
+### Recommended next action
+<One action.>
+
+### Complete evidence
+`Full report: .claude/ux-review/report.md`.
+<If P3 exists: `P3 advisories: N -- <evidence pointer>.`>
+```
+
+When there are at most eight P1/P2 findings, list each exactly once. When there
+are more than eight, list the highest-impact eight, state `N additional P1/P2
+findings` with the exact remaining count, and point to the complete report.
+Never imply that omitted findings do not exist. P3 advisories appear only as an
+exact count and evidence pointer in this handoff; they remain fully detailed in
+the report and never enter the fix queue.
+
+Do not repeat provider tables, agent transcripts, synthesis ledgers, cleanup
+tables, or raw reports in the handoff. Write them to the established durable
+artifact `.claude/ux-review/report.md` before delivery. Coverage gaps, blocked
+browser evidence, cleanup truth, finding IDs, and
+literal provider/model provenance remain in that complete evidence flow.
+
+### Representative handoffs
+
+Clean review:
+
+```markdown
+## CLEAN
+No P1/P2 findings were found, and all required lanes completed.
+### Actionable findings
+None.
+### Coverage gap requiring action
+None.
+### Recommended next action
+Merge the reviewed head.
+### Complete evidence
+Full report: `.claude/ux-review/report.md` (P3 advisories: 0).
+```
+
+Review with actionable findings:
+
+```markdown
+## APPROVE WITH FIXES
+Two P2 findings must be fixed before merge.
+### Actionable findings
+- `internal/members/handler.go:Create` -- validation accepts an empty name -- reject an empty trimmed value.
+- `web/templates/member.templ:member-form` -- error text is not associated with the field -- add the existing error ID to `aria-describedby`.
+### Coverage gap requiring action
+Safari browser evidence is blocked -- run the retained case on a Safari-capable host.
+### Recommended next action
+Fix the two P2 findings, then rerun their affected lanes and the blocked browser case.
+### Complete evidence
+Full report: `.claude/ux-review/report.md` (P3 advisories: 2).
+```
+
+## Complete Report Template
 
 ```markdown
 ## Code Review Report
@@ -227,7 +300,7 @@ The consolidator preserves the original citation format from each agent.
 4. **Clean agents are noted** in the summary table but don't get detail sections
 5. **Skipped agents are listed** with the reason (file type not changed, project type mismatch)
 6. **Deduplicated findings** show all source agents: `**Source:** a11y-css-reviewer, css-reviewer`
-7. **Full agent reports** are always included in collapsible sections for reference
+7. **Full agent reports** are always included in collapsible sections in the complete evidence, not expanded in the compact handoff
 8. **No sugar-coating** -- if the code has problems, say so directly
 9. **Stable identity is mandatory** -- every retained canonical finding uses
    `finding-v1:sha256(<normalized-key>)`, derived without reviewer, provider,
@@ -235,6 +308,9 @@ The consolidator preserves the original citation format from each agent.
 10. **Synthesis decisions are complete** -- every source finding appears with
     provenance, evidence, raw ref, agreement, disposition, closed reason code,
     and rationale; raw reviewer reports remain verbatim below
+11. **Human delivery is compact** -- the exact verdict, one-sentence explanation,
+    actionable P1/P2 findings, human-action coverage gaps, one recommended next
+    action, and complete-evidence pointer appear before the report
 
 ## Merge Recommendation Logic
 

--- a/plugins/ghostwriter/.claude-plugin/plugin.json
+++ b/plugins/ghostwriter/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ghostwriter",
   "description": "Travis Gertz's personal writing voice, editorial style engine, and social media publishing intelligence",
-  "version": "3.9.1",
+  "version": "3.10.0",
   "author": {
     "name": "Design Machines"
   },

--- a/plugins/ghostwriter/.codex-plugin/plugin.json
+++ b/plugins/ghostwriter/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ghostwriter",
-  "version": "3.9.1",
+  "version": "3.10.0",
   "description": "Travis Gertz's personal writing voice, editorial style engine, and social media publishing intelligence",
   "author": {
     "name": "Design Machines"

--- a/plugins/ghostwriter/commands/voice-check.md
+++ b/plugins/ghostwriter/commands/voice-check.md
@@ -30,10 +30,20 @@ delve, tapestry, landscape (metaphorical), navigate (metaphorical), leverage (ve
 
 **AI Writing Patterns:**
 - Em-dash clusters (more than 2 per paragraph)
-- Tricolon crutches (three parallel items as a default rhythm)
-- Mechanical transitions ("Furthermore," "Moreover," "Additionally,")
+- Puffery, promotional filler, vague attribution, and generic conclusions
+- Canned transitions and chatbot phrases
+- Forced rules of three (do not force a natural list into three items)
+- Synonym cycling that avoids repeating the clearest noun
+- False ranges whose endpoints do not share a meaningful scale
+- Excessive hedging or cutoff disclaimers that avoid a supported claim
+- Abstract jargon where a concrete word names the mechanism, fact, or actor
+- Unnecessary passive voice when the actor is known and matters
+- Weak verb plus adverb constructions where a stronger verb or measurement exists
+- Repetitive punctuation or formatting habits, including em-dash, colon, boldface, or inline-header clusters
+- Sentences that express a feeling but provide no fact, instruction, example, or decision
+- Dense sentences that require rereading; split or remove clauses
 - Emotional flatness (every paragraph at the same register)
-- Vocabulary uniformity (same word choices a human wouldn't repeat)
+- Sterile rewrites that remove the writer's actual voice, opinion, rhythm, or register
 
 **Rhythm Issues:**
 - No sentence variety (all medium-length)
@@ -46,25 +56,28 @@ delve, tapestry, landscape (metaphorical), navigate (metaphorical), leverage (ve
 
 ### 4. Report
 
+Return a compact edit, not an inventory of every scan result:
+
+```markdown
+## Verdict
+[Ready | Light edit | Rewrite needed] -- [one plain sentence explaining why]
+
+## Fix now
+[Highest-value concrete edits, ordered by impact. Use the natural number needed; do not force three.]
+
+## Suggested rewrite
+[Direct replacement text for the affected passage. If the text is ready, say "No rewrite needed."]
+
+## What remains
+[Only unresolved ambiguity or an intentional voice/register choice. If none, say "Nothing."]
 ```
-Voice Check -- [source]
 
-Kill words found: X
-AI patterns found: Y
-Rhythm issues: Z
+Do not report kill-word, pattern, or rhythm counts unless the user asks for an
+audit ledger. Prefer the smallest set of edits that materially improves the
+text. Preserve exact names, quotations, technical terms, paths, and commands
+when precision requires them.
 
-KILLS:
-- Line N: "leverage" -> try "use" or "exploit"
-- Line N: "robust" -> try "solid" or "tough"
-
-AI PATTERNS:
-- Para 2: Three consecutive "Additionally/Furthermore/Moreover" transitions
-- Para 4: Em-dash cluster (4 in one paragraph)
-
-RHYTHM:
-- All sentences 15-25 words -- needs variety (fragments + longer builds)
-- No gear shifts between registers
-
-REWRITES:
-[Provide 2-3 rewritten passages that fix the identified issues]
-```
+The voice skill is authoritative. A mechanical plain-language preference must
+not flatten a deliberate Travis metaphor, fragment, repetition, political
+position, joke, or platform register. The goal is clearer human writing in the
+writer's voice, not sterile uniformity.

--- a/plugins/ghostwriter/skills/voice-check/SKILL.md
+++ b/plugins/ghostwriter/skills/voice-check/SKILL.md
@@ -45,10 +45,20 @@ delve, tapestry, landscape (metaphorical), navigate (metaphorical), leverage (ve
 
 **AI Writing Patterns:**
 - Em-dash clusters (more than 2 per paragraph)
-- Tricolon crutches (three parallel items as a default rhythm)
-- Mechanical transitions ("Furthermore," "Moreover," "Additionally,")
+- Puffery, promotional filler, vague attribution, and generic conclusions
+- Canned transitions and chatbot phrases
+- Forced rules of three (do not force a natural list into three items)
+- Synonym cycling that avoids repeating the clearest noun
+- False ranges whose endpoints do not share a meaningful scale
+- Excessive hedging or cutoff disclaimers that avoid a supported claim
+- Abstract jargon where a concrete word names the mechanism, fact, or actor
+- Unnecessary passive voice when the actor is known and matters
+- Weak verb plus adverb constructions where a stronger verb or measurement exists
+- Repetitive punctuation or formatting habits, including em-dash, colon, boldface, or inline-header clusters
+- Sentences that express a feeling but provide no fact, instruction, example, or decision
+- Dense sentences that require rereading; split or remove clauses
 - Emotional flatness (every paragraph at the same register)
-- Vocabulary uniformity (same word choices a human wouldn't repeat)
+- Sterile rewrites that remove the writer's actual voice, opinion, rhythm, or register
 
 **Rhythm Issues:**
 - No sentence variety (all medium-length)
@@ -61,25 +71,28 @@ delve, tapestry, landscape (metaphorical), navigate (metaphorical), leverage (ve
 
 ### 4. Report
 
+Return a compact edit, not an inventory of every scan result:
+
+```markdown
+## Verdict
+[Ready | Light edit | Rewrite needed] -- [one plain sentence explaining why]
+
+## Fix now
+[Highest-value concrete edits, ordered by impact. Use the natural number needed; do not force three.]
+
+## Suggested rewrite
+[Direct replacement text for the affected passage. If the text is ready, say "No rewrite needed."]
+
+## What remains
+[Only unresolved ambiguity or an intentional voice/register choice. If none, say "Nothing."]
 ```
-Voice Check -- [source]
 
-Kill words found: X
-AI patterns found: Y
-Rhythm issues: Z
+Do not report kill-word, pattern, or rhythm counts unless the user asks for an
+audit ledger. Prefer the smallest set of edits that materially improves the
+text. Preserve exact names, quotations, technical terms, paths, and commands
+when precision requires them.
 
-KILLS:
-- Line N: "leverage" -> try "use" or "exploit"
-- Line N: "robust" -> try "solid" or "tough"
-
-AI PATTERNS:
-- Para 2: Three consecutive "Additionally/Furthermore/Moreover" transitions
-- Para 4: Em-dash cluster (4 in one paragraph)
-
-RHYTHM:
-- All sentences 15-25 words -- needs variety (fragments + longer builds)
-- No gear shifts between registers
-
-REWRITES:
-[Provide 2-3 rewritten passages that fix the identified issues]
-```
+The voice skill is authoritative. A mechanical plain-language preference must
+not flatten a deliberate Travis metaphor, fragment, repetition, political
+position, joke, or platform register. The goal is clearer human writing in the
+writer's voice, not sterile uniformity.

--- a/plugins/pipeline/.claude-plugin/plugin.json
+++ b/plugins/pipeline/.claude-plugin/plugin.json
@@ -1,13 +1,13 @@
 {
   "name": "pipeline",
   "description": "Autonomous feature development pipeline with approved-scope intake, minimum-adequate planning, bounded adversarial review, fresh tiered verification, browser recovery, and isolated execution",
-  "version": "1.50.0",
+  "version": "1.51.0",
   "author": {
     "name": "Design Machines",
     "url": "https://designmachines.io"
   },
   "pluginDependencies": {
-    "dm-review": ">=1.61.0",
+    "dm-review": ">=1.62.0",
     "ned": ">=1.4.0",
     "workflow-kernel": ">=0.16.0"
   },

--- a/plugins/pipeline/.codex-plugin/plugin.json
+++ b/plugins/pipeline/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pipeline",
-  "version": "1.50.0",
+  "version": "1.51.0",
   "description": "Autonomous feature development pipeline with approved-scope intake, minimum-adequate planning, bounded adversarial review, fresh tiered verification, browser recovery, and isolated execution",
   "author": {
     "name": "Design Machines",
@@ -167,7 +167,7 @@
     ]
   },
   "pluginDependencies": {
-    "dm-review": ">=1.61.0",
+    "dm-review": ">=1.62.0",
     "ned": ">=1.4.0",
     "workflow-kernel": ">=0.16.0"
   },

--- a/plugins/pipeline/agents/workflow/execution-orchestrator.md
+++ b/plugins/pipeline/agents/workflow/execution-orchestrator.md
@@ -2019,13 +2019,16 @@ rule prevents it, what automated check catches it earlier, what becomes the defa
   Failure Modes" (grep to confirm), draft both:
   1. a `docs/post-mortems/YYYY-MM-DD-<slug>.md` stub (symptom, root cause, hardening proposal), and
   2. a candidate "Known Pipeline Failure Modes" entry,
-  and surface both in the Step 6 Summary Report under **Codify Proposals** for human approval. Do NOT
-  edit CLAUDE.md or commit the postmortem yourself -- propose; the caller approves.
+  and write both under `## Codify Proposals` in the mandatory
+  `plans/<feature-slug>/run-postmortem.md` for human approval. The compact Step
+  6 summary links that postmortem. Do NOT edit CLAUDE.md or commit the proposed
+  postmortem stub yourself -- propose; the caller approves.
 
 This converts the previously reactive "someone remembers to write a postmortem" ritual into an
 automatic proposal emitted every time a novel failure occurs.
 
-If ai-memory is unavailable, still produce the Codify Proposals in the report; skip only the auto-write.
+If ai-memory is unavailable, still write the Codify Proposals to the run
+postmortem; skip only the memory write.
 
 Mark `FINAL 4. Record session to ai-memory` complete.
 
@@ -2332,102 +2335,56 @@ Mark `FINAL 5c. Campaign state write` complete.
 
 Before presenting the summary, use the terminal comparison and metrics result captured in Step 5b before any semantic-match cleanup. Report the semantic parity category and reasons without changing the authoritative merge, review, provider, browser, or cleanup result. If unavailable, report the attempted resolver source and safe reason. The stable comparison vocabulary is `match`, `explained_host_difference`, `missing_authoritative_evidence`, `unexpected_authoritative_transition`, `kernel_prediction_gap`, and `unsafe_to_promote`; diagnostics such as `semantic_receipts_required` and `run_spec_receipt_context_mismatch` belong only in `differences`.
 
-Present this report:
+Present this compact report. Populate every evidence path that exists; omit a
+nonexistent optional artifact rather than inventing one:
 
 ```markdown
-# Pipeline Execution Complete
+## <Done | Needs fixes | Blocked>
 
-## Feature: <feature-name>
-**Branch:** <featureBranch>
-**Base:** <baseBranch>
-**Branch mode:** create / reuse
-**Expected feature head:** <commit-or-null>
-For create mode, Base is the pullable branch from `manifest.baseBranch` and
-`main` is only the absent-field default. For reuse mode, Base is contextual
-only; execution starts from the exact fetched existing feature head and makes
-no setup push.
+<What changed, or the exact blocker and what stopped.>
 
-## Chunks Executed
-| Chunk | Status | Evaluation Gate Result | Notes |
-|-------|--------|----------------------|-------|
-| chunk-id | clean/needs-attention | N iterations, M findings | |
+**Verification:** <passed checks and final review result, or exact failed/pending evidence>
+**Branch or PR:** <branch and PR URL when present>
+**Recommended next action:** <one action; for blocked work, the smallest operator action>
+**Resumable work:** <preserved branch/worktree/artifact path; required when blocked>
 
-## Final Review
-- **Requested mode:** full / quick
-- **Effective mode:** full / quick
-- **Escalation:** none / security-sensitive-path
-- **Result:** Clean / N findings remaining
-- **Merge Recommendation:** CLEAN / APPROVE WITH FIXES / BLOCKS MERGE / BLOCKED PENDING CALLER VERIFICATION / BLOCKED PENDING REMOTE VERIFICATION
-- **executionMode:** full_cli / codex_native / manual_walkthrough
-- **isolationStrategy:** per-chunk-worktree / sequential-on-branch
-- **providerSplit:** `{claude: N, codex: N, openrouter: N}` measured from run receipts/postmortem; DeepSeek-model calls count under OpenRouter
-- **eligibleProviderSplit:** `{codex: N, openrouter: N, targetProfile: <name>, routingVariance: <measured>}` measured before disclosure/routing fallback
-- **workflowClass:** `<class>` (`workflow_class_defaulted=true|false`)
-- **shadow:** match / parity-gap / unavailable (reason)
-- **noMergeOnCompletion:** true/false
-
-## Steps Completed
-- [x] Chunk classification: [UI: N, Logic: N, Trivial: N, Integration: N]
-- [x] Worktree per chunk: yes/no
-- [x] Anti-pattern scan per chunk: yes/no (findings per chunk)
-- [x] Evaluation gate per chunk: yes/no (type and iterations per chunk)
-- [x] Playwright browser checks: N of M `renderedSurface: required` chunks checked; K `not_applicable` chunks recorded with rationale
-- [x] Approved final dm-review mode: yes/no
-- [x] final-requirements-crosscheck.md written: yes/no
-- [x] Merge policy honored (noMergeOnCompletion): yes/no
-- [x] ai-memory capture: yes/no
-- [x] Codify run (if run had friction): yes/no/n-a
-- [x] Run Post-Mortem written and measured providerSplit reported: yes/no
-- [x] Artifact cleanup: yes/no
-- [x] Repository cleanup: worktrees N->M, branches deleted K, blocked J
-- [x] Docker cleanup/reconciliation: created N, removed M, missing K, retained/blocked J
-- [x] Shadow comparison/metrics: match/parity-gap/unavailable
-- [x] Zero-deferral enforced: yes/no
-
-## Artifact Cleanup
-- Receipt: plans/<feature-slug>/receipt.md
-- Ephemeral removed: N files
-- Run-scoped removed: N files (or "preserved -- run failed")
-- Feature-scoped retained: N files
-
-## Repository Cleanup
-[Reproduce the `## Branch & Worktree Inventory` block from receipt.md verbatim -- both tables,
-the worktree before/after counts, and the `git status --porcelain` result. Every kept or blocked
-ref carries the exact follow-up command. Never report a blocked ref as deleted.]
-
-## Evaluation Receipts
-[List every EVAL_GATE_PASSED line, proving each chunk was evaluated]
-
-## Advisory Findings
-[List retained P3 advisories with their evidence references. If none, state "None."]
-
-## Codify Proposals
-[From Step 5.2. List each lesson and where it should be encoded. For any NOVEL pipeline failure pattern,
-include the drafted postmortem stub path and the candidate "Known Pipeline Failure Modes" entry text,
-flagged AWAITING APPROVAL -- the caller approves before anything is committed to CLAUDE.md or
-docs/post-mortems/. If the run was clean, state "None -- clean run, nothing to codify."]
-
-## Run Economics
-- Post-mortem: plans/<feature-slug>/run-postmortem.md
-- providerSplit: <measured split>
-- Claude share target: <from routing-policy.json>
-- Misroutes: <N>
-- Top recommendation: <title or none -- optimal>
-- Recommendation status: AWAITING APPROVAL
-
-## Warnings
-[List any recovered browser attempts, unresolved `human_help_required` browser blockers, degraded non-browser reviews, or anti-pattern findings that were fixed. Required browser verification is never skipped.]
-
-## Flagged Items
-[Any chunks or findings needing manual attention]
-
-## Next Steps
-1. Review: `git log main..<featureBranch>`
-2. Test end-to-end
-3. Create PR: `gh pr create`
+**Evidence:**
+- Receipt: `plans/<feature-slug>/receipt.md`
+- Requirements: `plans/<feature-slug>/final-requirements-crosscheck.md`
+- Postmortem: `plans/<feature-slug>/run-postmortem.md`
+- Detailed review: `.claude/ux-review/report.md`
 ```
 
-The "Steps Completed" section is your honest self-report. If any step was skipped, say so here.
+The visible summary normally stays within roughly 250 words. Exceed that only
+for actionable P1/P2 findings or a real blocker. Do not omit required action.
+Keep chunk tables, `Steps Completed`, provider accounting, cleanup inventory,
+evaluation receipts, P3 detail, browser receipts, synthesis/provenance ledgers,
+and raw reports in the evidence artifacts. The compact summary must still name
+any coverage gap or blocked browser evidence that requires human action and
+must never report blocked cleanup as complete.
+
+Successful-run specimen:
+
+```markdown
+## Done
+The membership validation change is committed and ready for review.
+**Verification:** Unit tests and the approved final review passed; no P1/P2 findings remain.
+**Branch or PR:** `enhance/member-validation` -- PR #123
+**Recommended next action:** Review and merge PR #123.
+**Evidence:** receipt, requirements crosscheck, postmortem, and detailed review under `plans/member-validation/`.
+```
+
+Blocked-run specimen:
+
+```markdown
+## Blocked
+Required Safari evidence for `member-form-mobile` could not run because no Safari-capable host is available.
+**Verification:** Code tests passed; the final review remains blocked on that browser case.
+**Branch or PR:** `enhance/member-form`
+**Recommended next action:** Run `member-form-mobile` on a Safari-capable host and attach the result.
+**Resumable work:** `enhance/member-form`; receipts and the pending case are preserved under `plans/member-form/`.
+**Evidence:** `plans/member-form/receipt.md` and `plans/member-form/final-requirements-crosscheck.md`.
+```
 
 Mark `FINAL 6. Present summary report` complete.
 

--- a/plugins/pipeline/agents/workflow/execution-orchestrator.md
+++ b/plugins/pipeline/agents/workflow/execution-orchestrator.md
@@ -1985,7 +1985,7 @@ waive or manufacture it.
 
 Read `manifest.noMergeOnCompletion` (default `false` if the field is absent).
 
-- **If `true`:** log `merge_skipped: noMergeOnCompletion=true`. Do NOT merge the feature branch into `baseBranch`. The caller retains the branch for manual review. Note this in the Summary Report's "Next Steps" section.
+- **If `true`:** log `merge_skipped: noMergeOnCompletion=true`. Do NOT merge the feature branch into `baseBranch`. The caller retains the branch for manual review. In the compact Step 6 summary, state `noMergeOnCompletion=true` in **Branch or PR** and make manual branch review the single **Recommended next action**.
 - **If `false`:** proceed with the normal merge workflow (feature branch is already assembled via per-chunk merges; no additional action needed here unless your workflow performs a final base-branch merge).
 
 Mark `FINAL 3. Check manifest.noMergeOnCompletion` complete.

--- a/plugins/pipeline/commands/pipeline-run.md
+++ b/plugins/pipeline/commands/pipeline-run.md
@@ -11,6 +11,22 @@ review for ordinary chunks, sensitive-path escalation, and the approved final
 review mode. This is the execution engine -- it creates or reuses branches, runs
 subagents, reviews, fixes, merges, and delivers a clean feature branch.
 
+## Human-Facing Completion
+
+Present the orchestrator's compact summary, not its durable ledgers. Start with
+exactly `Done`, `Needs fixes`, or `Blocked`; state what changed or stopped, the
+verification result, branch or PR, and one recommended next action. Link the
+existing `receipt.md`, `final-requirements-crosscheck.md`,
+`run-postmortem.md`, and detailed review when present. For blocked work, name
+the exact blocker, the smallest operator action, and the preserved resumable
+location. Normally stay within roughly 250 words, except for required P1/P2
+findings or a real blocker.
+
+Do not repeat `Steps Completed`, provider accounting, cleanup inventory, every
+evaluation receipt, raw review output, or a default action menu in visible chat.
+Those facts remain in the established artifacts. Put one recommended action
+before any genuinely live alternatives.
+
 ## Input
 
 <manifest_path> #$ARGUMENTS </manifest_path>
@@ -256,13 +272,9 @@ The `emit-cost-summary` command is one transaction: it owns the artifact path, c
 
 `bind-prediction` runs before corresponding authoritative actions, atomically seals the source, translated events, event digest, and RunSpec context, and appends exact binding authority to the canonical lifecycle ledger before `run.started`. `observe-pipeline` runs only after authoritative receipts exist and requires that ordered authority plus bound `pipeline-shadow-prediction.json`; direct comparison rechecks the same authority, and byte-identical predicted and authoritative receipts are valid only with the pre-start binding. It writes a separate `authoritative_observation` and never creates or changes the prediction. Without matching independent prediction evidence, observation and comparison fail closed. Keep the source and bound artifact until comparison completes. Write the shadow report and reliability metrics without changing the merge recommendation, cleanup disposition, or provider result. Never auto-delete the repository-lifetime `.workflow-kernel/repository-scope.json`; retain the terminal run directory or a durable tombstone until fresh exact-scope Docker inventory proves zero exact-run objects and no uninspectable matches, regardless of parity `match`.
 
-Present the summary report from the orchestrator, then ask:
-
-"Feature branch `<branch>` is ready. Options:
-1. Review the branch (`git log main..<branch>`)
-2. Create a PR (`gh pr create`)
-3. Give feedback for another iteration
-4. Run another full review (`/dm-review <branch>`)
-5. Done"
+Present the compact summary from the orchestrator. If an operator decision is
+still needed, ask for it after `Recommended next action`; mention additional
+choices only when they are genuinely live. Do not emit a standing five-option
+menu.
 
 If feedback given, suggest re-running `/pipeline-prompts` with the feedback to generate revision prompts, then `/pipeline-run` again on the same feature branch.

--- a/plugins/pipeline/commands/pipeline.md
+++ b/plugins/pipeline/commands/pipeline.md
@@ -35,6 +35,34 @@ In lean mode:
 
 **How to decide:** If the plan from Phase 3 has more than one logical step that could be parallelized or that touches separate file groups, use full mode. If it's a single coherent change that still benefits from quality checks, use lean mode. When in doubt, use full mode.
 
+## Human-Facing Output
+
+Keep phase gates, blocked-run messages, and delivery summaries compact. The
+durable artifacts carry process detail; visible chat helps the operator decide
+what to do.
+
+- At a phase gate, state what phase is ready, the decision or correction needed,
+  one recommended next action, and the artifact path. Do not paste the full
+  assessment, research, plan, requirements map, prompt inventory, or receipts.
+- A terminal summary starts with exactly `Done`, `Needs fixes`, or `Blocked`,
+  then states what changed or stopped, verification, branch or PR, one
+  recommended next action, and links or paths to the receipt, requirements
+  crosscheck, postmortem, and detailed review when present.
+- A blocked message names the exact blocker, the smallest operator action that
+  can clear it, and where resumable work is preserved. Required P1/P2 findings,
+  coverage gaps, blocked browser evidence, cleanup truth, and provenance remain
+  in the linked durable evidence.
+- Put `Recommended next action` before any additional option. Show other options
+  only when they are genuinely live decisions; do not print a default
+  multiple-choice menu.
+
+The visible summary should normally fit within roughly 250 words. Exceed that
+only to expose actionable P1/P2 findings or a real blocker. Never hide required
+action to meet the budget. Do not print `Steps Completed`, provider accounting,
+cleanup inventories, every evaluation receipt, or raw review output in chat by
+default; keep them in `receipt.md`, `run-postmortem.md`, the requirements
+crosscheck, and the established detailed review artifact.
+
 ## Provider-Adaptive Complexity
 
 Choose lean versus full mode from dependency shape, risk, and verification needs--not from a Claude model. Coding execution and review use Codex or OpenRouter. Claude effort settings may deepen explicitly non-coding planning, strategy, research synthesis, voice/editorial work, or optional plan critique, but they never change coding routes or justify broader implementation chunks.
@@ -283,7 +311,8 @@ Load the assess skill from `plugins/pipeline/skills/assess/SKILL.md`.
 3. In the existing assessment prose, classify the request as: desired outcomes; hard constraints and explicit approved decisions; implementation mechanisms proposed by the user or upstream prompt; and future or conditional ideas. Never silently discard an explicit request.
 4. Identify the smallest adequate solution. If it would omit or replace a requested mechanism, present both the smaller alternative and the mechanism-preserving option at this gate. Do not choose for the user.
 5. Save the Assessment Brief to `plans/<feature-slug>/assessment.html` (per **Artifact Format** above). Before the gate, any proposed Key Requirements are provisional. After the user's response, update the `keyRequirements` island so it contains only the resulting approved outcomes, constraints, and decisions; proposed mechanisms enter it only when the user approves them as scope.
-6. Present key findings to the user
+6. Present only the phase outcome, any correction needed, one recommended next
+   action, and the `assessment.html` path
 
 Mark ledger item 2 as complete.
 
@@ -300,7 +329,8 @@ You MUST run this phase even if you think you already have enough context. Resea
 1. Pass the feature description and Assessment Brief to the research orchestrator
 2. Dispatch parallel research agents across all available sources (ai-memory, RAG, domain plugins, web, codebase)
 3. Save the Research Brief to `plans/<feature-slug>/research.html` (per **Artifact Format** above; `findings`/`references` island)
-4. Present the Research Brief summary to the user
+4. Present only the phase outcome, any scope decision needed, one recommended
+   next action, and the `research.html` path
 
 **Verification:** The Research Brief file MUST exist on disk before proceeding. Run `ls plans/<feature-slug>/research.html` to confirm.
 
@@ -431,7 +461,7 @@ legacy/default receipt above is authoritative until a new manifest is generated.
 
 Mark ledger item 8 as complete.
 
-**Requirements coverage check (ledger item 9):** Read the cached Key Requirements from the `keyRequirements` island of `plans/<feature-slug>/assessment.html`. For each requirement, verify at least one chunk's acceptance criteria covers it. Present the coverage map:
+**Requirements coverage check (ledger item 9):** Read the cached Key Requirements from the `keyRequirements` island of `plans/<feature-slug>/assessment.html`. For each requirement, verify at least one chunk's acceptance criteria covers it. Keep the complete coverage map in the existing plan/manifest artifacts:
 
 ```
 Requirements Coverage:
@@ -442,7 +472,9 @@ Requirements Coverage:
 
 If any requirement is uncovered, fix it before proceeding. Mark item 9 when coverage is 100%.
 
-Present the manifest summary: chunk count, parallel groups, overlap risk, requirements coverage.
+At the gate, present only the chunk count, whether coverage is complete, any
+operator decision, one recommended next action, and the manifest path. Keep
+parallel groups, overlap detail, and the full coverage map in the manifest.
 
 ## Phase 5: Adversarial Scope Review
 
@@ -597,24 +629,21 @@ Entries marked "Addressed" without an evidence type are treated as NOT ADDRESSED
 
 Mark item 13 as complete.
 
-**GATE (ledger item 14):** Use AskUserQuestion to present options:
-
-"Feature branch `<branch>` is ready. Review it with `git log main..<branch>`. What next?"
-
-Options:
-1. **Create PR** -- work continues on the branch; feature-scoped artifacts retained
-2. **Give feedback** -- another iteration; feature-scoped artifacts retained
-3. **Done -- clean up** -- retain only `receipt.md`
+**GATE (ledger item 14):** Use AskUserQuestion with the compact terminal summary
+contract above. Lead with the outcome and one recommendation, for example:
+"Done. Feature branch `<branch>` passed verification. Recommended next action:
+create the PR. Reply with feedback instead if another iteration is needed."
+Include the evidence paths. Do not print a standing multiple-choice menu.
 
 **The repository cleanup phase runs on all three answers.** Only *artifact* disposition varies by answer. Orphan worktrees and temp chunk branches are never left behind because the caller chose "Create PR" or "Give feedback" -- they collide with the next run's `git worktree add`. See `plugins/dm-review/skills/review/references/repo-cleanup-contract.md`.
 
 Before presenting this gate, confirm the orchestrator's Step 5b ran its repository cleanup and that `plans/<feature-slug>/receipt.md` carries a `## Branch & Worktree Inventory` block. If it does not, run the cleanup phase now and write the inventory before proceeding.
 
-**If option 1 (PR):** Proceed to create PR. The feature branch is kept (no merge proof yet -- that is expected, and the inventory says so). Artifact Tier 3 cleanup deferred until the user returns.
+**If the user chooses PR:** Proceed to create PR. The feature branch is kept (no merge proof yet -- that is expected, and the inventory says so). Artifact Tier 3 cleanup deferred until the user returns.
 
-**If option 2 (feedback):** Append the new feedback to `original-prompt.md` as a new section (`## Iteration N Feedback`), extract new requirements, and re-enter at Phase 3 or Phase 4. This ensures feedback accumulates rather than replacing context.
+**If the user gives feedback:** Append the new feedback to `original-prompt.md` as a new section (`## Iteration N Feedback`), extract new requirements, and re-enter at Phase 3 or Phase 4. This ensures feedback accumulates rather than replacing context.
 
-**If option 3 (done):** Run full cleanup per the artifact lifecycle policy:
+**If the user says done:** Run full cleanup per the artifact lifecycle policy:
 1. Ensure `plans/<feature-slug>/receipt.md` exists (written by orchestrator Step 5b). If missing, write it now.
 2. Delete Tier 1 + 2 artifacts (if not already cleaned by orchestrator).
 3. Delete Tier 3 artifacts:
@@ -628,7 +657,7 @@ Before presenting this gate, confirm the orchestrator's Step 5b ran its reposito
    Every filename carries the `plans/<slug>/` prefix. Without it the `rm` silently matches nothing and the artifacts accumulate.
 4. Only `receipt.md` remains in `plans/<feature-slug>/`.
 5. Re-verify the repository readiness checks (clean tree, no stale worktree registrations).
-6. Report: `Plan directory cleaned. Receipt retained at plans/<slug>/receipt.md.` Then reproduce the inventory's "Remaining after cleanup" table so the user sees exactly which branches still exist and why.
+6. Report: `Plan directory cleaned. Receipt retained at plans/<slug>/receipt.md.` Name only blocked refs that require operator action and point to the receipt for the complete inventory.
 
 ## Self-Audit
 

--- a/plugins/pipeline/references/artifact-lifecycle.md
+++ b/plugins/pipeline/references/artifact-lifecycle.md
@@ -57,6 +57,7 @@ Refs are not artifacts -- they are not deleted by tier, but by the safe-to-delet
 |------|------|-------|
 | `.claude/ux-review/screenshots/<date>/*.png` | 1 | Rotated: only today's date kept |
 | `.claude/ux-review/manifest.json` | 2 | Overwritten each run |
+| `.claude/ux-review/report.md` | 3 | Complete unified review, including findings, coverage, cleanup, provenance, and collapsed raw reports |
 | `.claude/ux-review/workflow-kernel/request.json` | 2 | Validated review request with unchanged/defaulted workflow class |
 | `.claude/ux-review/workflow-kernel/authoritative-receipts.json` | 2 | Cumulative ordered redacted review receipt array |
 | `.claude/ux-review/workflow-kernel/review-shadow-observation.json` | 2 | Explicit authoritative review observation snapshot |

--- a/plugins/pipeline/skills/pipeline-run/SKILL.md
+++ b/plugins/pipeline/skills/pipeline-run/SKILL.md
@@ -26,6 +26,22 @@ review for ordinary chunks, sensitive-path escalation, and the approved final
 review mode. This is the execution engine -- it creates or reuses branches, runs
 subagents, reviews, fixes, merges, and delivers a clean feature branch.
 
+## Human-Facing Completion
+
+Present the orchestrator's compact summary, not its durable ledgers. Start with
+exactly `Done`, `Needs fixes`, or `Blocked`; state what changed or stopped, the
+verification result, branch or PR, and one recommended next action. Link the
+existing `receipt.md`, `final-requirements-crosscheck.md`,
+`run-postmortem.md`, and detailed review when present. For blocked work, name
+the exact blocker, the smallest operator action, and the preserved resumable
+location. Normally stay within roughly 250 words, except for required P1/P2
+findings or a real blocker.
+
+Do not repeat `Steps Completed`, provider accounting, cleanup inventory, every
+evaluation receipt, raw review output, or a default action menu in visible chat.
+Those facts remain in the established artifacts. Put one recommended action
+before any genuinely live alternatives.
+
 ## Input
 
 <manifest_path> #$ARGUMENTS </manifest_path>
@@ -271,13 +287,9 @@ The `emit-cost-summary` command is one transaction: it owns the artifact path, c
 
 `bind-prediction` runs before corresponding authoritative actions, atomically seals the source, translated events, event digest, and RunSpec context, and appends exact binding authority to the canonical lifecycle ledger before `run.started`. `observe-pipeline` runs only after authoritative receipts exist and requires that ordered authority plus bound `pipeline-shadow-prediction.json`; direct comparison rechecks the same authority, and byte-identical predicted and authoritative receipts are valid only with the pre-start binding. It writes a separate `authoritative_observation` and never creates or changes the prediction. Without matching independent prediction evidence, observation and comparison fail closed. Keep the source and bound artifact until comparison completes. Write the shadow report and reliability metrics without changing the merge recommendation, cleanup disposition, or provider result. Never auto-delete the repository-lifetime `.workflow-kernel/repository-scope.json`; retain the terminal run directory or a durable tombstone until fresh exact-scope Docker inventory proves zero exact-run objects and no uninspectable matches, regardless of parity `match`.
 
-Present the summary report from the orchestrator, then ask:
-
-"Feature branch `<branch>` is ready. Options:
-1. Review the branch (`git log main..<branch>`)
-2. Create a PR (`gh pr create`)
-3. Give feedback for another iteration
-4. Run another full review (`/dm-review <branch>`)
-5. Done"
+Present the compact summary from the orchestrator. If an operator decision is
+still needed, ask for it after `Recommended next action`; mention additional
+choices only when they are genuinely live. Do not emit a standing five-option
+menu.
 
 If feedback given, suggest re-running `/pipeline-prompts` with the feedback to generate revision prompts, then `/pipeline-run` again on the same feature branch.

--- a/plugins/pipeline/skills/pipeline/SKILL.md
+++ b/plugins/pipeline/skills/pipeline/SKILL.md
@@ -50,6 +50,34 @@ In lean mode:
 
 **How to decide:** If the plan from Phase 3 has more than one logical step that could be parallelized or that touches separate file groups, use full mode. If it's a single coherent change that still benefits from quality checks, use lean mode. When in doubt, use full mode.
 
+## Human-Facing Output
+
+Keep phase gates, blocked-run messages, and delivery summaries compact. The
+durable artifacts carry process detail; visible chat helps the operator decide
+what to do.
+
+- At a phase gate, state what phase is ready, the decision or correction needed,
+  one recommended next action, and the artifact path. Do not paste the full
+  assessment, research, plan, requirements map, prompt inventory, or receipts.
+- A terminal summary starts with exactly `Done`, `Needs fixes`, or `Blocked`,
+  then states what changed or stopped, verification, branch or PR, one
+  recommended next action, and links or paths to the receipt, requirements
+  crosscheck, postmortem, and detailed review when present.
+- A blocked message names the exact blocker, the smallest operator action that
+  can clear it, and where resumable work is preserved. Required P1/P2 findings,
+  coverage gaps, blocked browser evidence, cleanup truth, and provenance remain
+  in the linked durable evidence.
+- Put `Recommended next action` before any additional option. Show other options
+  only when they are genuinely live decisions; do not print a default
+  multiple-choice menu.
+
+The visible summary should normally fit within roughly 250 words. Exceed that
+only to expose actionable P1/P2 findings or a real blocker. Never hide required
+action to meet the budget. Do not print `Steps Completed`, provider accounting,
+cleanup inventories, every evaluation receipt, or raw review output in chat by
+default; keep them in `receipt.md`, `run-postmortem.md`, the requirements
+crosscheck, and the established detailed review artifact.
+
 ## Provider-Adaptive Complexity
 
 Choose lean versus full mode from dependency shape, risk, and verification needs--not from a Claude model. Coding execution and review use Codex or OpenRouter. Claude effort settings may deepen explicitly non-coding planning, strategy, research synthesis, voice/editorial work, or optional plan critique, but they never change coding routes or justify broader implementation chunks.
@@ -298,7 +326,8 @@ Load the assess skill from `plugins/pipeline/skills/assess/SKILL.md`.
 3. In the existing assessment prose, classify the request as: desired outcomes; hard constraints and explicit approved decisions; implementation mechanisms proposed by the user or upstream prompt; and future or conditional ideas. Never silently discard an explicit request.
 4. Identify the smallest adequate solution. If it would omit or replace a requested mechanism, present both the smaller alternative and the mechanism-preserving option at this gate. Do not choose for the user.
 5. Save the Assessment Brief to `plans/<feature-slug>/assessment.html` (per **Artifact Format** above). Before the gate, any proposed Key Requirements are provisional. After the user's response, update the `keyRequirements` island so it contains only the resulting approved outcomes, constraints, and decisions; proposed mechanisms enter it only when the user approves them as scope.
-6. Present key findings to the user
+6. Present only the phase outcome, any correction needed, one recommended next
+   action, and the `assessment.html` path
 
 Mark ledger item 2 as complete.
 
@@ -315,7 +344,8 @@ You MUST run this phase even if you think you already have enough context. Resea
 1. Pass the feature description and Assessment Brief to the research orchestrator
 2. Dispatch parallel research agents across all available sources (ai-memory, RAG, domain plugins, web, codebase)
 3. Save the Research Brief to `plans/<feature-slug>/research.html` (per **Artifact Format** above; `findings`/`references` island)
-4. Present the Research Brief summary to the user
+4. Present only the phase outcome, any scope decision needed, one recommended
+   next action, and the `research.html` path
 
 **Verification:** The Research Brief file MUST exist on disk before proceeding. Run `ls plans/<feature-slug>/research.html` to confirm.
 
@@ -446,7 +476,7 @@ legacy/default receipt above is authoritative until a new manifest is generated.
 
 Mark ledger item 8 as complete.
 
-**Requirements coverage check (ledger item 9):** Read the cached Key Requirements from the `keyRequirements` island of `plans/<feature-slug>/assessment.html`. For each requirement, verify at least one chunk's acceptance criteria covers it. Present the coverage map:
+**Requirements coverage check (ledger item 9):** Read the cached Key Requirements from the `keyRequirements` island of `plans/<feature-slug>/assessment.html`. For each requirement, verify at least one chunk's acceptance criteria covers it. Keep the complete coverage map in the existing plan/manifest artifacts:
 
 ```
 Requirements Coverage:
@@ -457,7 +487,9 @@ Requirements Coverage:
 
 If any requirement is uncovered, fix it before proceeding. Mark item 9 when coverage is 100%.
 
-Present the manifest summary: chunk count, parallel groups, overlap risk, requirements coverage.
+At the gate, present only the chunk count, whether coverage is complete, any
+operator decision, one recommended next action, and the manifest path. Keep
+parallel groups, overlap detail, and the full coverage map in the manifest.
 
 ## Phase 5: Adversarial Scope Review
 
@@ -612,24 +644,21 @@ Entries marked "Addressed" without an evidence type are treated as NOT ADDRESSED
 
 Mark item 13 as complete.
 
-**GATE (ledger item 14):** Use AskUserQuestion to present options:
-
-"Feature branch `<branch>` is ready. Review it with `git log main..<branch>`. What next?"
-
-Options:
-1. **Create PR** -- work continues on the branch; feature-scoped artifacts retained
-2. **Give feedback** -- another iteration; feature-scoped artifacts retained
-3. **Done -- clean up** -- retain only `receipt.md`
+**GATE (ledger item 14):** Use AskUserQuestion with the compact terminal summary
+contract above. Lead with the outcome and one recommendation, for example:
+"Done. Feature branch `<branch>` passed verification. Recommended next action:
+create the PR. Reply with feedback instead if another iteration is needed."
+Include the evidence paths. Do not print a standing multiple-choice menu.
 
 **The repository cleanup phase runs on all three answers.** Only *artifact* disposition varies by answer. Orphan worktrees and temp chunk branches are never left behind because the caller chose "Create PR" or "Give feedback" -- they collide with the next run's `git worktree add`. See `plugins/dm-review/skills/review/references/repo-cleanup-contract.md`.
 
 Before presenting this gate, confirm the orchestrator's Step 5b ran its repository cleanup and that `plans/<feature-slug>/receipt.md` carries a `## Branch & Worktree Inventory` block. If it does not, run the cleanup phase now and write the inventory before proceeding.
 
-**If option 1 (PR):** Proceed to create PR. The feature branch is kept (no merge proof yet -- that is expected, and the inventory says so). Artifact Tier 3 cleanup deferred until the user returns.
+**If the user chooses PR:** Proceed to create PR. The feature branch is kept (no merge proof yet -- that is expected, and the inventory says so). Artifact Tier 3 cleanup deferred until the user returns.
 
-**If option 2 (feedback):** Append the new feedback to `original-prompt.md` as a new section (`## Iteration N Feedback`), extract new requirements, and re-enter at Phase 3 or Phase 4. This ensures feedback accumulates rather than replacing context.
+**If the user gives feedback:** Append the new feedback to `original-prompt.md` as a new section (`## Iteration N Feedback`), extract new requirements, and re-enter at Phase 3 or Phase 4. This ensures feedback accumulates rather than replacing context.
 
-**If option 3 (done):** Run full cleanup per the artifact lifecycle policy:
+**If the user says done:** Run full cleanup per the artifact lifecycle policy:
 1. Ensure `plans/<feature-slug>/receipt.md` exists (written by orchestrator Step 5b). If missing, write it now.
 2. Delete Tier 1 + 2 artifacts (if not already cleaned by orchestrator).
 3. Delete Tier 3 artifacts:
@@ -643,7 +672,7 @@ Before presenting this gate, confirm the orchestrator's Step 5b ran its reposito
    Every filename carries the `plans/<slug>/` prefix. Without it the `rm` silently matches nothing and the artifacts accumulate.
 4. Only `receipt.md` remains in `plans/<feature-slug>/`.
 5. Re-verify the repository readiness checks (clean tree, no stale worktree registrations).
-6. Report: `Plan directory cleaned. Receipt retained at plans/<slug>/receipt.md.` Then reproduce the inventory's "Remaining after cleanup" table so the user sees exactly which branches still exist and why.
+6. Report: `Plan directory cleaned. Receipt retained at plans/<slug>/receipt.md.` Name only blocked refs that require operator action and point to the receipt for the complete inventory.
 
 ## Self-Audit
 

--- a/tools/check-dependencies.sh
+++ b/tools/check-dependencies.sh
@@ -274,8 +274,8 @@ for consumer, expected in consumer_floors.items():
 
 pipeline = manifests.get("pipeline")
 dm_review_floor = None if pipeline is None else pipeline.get("pluginDependencies", {}).get("dm-review")
-if dm_review_floor != ">=1.61.0":
-    errors.append("pipeline must require dm-review >=1.61.0")
+if dm_review_floor != ">=1.62.0":
+    errors.append("pipeline must require dm-review >=1.62.0")
 
 if errors:
     for error in errors:

--- a/tools/validate-dm-review-codex-perspective.sh
+++ b/tools/validate-dm-review-codex-perspective.sh
@@ -364,10 +364,10 @@ require_text "$review_skill" 'reachable actor/input/path' "P1/P2 requires a reac
 require_text "$review_skill" 'realistic harm or regression' "P1/P2 requires realistic harm"
 require_text "$review_skill" 'smallest adequate repair' "P1/P2 requires the smallest repair"
 require_text "$consolidator" 'Reject scope-expanding repairs' "consolidation rejects unrelated product scope"
-require_text "$REPO_ROOT/plugins/dm-review/.claude-plugin/plugin.json" '"version": "1.61.0"' "canonical dm-review version is 1.61.0"
-require_text "$REPO_ROOT/plugins/dm-review/.codex-plugin/plugin.json" '"version": "1.61.0"' "generated dm-review version is 1.61.0"
-require_text "$REPO_ROOT/plugins/pipeline/.claude-plugin/plugin.json" '"version": "1.50.0"' "canonical Pipeline version is 1.50.0"
-require_text "$REPO_ROOT/plugins/pipeline/.codex-plugin/plugin.json" '"dm-review": ">=1.61.0"' "generated Pipeline dependency floor is current"
+require_text "$REPO_ROOT/plugins/dm-review/.claude-plugin/plugin.json" '"version": "1.62.0"' "canonical dm-review version is 1.62.0"
+require_text "$REPO_ROOT/plugins/dm-review/.codex-plugin/plugin.json" '"version": "1.62.0"' "generated dm-review version is 1.62.0"
+require_text "$REPO_ROOT/plugins/pipeline/.claude-plugin/plugin.json" '"version": "1.51.0"' "canonical Pipeline version is 1.51.0"
+require_text "$REPO_ROOT/plugins/pipeline/.codex-plugin/plugin.json" '"dm-review": ">=1.62.0"' "generated Pipeline dependency floor is current"
 
 printf "Synthesis identity fixtures\n"
 base_id=$(fixture_finding_id \

--- a/tools/validate-workflow-contracts.sh
+++ b/tools/validate-workflow-contracts.sh
@@ -501,7 +501,7 @@ for loop_contract in "$review_loop" "$review_loop_skill"; do
 done
 require_text "$review_skill" '`review_lane_allowlist`' "review receiver names the selective lane allowlist"
 require_text "$REPO_ROOT/plugins/dm-review/.claude-plugin/plugin.json" '"workflow-kernel": ">=0.14.0"' "dm-review requires the simplified verification kernel release"
-require_text "$REPO_ROOT/plugins/pipeline/.claude-plugin/plugin.json" '"dm-review": ">=1.61.0"' "pipeline requires proportional-scope dm-review release"
+require_text "$REPO_ROOT/plugins/pipeline/.claude-plugin/plugin.json" '"dm-review": ">=1.62.0"' "pipeline requires compact-handoff dm-review release"
 require_text "$REPO_ROOT/plugins/dm-review/.claude-plugin/plugin.json" '"name": "Second Perspective Reviewer"' "dm-review manifest names the provider-neutral perspective lane"
 require_text "$REPO_ROOT/plugins/dm-review/.claude-plugin/plugin.json" 'family-independent second-opinion review' "dm-review manifest describes family-independent perspective resolution"
 require_text "$REPO_ROOT/plugins/dm-review/skills/review/references/agent-registry.md" 'Full mode only.' "migration-validator registry limits the lane to full mode"
@@ -1062,6 +1062,119 @@ for f in "$openrouter_agent_runner" "$openrouter_wrapper"; do
   require_text "$f" "security review role requires Kimi K3 primary and GPT-5.6 Terra fallback" \
     "$rel binds security review routing to the approved model pair"
 done
+
+# ---------------------------------------------------------------------------
+# Group 10: compact human output with durable evidence
+# ---------------------------------------------------------------------------
+printf "\nGroup 10: compact human output with durable evidence\n"
+
+voice_check="$REPO_ROOT/plugins/ghostwriter/commands/voice-check.md"
+voice_check_alias="$REPO_ROOT/plugins/ghostwriter/skills/voice-check/SKILL.md"
+review_output="$REPO_ROOT/plugins/dm-review/skills/review/references/output-format.md"
+review_consolidator="$REPO_ROOT/plugins/dm-review/agents/workflow/review-consolidator.md"
+review_command="$REPO_ROOT/plugins/dm-review/commands/dm-review.md"
+review_alias="$REPO_ROOT/plugins/dm-review/skills/dm-review/SKILL.md"
+pipeline_alias="$REPO_ROOT/plugins/pipeline/skills/pipeline/SKILL.md"
+
+for f in "$voice_check" "$voice_check_alias"; do
+  rel="${f#$REPO_ROOT/}"
+  require_text "$f" 'Puffery, promotional filler, vague attribution, and generic conclusions' \
+    "$rel audits promotional and vague language"
+  require_text "$f" 'Sentences that express a feeling but provide no fact, instruction, example, or decision' \
+    "$rel requires concrete information"
+  require_text "$f" 'Dense sentences that require rereading' \
+    "$rel catches dense sentences"
+  require_text "$f" 'Sterile rewrites that remove the writer' \
+    "$rel preserves deliberate voice"
+  require_text "$f" '## Verdict' "$rel starts the compact result shape with Verdict"
+  require_text "$f" '## Fix now' "$rel includes impact-ordered fixes"
+  require_text "$f" '## Suggested rewrite' "$rel includes direct replacement text"
+  require_text "$f" '## What remains' "$rel limits residual commentary"
+done
+require_absent "$voice_check" 'Provide 2-3 rewritten passages' \
+  "voice-check no longer forces a fixed rewrite count"
+
+require_before "$review_output" '## Compact Human Handoff' '## Complete Report Template' \
+  "dm-review leads with compact handoff before complete evidence"
+require_text "$review_output" 'path:anchor -- problem -- smallest adequate fix' \
+  "dm-review handoff has the compact P1/P2 row shape"
+require_text "$review_output" 'findings` with the exact remaining count' \
+  "dm-review discloses the exact overflow count"
+require_text "$review_output" 'exact count and evidence pointer in this handoff' \
+  "dm-review keeps P3 advisory detail out of the handoff"
+require_text "$review_output" '### Synthesis Decisions' \
+  "dm-review retains the complete synthesis ledger"
+require_text "$review_output" '### Repository Cleanup' \
+  "dm-review retains cleanup truth"
+require_text "$review_output" '### Detailed Agent Reports' \
+  "dm-review retains raw reviewer evidence"
+require_text "$review_skill" 'Preserve the complete unified report and all' \
+  "dm-review preserves complete report evidence"
+require_text "$review_skill" 'write the complete report to `.claude/ux-review/report.md`' \
+  "dm-review always writes the complete report before compact delivery"
+require_text "$lifecycle" '| `.claude/ux-review/report.md` | 3 |' \
+  "dm-review complete report uses the existing artifact lifecycle"
+require_text "$review_consolidator" 'Coverage Gaps' \
+  "dm-review consolidator retains coverage gaps"
+require_absent "$review_skill" 'Output the full report to the user.' \
+  "dm-review rejects the old visible full-report dump"
+for f in "$review_command" "$review_alias"; do
+  rel="${f#$REPO_ROOT/}"
+  require_text "$f" 'show only the exact count and evidence pointer in the compact handoff' \
+    "$rel keeps P3 detail in complete evidence"
+  require_absent "$f" 'retain every P3 as a visible advisory' \
+    "$rel rejects expanded P3 delivery"
+done
+require_text "$review_output" 'Clean review:' \
+  "dm-review carries a clean-review specimen"
+require_text "$review_output" 'Review with actionable findings:' \
+  "dm-review carries an actionable-review specimen"
+
+for f in "$pipeline_cmd" "$pipeline_alias" "$pipeline_run" "$pipeline_run_skill"; do
+  rel="${f#$REPO_ROOT/}"
+  require_text "$f" 'Done' "$rel includes the successful outcome token"
+  require_text "$f" 'Needs fixes' "$rel includes the repair outcome token"
+  require_text "$f" 'Blocked' "$rel includes the blocked outcome token"
+  require_text "$f" 'Recommended next action' "$rel requires one recommended next action"
+done
+require_text "$orchestrator" '## <Done | Needs fixes | Blocked>' \
+  "Pipeline final summary leads with the outcome"
+require_text "$orchestrator" '**Recommended next action:** <one action; for blocked work, the smallest operator action>' \
+  "Pipeline final summary has one recommended action"
+require_text "$orchestrator" 'Successful-run specimen:' \
+  "Pipeline carries a successful-run specimen"
+require_text "$orchestrator" 'Blocked-run specimen:' \
+  "Pipeline carries a blocked-run specimen"
+require_text "$orchestrator" 'Required Safari evidence for `member-form-mobile` could not run' \
+  "blocked specimen exposes exact browser evidence"
+require_text "$orchestrator" 'plans/<feature-slug>/receipt.md' \
+  "Pipeline keeps the durable receipt path"
+require_text "$orchestrator" 'plans/<feature-slug>/final-requirements-crosscheck.md' \
+  "Pipeline keeps the durable requirements crosscheck"
+require_text "$orchestrator" 'plans/<feature-slug>/run-postmortem.md' \
+  "Pipeline keeps the durable postmortem"
+require_text "$orchestrator" 'write both under `## Codify Proposals` in the mandatory' \
+  "Pipeline preserves approval-ready codify proposals in the postmortem"
+require_text "$orchestrator" 'Detailed review: `.claude/ux-review/report.md`' \
+  "Pipeline links the mandatory detailed review artifact"
+require_text "$orchestrator" 'providerSplit: {claude: N, codex: N, openrouter: N}' \
+  "Pipeline receipt retains provider provenance"
+require_text "$orchestrator" 'retained/blocked <J>' \
+  "Pipeline receipt retains cleanup truth"
+require_text "$orchestrator" 'P1/P2' \
+  "Pipeline still preserves actionable findings"
+require_text "$orchestrator" 'human_help_required' \
+  "Pipeline still preserves blocked browser evidence"
+require_absent "$orchestrator" '# Pipeline Execution Complete' \
+  "Pipeline rejects the old giant visible completion template"
+require_absent "$pipeline_run" 'Feature branch `<branch>` is ready. Options:' \
+  "pipeline-run rejects the old standing action menu"
+require_text "$pipeline_cmd" 'Keep the complete coverage map in the existing plan/manifest artifacts' \
+  "Pipeline phase gate keeps detailed coverage durable"
+require_text "$pipeline_cmd" 'At the gate, present only the chunk count' \
+  "Pipeline phase gate stays compact"
+require_absent "$pipeline_cmd" 'Then reproduce the inventory' \
+  "Pipeline cleanup delivery does not dump the complete inventory"
 
 printf "\n"
 if [ "$failures" -ne 0 ]; then

--- a/tools/validate-workflow-contracts.sh
+++ b/tools/validate-workflow-contracts.sh
@@ -1111,7 +1111,15 @@ require_text "$review_output" '### Detailed Agent Reports' \
 require_text "$review_skill" 'Preserve the complete unified report and all' \
   "dm-review preserves complete report evidence"
 require_text "$review_skill" 'write the complete report to `.claude/ux-review/report.md`' \
-  "dm-review always writes the complete report before compact delivery"
+  "dm-review always writes the complete report"
+require_before "$review_skill" '### Phase 8: Repository Cleanup' '### Finalize Report and Deliver Handoff' \
+  "dm-review finalizes the report only after mandatory cleanup"
+require_before "$review_skill" '### Phase 8: Repository Cleanup' 'write the complete report to `.claude/ux-review/report.md`' \
+  "dm-review writes the complete report only after cleanup truth exists"
+require_before "$review_skill" 'write the complete report to `.claude/ux-review/report.md`' 'Deliver the compact human handoff' \
+  "dm-review delivers the compact handoff only after the complete report write"
+require_text "$review_skill" 'Do not write `.claude/ux-review/report.md` or deliver the compact human handoff' \
+  "dm-review consolidation explicitly forbids early final delivery"
 require_text "$lifecycle" '| `.claude/ux-review/report.md` | 3 |' \
   "dm-review complete report uses the existing artifact lifecycle"
 require_text "$review_consolidator" 'Coverage Gaps' \
@@ -1157,6 +1165,12 @@ require_text "$orchestrator" 'write both under `## Codify Proposals` in the mand
   "Pipeline preserves approval-ready codify proposals in the postmortem"
 require_text "$orchestrator" 'Detailed review: `.claude/ux-review/report.md`' \
   "Pipeline links the mandatory detailed review artifact"
+require_before "$orchestrator" '## Step 4c: Merge Policy Check' '## Step 6: Summary Report' \
+  "Pipeline records merge policy before final human delivery"
+require_text "$orchestrator" 'state `noMergeOnCompletion=true` in **Branch or PR** and make manual branch review the single **Recommended next action**' \
+  "Pipeline routes no-merge disposition into live compact-summary fields"
+require_absent "$orchestrator" 'Summary Report'"'"'s "Next Steps" section' \
+  "Pipeline no longer points no-merge runs at the deleted Next Steps section"
 require_text "$orchestrator" 'providerSplit: {claude: N, codex: N, openrouter: N}' \
   "Pipeline receipt retains provider provenance"
 require_text "$orchestrator" 'retained/blocked <J>' \

--- a/tools/validate-workflow-contracts.sh
+++ b/tools/validate-workflow-contracts.sh
@@ -1124,6 +1124,20 @@ require_text "$lifecycle" '| `.claude/ux-review/report.md` | 3 |' \
   "dm-review complete report uses the existing artifact lifecycle"
 require_text "$review_consolidator" 'Coverage Gaps' \
   "dm-review consolidator retains coverage gaps"
+require_text "$review_consolidator" 'provisional report body preserving' \
+  "dm-review consolidator produces only a provisional report body"
+require_text "$review_consolidator" 'Do not write `.claude/ux-review/report.md` and do not deliver or project the' \
+  "dm-review consolidator forbids delegated publication"
+require_before "$review_consolidator" '### Step 5.5: Coverage Gaps' 'Return the provisional report body only after this Coverage Gaps section is' \
+  "dm-review consolidator completes coverage gaps before returning its provisional body"
+require_absent "$review_consolidator" 'Write that report to `.claude/ux-review/report.md`' \
+  "dm-review consolidator does not write the final report early"
+require_absent "$review_consolidator" 'then project its compact' \
+  "dm-review consolidator does not project the handoff early"
+require_text "$review_skill" 'After consolidation, determine tracking method automatically:' \
+  "dm-review issue tracking follows consolidation rather than publication"
+require_absent "$review_skill" 'After outputting the report' \
+  "dm-review removes the stale early-publication Phase 6 phrase"
 require_absent "$review_skill" 'Output the full report to the user.' \
   "dm-review rejects the old visible full-report dump"
 for f in "$review_command" "$review_alias"; do


### PR DESCRIPTION
## Summary

- expand voice-check concrete-language criteria and return a compact edit shape
- lead dm-review with an actionable handoff while preserving the full report at `.claude/ux-review/report.md`
- replace Pipeline phase/final output walls with outcome-first summaries backed by existing receipts
- add representative specimens and regression checks; bump ghostwriter, dm-review, and Pipeline minor versions

## Verification

- `./tools/generate-codex-manifests.py --check`
- `./tools/generate-codex-command-skills.py --check`
- `./tools/validate-workflow-contracts.sh`
- `./tools/validate-dm-review-codex-perspective.sh`
- `./tools/validate-codex-native-pipeline.sh`
- `./tools/validate-dual-compat.sh`
- `./tools/validate-composition.sh --all`
- `git diff --check`

A focused read-only diff review found two durable-evidence gaps; one repair bound the complete dm-review report to the existing UX-review artifact flow and codify proposals to the mandatory Pipeline postmortem. Targeted rechecks passed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Design-Machines-Studio/codesmith/depot/pr/53"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789227804&installation_model_id=428410&pr_number=53&repository=Design-Machines-Studio%2Fdepot&return_to=https%3A%2F%2Fgithub.com%2FDesign-Machines-Studio%2Fdepot%2Fpull%2F53&signature=5dcf884c1dfd2577852cf320a7636d3fef70dd7c5ebf9858a86233279d71cd09"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->