### PR TITLE
fix(pipeline): preserve rejected OpenRouter attempt evidence

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -361,7 +361,7 @@
     {
       "name": "pipeline",
       "source": "./plugins/pipeline",
-      "version": "1.51.1",
+      "version": "1.51.2",
       "author": {
         "name": "Design Machines",
         "url": "https://designmachines.studio"

--- a/plans/depot-efficiency-program.md
+++ b/plans/depot-efficiency-program.md
@@ -10,24 +10,29 @@ external handoff only; it does not duplicate Baseplate's production roadmap.
 
 The current priority order is:
 
-1. **P1 -- close out the real cheap-path canary.** PR
+1. **P1 -- preserve rejected OpenRouter attempt evidence.** PR #55 supplied
+   the real R4 specimen: a paid provider response was rejected as
+   `headerless-diff`, then its temporary wrapper receipt was deleted. Preserve
+   the existing content-free receipt through Workflow Kernel `record-attempt`;
+   do not create a separate report system.
+2. **Close out the real cheap-path canary.** PR
    [#55](https://github.com/Design-Machines-Studio/depot/pull/55) merged the
    runtime resolver repair. Issue
    [#28](https://github.com/Design-Machines-Studio/depot/issues/28) remains open
    in `Review` for owner closeout; do not invent more implementation work.
-2. **Next -- reusable Assembly planning coordinator.**
-   [#54](https://github.com/Design-Machines-Studio/depot/issues/54) captures the
-   shared GitHub-native planning, Design Machines context, prompt preparation,
-   and scope-guard workflow for both Travis and Jeremy.
-3. **Prepared P2 -- Assembly release-operations skill planning.** The
+3. **Assembly planning coordinator complete.**
+   [#54](https://github.com/Design-Machines-Studio/depot/issues/54) and PR #57
+   are complete on trusted main.
+4. **Prepared P2 -- Assembly release-operations skill planning.** The
    [planning prompt](assembly-release-skill/prompts/00-plan-assembly-release.md)
    will decide the smallest reusable `/assembly-release` boundary from current
    Depot and Baseplate evidence. It follows the optimization initiative, does
    not delay live Baseplate or Fixture releases, and is not yet a Project item.
-4. **Evidence-gated follow-ons.** Workflow Kernel changes, R4, R5, new routing,
-   and speculative harness/platform tooling stay parked until a current failure
-   or measured workload proves the need.
-5. **P2 -- Fixture handoff remains external.** Baseplate and Jig own their
+5. **Evidence-gated follow-ons.** Workflow Kernel changes, R5, new routing, and
+   speculative harness/platform tooling stay parked until a current failure or
+   measured workload proves the need. R2 remains done/no-code and R3 remains
+   removed.
+6. **P2 -- Fixture handoff remains external.** Baseplate and Jig own their
    verifier/product repair; Depot supplies proportional policy, not product code.
 
 ### Single next Depot chunk
@@ -46,10 +51,10 @@ results. No measured workload justifies adding the authored caller-supplied
 `mechanical_globs` policy, so the old untracked R2 prompts are historical inputs,
 not executable work.
 
-The immediate Depot successor is #54. It should turn the planning discipline
-used in this program into a small reusable coordinator for Travis and Jeremy.
-Issue #28 needs only owner review/closure against merged PR #55; that bookkeeping
-does not justify another implementation session.
+Issue #54 is complete through PR #57. The immediate Depot successor is the
+narrow R4 failure-observability residual above: retain an existing validated
+wrapper receipt long enough to atomically record the paid rejected attempt.
+Issue #28 still needs only owner review/closure against merged PR #55.
 
 ### Ordered Depot queue
 
@@ -64,22 +69,23 @@ does not justify another implementation session.
 | 6 | Clear Publish Preview operator output | **DONE** | PR #51 exact head `6da69ba` landed through `3c2a276`; the playbook returns explicit publication status |
 | 7 | Clear human output for voice-check, dm-review, and Pipeline | **DONE** | PR #53 merged as `ecc8533`; three release tags and both installed harness caches are current |
 | 8 | [#28](https://github.com/Design-Machines-Studio/depot/issues/28) / [PR #55](https://github.com/Design-Machines-Studio/depot/pull/55) runtime cache-resolution repair and cheap-path canary | **MERGED / ISSUE REVIEW** | exact head `d462e8f` merged as `5afc8de`; owner closes #28 after confirming the merged outcome |
-| 9 | [#54](https://github.com/Design-Machines-Studio/depot/issues/54) reusable Assembly planning-coordinator skill | **NEXT / P1** | Travis and Jeremy recover the same live cross-repository successor and produce proportional prompts from a fresh session |
+| 9 | [#54](https://github.com/Design-Machines-Studio/depot/issues/54) / PR #57 reusable Assembly planning-coordinator skill | **DONE** | merged at `844fc1b`; live Project 1 records the native issue Done |
 | 10 | [Assembly release-operations skill planning](assembly-release-skill/prompts/00-plan-assembly-release.md) | **PREPARED / P2 / AFTER OPTIMIZATION** | live Depot/Baseplate inspection proves the smallest command boundary and produces one implementation prompt without delaying active releases |
 | 11 | Minimal worker/advisor routing adjustment | HOLD / REASSESS | canary shows a concrete routing miss; otherwise current matrix stands |
 | 12 | Baseplate verifier -> canonical Jig Fixture handoff | EXTERNAL / P2 | producer checks and consumer proof clear in their owning repositories; roadmap remains external |
-| 13 | R4 static run report | LATER / EVIDENCE-GATED | a current failed run supplies a diagnosis specimen |
+| 13 | R4 rejected OpenRouter attempt evidence | **CURRENT / P1** | a provider-completed `headerless-diff` failure retains content-free usage/cost evidence through one `record-attempt` call; no standalone report |
 | 14 | R5 Agent Plugins interop | PARK / EVIDENCE-GATED | a named client or distribution target exists |
 | 15 | Workflow Kernel or speculative harness/platform changes | HOLD / EVIDENCE-GATED | a current reachable failure proves the smallest required change |
 | 16 | Workflow Authority install, integration, and Darwin port | **REMOVED** | reintroduction requires a new owner decision backed by a demonstrated threat or operational need |
 
 The Fixture-development handoff remains an external P2 lane and may advance in
 parallel when its Baseplate/Jig dependency chain clears; it does not displace
-the single `NEXT` Depot chunk.
+the single `CURRENT` Depot chunk.
 
-Only #54 authorizes the next Depot execution session. The Assembly release
-prompt is prepared P2 planning work after the optimization initiative. DONE,
-HOLD, EXTERNAL, LATER, FUTURE, PARK, and PREPARED are not execution prompts.
+Only the R4 rejected-attempt-evidence residual authorizes the next Depot
+execution session. The Assembly release prompt is prepared P2 planning work
+after the optimization initiative. DONE, HOLD, EXTERNAL, LATER, FUTURE, PARK,
+and PREPARED are not execution prompts.
 
 ### Cross-repository handoff
 
@@ -89,12 +95,13 @@ HOLD, EXTERNAL, LATER, FUTURE, PARK, and PREPARED are not execution prompts.
 | Baseplate Fixture verifier | [PR 662](https://github.com/Design-Machines-Studio/assembly-baseplate/pull/662) open, non-draft, mergeable at `af2411a3a3ea3d7d55315bd909d7817cf72bb413`; required test, security, composer-security, and docker-startup checks pass; addresses [#659](https://github.com/Design-Machines-Studio/assembly-baseplate/issues/659) | exact-head owner review/merge and trusted verifier publication | Baseplate acts next. Safe in parallel with Depot; PR 660 is merged, so its former file collision is gone. |
 | Canonical Jig | [PR 11](https://github.com/Design-Machines-Studio/assembly-fixture-jig/pull/11) draft at `a1738fccc31f6738b546d36e0e7d949ae67ae0a6`; mergeable but unstable because `pull-request-checks` fails; [#8](https://github.com/Design-Machines-Studio/assembly-fixture-jig/issues/8) and [#10](https://github.com/Design-Machines-Studio/assembly-fixture-jig/issues/10) remain open | published Baseplate verifier, repaired exact-head check, required consumer proof, and retained browser evidence | Jig acts after Baseplate. No Depot file collision; dependency and red CI block closeout. |
 
-Project 1 carries #28 as `Review / P1 / Tooling`, #54 as the sole Depot
-`Next / P1 / Tooling` item, and the active Baseplate/Jig native items with their
-existing fields. Depot Issues #35 and #39 are `Done`. No native Issue exists yet
-for the Assembly release skill; its planner must inspect live Baseplate release
-state before admitting one. Do not create a free-form Project note for the
-prepared prompt.
+Project 1 carries #28 as `Review / P1 / Tooling`, #54 as
+`Done / P1 / Tooling`, and the active Baseplate/Jig native items with their
+existing fields. This R4 residual will enter Project 1 as its native PR in
+`Review / P1 / Tooling`; no duplicate Issue or free-form note is needed. Depot
+Issues #35 and #39 are `Done`. No native Issue exists yet for the Assembly
+release skill; its planner must inspect live Baseplate release state before
+admitting one.
 
 ### Operating doctrine
 
@@ -111,9 +118,10 @@ prepared prompt.
 - Workflow Authority has been removed. Do not reintroduce a provider broker or
   make one a prerequisite for Pipeline or dm-review without a new owner decision
   backed by a demonstrated threat or operational need.
-- R2 is closed rather than run as authored; R4 waits for a real diagnostic
-  specimen; R5 waits for a real consumer. Old prompts remain historical inputs
-  until explicitly refreshed and marked NEXT.
+- R2 is closed rather than run as authored. The old R4 report proposal is
+  retired in favor of the evidenced receipt-retention residual. R5 waits for a
+  real consumer. Old prompts remain historical inputs until explicitly
+  refreshed and marked NEXT.
 
 The historical program below is retained as provenance. Its old `Next`,
 `PENDING`, and entry-gate labels do not override the active queue above.

--- a/plugins/pipeline/.claude-plugin/plugin.json
+++ b/plugins/pipeline/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "pipeline",
   "description": "Autonomous feature development pipeline with approved-scope intake, minimum-adequate planning, bounded adversarial review, fresh tiered verification, browser recovery, and isolated execution",
-  "version": "1.51.1",
+  "version": "1.51.2",
   "author": {
     "name": "Design Machines",
     "url": "https://designmachines.io"

--- a/plugins/pipeline/.codex-plugin/plugin.json
+++ b/plugins/pipeline/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pipeline",
-  "version": "1.51.1",
+  "version": "1.51.2",
   "description": "Autonomous feature development pipeline with approved-scope intake, minimum-adequate planning, bounded adversarial review, fresh tiered verification, browser recovery, and isolated execution",
   "author": {
     "name": "Design Machines",

--- a/plugins/pipeline/agents/workflow/execution-orchestrator.md
+++ b/plugins/pipeline/agents/workflow/execution-orchestrator.md
@@ -364,6 +364,16 @@ one-use receipt-consumption registry from the repository lease root rather than
 accepting a caller-selected ledger.
 Each wrapper receipt is one-use measurement evidence; a retry must record the
 new receipt produced by that provider attempt rather than replay the prior one.
+For Pipeline OpenRouter execution, give `cascade-dispatch.sh` a fresh
+repository-relative `--attempt-receipt` path for every chunk attempt and export
+that attempt's `OPENROUTER_RUN_ID` and `OPENROUTER_LANE_ID`. The adapter writes
+the validated content-free wrapper receipt there before patch validation. A
+provider-completed patch rejection therefore records `status: failed` with the
+exact stable rejection reason and that receipt. If no wrapper receipt was
+produced, still call `record-attempt` without measurement evidence so the pair
+contains `attempt_unmeasured`; never estimate the missing usage. A successful
+attempt uses the same retained receipt once and must not also append standalone
+`openrouter-usage` evidence.
 
 A `lanes: 0` cost summary after a run that executed chunks means this step was
 skipped. The terminal `emit-cost-summary` reports the count on the receipt line
@@ -1034,16 +1044,22 @@ PRIMARY_RAIL_STATUS="ready"
 # proactive probe proves the selected primary cannot run.
 # PRIMARY_RAIL_STATUS="capped-or-unavailable"
 OPENROUTER_EXEC_ALLOWED_PATHS="$CHUNK_FILES_TO_MODIFY_NEWLINE"
-export OPENROUTER_EXEC_ALLOWED_PATHS
+OPENROUTER_ATTEMPT_RECEIPT="plans/<feature-slug>/receipts/openrouter/<chunk-id>-attempt-<n>.json"
+mkdir -p "$(dirname "$OPENROUTER_ATTEMPT_RECEIPT")"
+OPENROUTER_RUN_ID="<run-id>"
+OPENROUTER_LANE_ID="<chunk-id>"
+export OPENROUTER_EXEC_ALLOWED_PATHS OPENROUTER_RUN_ID OPENROUTER_LANE_ID
 run_cascade() {
   local exhausted_rail="${1:-}"
   if [ -n "$exhausted_rail" ]; then
     printf '%s' "$CHUNK_PROMPT" | "$CASCADE_DISPATCH" \
       --kind "<kind>" --prompt - --phase execute --timeout 3600 \
-      --exhausted-rail "$exhausted_rail"
+      --exhausted-rail "$exhausted_rail" \
+      --attempt-receipt "$OPENROUTER_ATTEMPT_RECEIPT"
   else
     printf '%s' "$CHUNK_PROMPT" | "$CASCADE_DISPATCH" \
-      --kind "<kind>" --prompt - --phase execute --timeout 3600
+      --kind "<kind>" --prompt - --phase execute --timeout 3600 \
+      --attempt-receipt "$OPENROUTER_ATTEMPT_RECEIPT"
   fi
 }
 CASCADE_EXHAUSTED_RAIL=""
@@ -1070,10 +1086,21 @@ Never parse model names yourself -- the script owns class->ladder->role->rail re
 | `CASCADE_RC` | Meaning | Orchestrator action |
 |---|---|---|
 | `64` | NATIVE rung. stdout is `{dispatch:"native",model,role,probe_rail}`. | Parse `model` and `role`. **Re-dispatch IN-PROCESS through the current host's native path**, then apply **Native Model Descent** below. Do NOT run anything from the script. Then proceed to Step 3e exactly as a normal dispatch. |
+| `65` | OpenRouter reached the provider, retained its wrapper receipt when available, and rejected the returned implementation structurally. stderr names the stable reason, such as `headerless-diff`. | Call `record-attempt` exactly once with `status: failed`, the exact rejection reason, and the retained receipt when present. Do not apply or commit the patch. This is a non-cap quality failure: flag the chunk failed without retry or fallback. |
 | `0` | `openrouter_exec`, wrapper, or codex-companion rung executed; stdout is produced text or a receipt. | If stdout includes `implementedBy: openrouter` or a JSON receipt with `"implementedBy": "openrouter"`, treat it as an agentic OpenRouter implementation receipt. Otherwise apply the **one-shot validity rule** below. |
 | `76` | Ladder exhausted -- no configured rung above the quality floor had headroom. | Run **Step 3d.5 -- Rail-exhaustion ask gate** BEFORE any terminal receipt. The current exits are: **wait** -> parked resumable, `wait_category: human_gate` receipt carries the named reset time and resume instruction; **park, `PIPELINE_EXHAUSTION_ASK=0`, a fail-closed policy read, or any context that cannot reach the operator** -> flag the chunk failed and preserve resumable state. Do NOT silently ship partial output. |
 | `77` | Missing/invalid key, unavailable provider/bundle, or automatic disclosure/output boundary decline. | Record the exact reason, then use the Codex fallback without prompting. |
-| other | Bad args / engine error. | Fall back to Codex once. If Codex is unavailable, fail the chunk; do not route coding work to Claude. |
+| other | Bad args / engine error. | Fall back to Codex once. If Codex is unavailable, fail the chunk; do not route coding work to Claude. Never classify RC 65 or its stable rejection reason as an engine error. |
+
+After every cascade settlement, inspect only the caller-owned attempt receipt
+path for that attempt. When it exists, read its request-envelope digest and
+pass the same file to `record-attempt`; do not copy prompt, response, or patch
+content into the chunk receipt or human output. When a failed contacted attempt
+has no receipt, record it without `--openrouter-receipt`, producing
+`attempt_unmeasured`. Record the eventual Codex fallback, when policy permits
+one, as its own later attempt. This keeps one usage row per real attempt and
+prevents a successful fallback from erasing or double-counting the paid failed
+call.
 
 **Native Model Descent (RC 64).** `cascade-dispatch.sh` emits a directive for the FIRST model in the role's list that clears the quality floor and then `exit 64`s -- it does **not** walk the rest of that role's `models[]`. Walking the remainder is the orchestrator's job, and it is host-specific. Without this, every model after position 1 in a `kind: native` role is decorative.
 
@@ -2048,7 +2075,7 @@ Measurement requirements:
 1. **Claude JSONL delta:** Snapshot cumulative Claude tokens at the start of Phase 6 and again here by parsing the current Claude session transcript JSONL. Sum `message.usage.{input_tokens, output_tokens, cache_creation_input_tokens, cache_read_input_tokens}` grouped by `model`. Report the DELTA as this run's Claude main-loop spend.
 2. If `ccusage` is on PATH, run `ccusage blocks --json` as a cost/pricing cross-check. Prefer ccusage cost and the Claude JSONL delta for run-scoped token counts.
 3. **Codex:** sum each exec's `tokens used` lines from chunk receipts.
-4. **OpenRouter:** sum each API `usage` object from `openrouter-exec.sh`, `openrouter-agent-runner`, and `openrouter-bulk-analyst` receipts. Calls whose model slug is `deepseek/*` remain in this OpenRouter bucket.
+4. **OpenRouter:** use the `attempt_usage` rows paired by `record-attempt`, including retained receipts for structurally rejected `openrouter-exec.sh` calls. Do not rescan successful stdout or append standalone usage for those attempts. Calls whose model slug is `deepseek/*` remain in this OpenRouter bucket.
 5. Record shell-proxy or rtk savings separately as input-avoidance context. Do not mix them into providerSplit.
 
 Post-mortem content:
@@ -2351,6 +2378,7 @@ nonexistent optional artifact rather than inventing one:
 <What changed, or the exact blocker and what stopped.>
 
 **Verification:** <passed checks and final review result, or exact failed/pending evidence>
+**Attempt result:** <for a failed provider attempt: stable failure reason; usage/cost reported or unmeasured>
 **Branch or PR:** <branch and PR URL when present>
 **Recommended next action:** <one action; for blocked work, the smallest operator action>
 **Resumable work:** <preserved branch/worktree/artifact path; required when blocked>
@@ -2361,6 +2389,10 @@ nonexistent optional artifact rather than inventing one:
 - Postmortem: `plans/<feature-slug>/run-postmortem.md`
 - Detailed review: `.claude/ux-review/report.md`
 ```
+
+Omit `Attempt result` when no provider attempt failed. When present, keep it to
+one short line: what failed and whether usage/cost was reported; the existing
+`Recommended next action` remains the single action.
 
 The visible summary normally stays within roughly 250 words. Exceed that only
 for actionable P1/P2 findings or a real blocker. Do not omit required action.

--- a/plugins/pipeline/agents/workflow/execution-orchestrator.md
+++ b/plugins/pipeline/agents/workflow/execution-orchestrator.md
@@ -365,15 +365,17 @@ accepting a caller-selected ledger.
 Each wrapper receipt is one-use measurement evidence; a retry must record the
 new receipt produced by that provider attempt rather than replay the prior one.
 For Pipeline OpenRouter execution, give `cascade-dispatch.sh` a fresh
-repository-relative `--attempt-receipt` path for every chunk attempt and export
-that attempt's `OPENROUTER_RUN_ID` and `OPENROUTER_LANE_ID`. The adapter writes
-the validated content-free wrapper receipt there before patch validation. A
-provider-completed patch rejection therefore records `status: failed` with the
-exact stable rejection reason and that receipt. If no wrapper receipt was
-produced, still call `record-attempt` without measurement evidence so the pair
-contains `attempt_unmeasured`; never estimate the missing usage. A successful
-attempt uses the same retained receipt once and must not also append standalone
-`openrouter-usage` evidence.
+repository-relative `--attempt-receipt-template` containing `{attempt}` and
+export that chunk attempt's `OPENROUTER_RUN_ID` and `OPENROUTER_LANE_ID`. The
+cascade substitutes a distinct positive sequence number for every provider
+attempt. The adapter writes each validated content-free wrapper receipt before
+patch validation, without changing the existing model-ladder or Codex-fallback
+result. A provider-completed patch rejection therefore records `status: failed`
+with the exact stable rejection reason and its receipt before the later attempt
+is recorded. If no wrapper receipt was produced, still call `record-attempt`
+without measurement evidence so the pair contains `attempt_unmeasured`; never
+estimate the missing usage. A successful attempt uses its retained receipt once
+and must not also append standalone `openrouter-usage` evidence.
 
 A `lanes: 0` cost summary after a run that executed chunks means this step was
 skipped. The terminal `emit-cost-summary` reports the count on the receipt line
@@ -1044,8 +1046,9 @@ PRIMARY_RAIL_STATUS="ready"
 # proactive probe proves the selected primary cannot run.
 # PRIMARY_RAIL_STATUS="capped-or-unavailable"
 OPENROUTER_EXEC_ALLOWED_PATHS="$CHUNK_FILES_TO_MODIFY_NEWLINE"
-OPENROUTER_ATTEMPT_RECEIPT="plans/<feature-slug>/receipts/openrouter/<chunk-id>-attempt-<n>.json"
-mkdir -p "$(dirname "$OPENROUTER_ATTEMPT_RECEIPT")"
+OPENROUTER_ATTEMPT_RECEIPT_DIR="plans/<feature-slug>/receipts/openrouter/<chunk-id>-cascade-<n>"
+OPENROUTER_ATTEMPT_RECEIPT_TEMPLATE="$OPENROUTER_ATTEMPT_RECEIPT_DIR/provider-{attempt}.json"
+mkdir -p "$OPENROUTER_ATTEMPT_RECEIPT_DIR"
 OPENROUTER_RUN_ID="<run-id>"
 OPENROUTER_LANE_ID="<chunk-id>"
 export OPENROUTER_EXEC_ALLOWED_PATHS OPENROUTER_RUN_ID OPENROUTER_LANE_ID
@@ -1055,11 +1058,11 @@ run_cascade() {
     printf '%s' "$CHUNK_PROMPT" | "$CASCADE_DISPATCH" \
       --kind "<kind>" --prompt - --phase execute --timeout 3600 \
       --exhausted-rail "$exhausted_rail" \
-      --attempt-receipt "$OPENROUTER_ATTEMPT_RECEIPT"
+      --attempt-receipt-template "$OPENROUTER_ATTEMPT_RECEIPT_TEMPLATE"
   else
     printf '%s' "$CHUNK_PROMPT" | "$CASCADE_DISPATCH" \
       --kind "<kind>" --prompt - --phase execute --timeout 3600 \
-      --attempt-receipt "$OPENROUTER_ATTEMPT_RECEIPT"
+      --attempt-receipt-template "$OPENROUTER_ATTEMPT_RECEIPT_TEMPLATE"
   fi
 }
 CASCADE_EXHAUSTED_RAIL=""
@@ -1086,20 +1089,23 @@ Never parse model names yourself -- the script owns class->ladder->role->rail re
 | `CASCADE_RC` | Meaning | Orchestrator action |
 |---|---|---|
 | `64` | NATIVE rung. stdout is `{dispatch:"native",model,role,probe_rail}`. | Parse `model` and `role`. **Re-dispatch IN-PROCESS through the current host's native path**, then apply **Native Model Descent** below. Do NOT run anything from the script. Then proceed to Step 3e exactly as a normal dispatch. |
-| `65` | OpenRouter reached the provider, retained its wrapper receipt when available, and rejected the returned implementation structurally. stderr names the stable reason, such as `headerless-diff`. | Call `record-attempt` exactly once with `status: failed`, the exact rejection reason, and the retained receipt when present. Do not apply or commit the patch. This is a non-cap quality failure: flag the chunk failed without retry or fallback. |
 | `0` | `openrouter_exec`, wrapper, or codex-companion rung executed; stdout is produced text or a receipt. | If stdout includes `implementedBy: openrouter` or a JSON receipt with `"implementedBy": "openrouter"`, treat it as an agentic OpenRouter implementation receipt. Otherwise apply the **one-shot validity rule** below. |
 | `76` | Ladder exhausted -- no configured rung above the quality floor had headroom. | Run **Step 3d.5 -- Rail-exhaustion ask gate** BEFORE any terminal receipt. The current exits are: **wait** -> parked resumable, `wait_category: human_gate` receipt carries the named reset time and resume instruction; **park, `PIPELINE_EXHAUSTION_ASK=0`, a fail-closed policy read, or any context that cannot reach the operator** -> flag the chunk failed and preserve resumable state. Do NOT silently ship partial output. |
 | `77` | Missing/invalid key, unavailable provider/bundle, or automatic disclosure/output boundary decline. | Record the exact reason, then use the Codex fallback without prompting. |
-| other | Bad args / engine error. | Fall back to Codex once. If Codex is unavailable, fail the chunk; do not route coding work to Claude. Never classify RC 65 or its stable rejection reason as an engine error. |
+| other | Bad args / engine error. | Fall back to Codex once. If Codex is unavailable, fail the chunk; do not route coding work to Claude. |
 
-After every cascade settlement, inspect only the caller-owned attempt receipt
-path for that attempt. When it exists, read its request-envelope digest and
-pass the same file to `record-attempt`; do not copy prompt, response, or patch
-content into the chunk receipt or human output. When a failed contacted attempt
-has no receipt, record it without `--openrouter-receipt`, producing
-`attempt_unmeasured`. Record the eventual Codex fallback, when policy permits
-one, as its own later attempt. This keeps one usage row per real attempt and
-prevents a successful fallback from erasing or double-counting the paid failed
+After every cascade settlement, inspect only the caller-owned numbered receipt
+files in that cascade attempt's fresh directory, in positive sequence order.
+Pair each rejected provider attempt with the corresponding content-free stable
+reason emitted on stderr, such as `headerless-diff`, then pass that file and its
+request-envelope digest to `record-attempt`. The last receipt is successful only
+when the cascade returned a committed `openrouter_exec` result; otherwise it is
+failed before the unchanged ladder or Codex fallback result. Do not copy prompt,
+response, or patch content into the chunk receipt or human output. When a failed
+contacted attempt has no receipt, record it without `--openrouter-receipt`,
+producing `attempt_unmeasured`. Record the eventual Codex fallback as its own
+later attempt. This keeps one usage row per real attempt and prevents a
+successful retry or fallback from erasing or double-counting the paid failed
 call.
 
 **Native Model Descent (RC 64).** `cascade-dispatch.sh` emits a directive for the FIRST model in the role's list that clears the quality floor and then `exit 64`s -- it does **not** walk the rest of that role's `models[]`. Walking the remainder is the orchestrator's job, and it is host-specific. Without this, every model after position 1 in a `kind: native` role is decorative.

--- a/plugins/pipeline/references/cascade-dispatch.sh
+++ b/plugins/pipeline/references/cascade-dispatch.sh
@@ -18,6 +18,7 @@
 #   0   a wrapper/codex_companion/openrouter_exec rung executed -- output on stdout
 #   64  chosen rung is NATIVE -- directive JSON on stdout; the HOST orchestrator
 #       runs that model in-process (Claude subagent / Codex). The only host-specific action.
+#   65  provider completed, but its implementation failed structural validation
 #   76  ladder exhausted -- no rung had headroom above the floor
 #   77  disclosure declined -- use the trusted native fallback
 #   2   bad args
@@ -34,6 +35,7 @@ CASCADE="${CASCADE_FILE:-$DIR/model-cascade.json}"
 PROFILE="${PROFILE_FILE:-$DIR/harness-profile.json}"
 PROBE="${PROBE_CMD:-$DIR/usage-probe.sh}"
 CLASS=""; KIND=""; PROMPT=""; PHASE="execute"; HOST=""; TIMEOUT="3600"; DRYRUN=0; PROBE_FILE=""
+ATTEMPT_RECEIPT=""
 EXHAUSTED_RAILS="${CASCADE_EXHAUSTED_RAILS:-}"
 while [ $# -gt 0 ]; do
   case "$1" in
@@ -45,6 +47,7 @@ while [ $# -gt 0 ]; do
     --timeout) TIMEOUT="$2"; shift 2;;
     --dry-run) DRYRUN=1; shift;;
     --probe-file) PROBE_FILE="$2"; shift 2;;
+    --attempt-receipt) ATTEMPT_RECEIPT="$2"; shift 2;;
     --exhausted-rail) EXHAUSTED_RAILS="${EXHAUSTED_RAILS}${EXHAUSTED_RAILS:+,}$2"; shift 2;;
     *) echo "unknown arg: $1" >&2; exit 2;;
   esac
@@ -185,7 +188,12 @@ resolve_openrouter_exec() {
 dispatch_openrouter_exec() {
   local runner; runner="$(resolve_openrouter_exec)"
   [ -z "$runner" ] && return 1
-  printf '%s' "$PROMPT" | "$runner" --model "$1" --timeout "$TIMEOUT"
+  if [ -n "$ATTEMPT_RECEIPT" ]; then
+    printf '%s' "$PROMPT" | "$runner" --model "$1" --timeout "$TIMEOUT" \
+      --attempt-receipt "$ATTEMPT_RECEIPT"
+  else
+    printf '%s' "$PROMPT" | "$runner" --model "$1" --timeout "$TIMEOUT"
+  fi
 }
 
 # Gate OpenRouter availability once before any external rung. Payload screening
@@ -359,6 +367,7 @@ for role in $LADDER; do
       openrouter_exec)
         out="$(dispatch_openrouter_exec "$model")"; rc=$?
         [ $rc -eq 0 ] && { printf '%s\n' "$out"; exit 0; }
+        [ $rc -eq 65 ] && exit 65
         if [ $rc -eq 77 ]; then
           OPENROUTER_GATE_STATE="denied"
           EXHAUSTED_RAILS="${EXHAUSTED_RAILS}${EXHAUSTED_RAILS:+,}openrouter"

--- a/plugins/pipeline/references/cascade-dispatch.sh
+++ b/plugins/pipeline/references/cascade-dispatch.sh
@@ -11,6 +11,7 @@
 #   cascade-dispatch.sh --class <codex|openrouter> --prompt <text|-> \
 #       [--kind <ui|logic|integration|config>] [--phase <p>] [--host H] \
 #       [--timeout N] [--dry-run] [--probe-file <json>] \
+#       [--attempt-receipt-template <path-with-{attempt}>] \
 #       [--exhausted-rail <codex|openrouter>]
 #   (--kind is an alternative to --class; mapped via cascade.class_from_kind)
 #
@@ -18,7 +19,6 @@
 #   0   a wrapper/codex_companion/openrouter_exec rung executed -- output on stdout
 #   64  chosen rung is NATIVE -- directive JSON on stdout; the HOST orchestrator
 #       runs that model in-process (Claude subagent / Codex). The only host-specific action.
-#   65  provider completed, but its implementation failed structural validation
 #   76  ladder exhausted -- no rung had headroom above the floor
 #   77  disclosure declined -- use the trusted native fallback
 #   2   bad args
@@ -35,7 +35,8 @@ CASCADE="${CASCADE_FILE:-$DIR/model-cascade.json}"
 PROFILE="${PROFILE_FILE:-$DIR/harness-profile.json}"
 PROBE="${PROBE_CMD:-$DIR/usage-probe.sh}"
 CLASS=""; KIND=""; PROMPT=""; PHASE="execute"; HOST=""; TIMEOUT="3600"; DRYRUN=0; PROBE_FILE=""
-ATTEMPT_RECEIPT=""
+ATTEMPT_RECEIPT_TEMPLATE=""
+OPENROUTER_ATTEMPT_INDEX=0
 EXHAUSTED_RAILS="${CASCADE_EXHAUSTED_RAILS:-}"
 while [ $# -gt 0 ]; do
   case "$1" in
@@ -47,7 +48,7 @@ while [ $# -gt 0 ]; do
     --timeout) TIMEOUT="$2"; shift 2;;
     --dry-run) DRYRUN=1; shift;;
     --probe-file) PROBE_FILE="$2"; shift 2;;
-    --attempt-receipt) ATTEMPT_RECEIPT="$2"; shift 2;;
+    --attempt-receipt-template) ATTEMPT_RECEIPT_TEMPLATE="$2"; shift 2;;
     --exhausted-rail) EXHAUSTED_RAILS="${EXHAUSTED_RAILS}${EXHAUSTED_RAILS:+,}$2"; shift 2;;
     *) echo "unknown arg: $1" >&2; exit 2;;
   esac
@@ -55,6 +56,12 @@ done
 command -v jq >/dev/null 2>&1 || { echo "cascade-dispatch: jq required" >&2; exit 2; }
 [ -z "$CLASS" ] && [ -n "$KIND" ] && CLASS="$(jq -r --arg k "$KIND" '.class_from_kind[$k] // empty' "$CASCADE")"
 [ -z "$CLASS" ] || [ -z "$PROMPT" ] && { echo "usage: $0 --class <codex|openrouter>|--kind <k> --prompt <p|-> [opts]" >&2; exit 2; }
+if [ -n "$ATTEMPT_RECEIPT_TEMPLATE" ]; then
+  case "$ATTEMPT_RECEIPT_TEMPLATE" in
+    *'{attempt}'*) ;;
+    *) echo "cascade-dispatch: attempt receipt template requires {attempt}" >&2; exit 2;;
+  esac
+fi
 [ "$PROMPT" = "-" ] && PROMPT="$(cat)"
 
 # --- host detection ----------------------------------------------------------
@@ -186,11 +193,13 @@ resolve_openrouter_exec() {
   [ -x "$DIR/openrouter-exec.sh" ] && printf '%s' "$DIR/openrouter-exec.sh"
 }
 dispatch_openrouter_exec() {
-  local runner; runner="$(resolve_openrouter_exec)"
+  local runner attempt_receipt=""
+  runner="$(resolve_openrouter_exec)"
   [ -z "$runner" ] && return 1
-  if [ -n "$ATTEMPT_RECEIPT" ]; then
+  if [ -n "$ATTEMPT_RECEIPT_TEMPLATE" ]; then
+    attempt_receipt="${ATTEMPT_RECEIPT_TEMPLATE//\{attempt\}/$2}"
     printf '%s' "$PROMPT" | "$runner" --model "$1" --timeout "$TIMEOUT" \
-      --attempt-receipt "$ATTEMPT_RECEIPT"
+      --attempt-receipt "$attempt_receipt"
   else
     printf '%s' "$PROMPT" | "$runner" --model "$1" --timeout "$TIMEOUT"
   fi
@@ -365,9 +374,9 @@ for role in $LADDER; do
         [ $rc -eq 2 ] && exit 2
         continue;;                                     # wrapper error -> next model
       openrouter_exec)
-        out="$(dispatch_openrouter_exec "$model")"; rc=$?
+        OPENROUTER_ATTEMPT_INDEX=$((OPENROUTER_ATTEMPT_INDEX + 1))
+        out="$(dispatch_openrouter_exec "$model" "$OPENROUTER_ATTEMPT_INDEX")"; rc=$?
         [ $rc -eq 0 ] && { printf '%s\n' "$out"; exit 0; }
-        [ $rc -eq 65 ] && exit 65
         if [ $rc -eq 77 ]; then
           OPENROUTER_GATE_STATE="denied"
           EXHAUSTED_RAILS="${EXHAUSTED_RAILS}${EXHAUSTED_RAILS:+,}openrouter"

--- a/plugins/pipeline/references/openrouter-exec.sh
+++ b/plugins/pipeline/references/openrouter-exec.sh
@@ -10,6 +10,7 @@ FALLBACK_MODEL="${OPENROUTER_EXEC_FALLBACK_MODEL:-}"
 TIMEOUT="${OPENROUTER_EXEC_TIMEOUT:-3600}"
 DEFERRED_VERIFY_CMD="${OPENROUTER_EXEC_VERIFY_CMD:-}"
 COMMIT_MSG="${OPENROUTER_EXEC_COMMIT_MSG:-pipeline: implement openrouter chunk}"
+ATTEMPT_RECEIPT=""
 
 while [ $# -gt 0 ]; do
   case "$1" in
@@ -19,6 +20,7 @@ while [ $# -gt 0 ]; do
     --timeout) TIMEOUT="$2"; shift 2;;
     --verify-cmd) DEFERRED_VERIFY_CMD="$2"; shift 2;;
     --commit-message) COMMIT_MSG="$2"; shift 2;;
+    --attempt-receipt) ATTEMPT_RECEIPT="$2"; shift 2;;
     *) echo "unknown arg: $1" >&2; exit 2;;
   esac
 done
@@ -50,6 +52,36 @@ fi
   echo "openrouter-exec: OPENROUTER_EXEC_ALLOWED_PATHS is required" >&2
   exit 2
 }
+
+# A caller may retain the wrapper's existing content-free receipt for this one
+# attempt. Validate the destination before provider contact, require a fresh
+# repository-contained file, and never publish the caller's path in output.
+if [ -n "$ATTEMPT_RECEIPT" ]; then
+  case "$ATTEMPT_RECEIPT" in
+    /*|../*|*/../*|*/..|./*|*/./*|*/.|*//*|*$'\n'*|*$'\r'*|*$'\t'*)
+      echo "openrouter-exec: invalid attempt receipt destination" >&2
+      exit 2
+      ;;
+  esac
+  ATTEMPT_RECEIPT_PARENT="$(dirname -- "$ATTEMPT_RECEIPT")"
+  [ -d "$ATTEMPT_RECEIPT_PARENT" ] && [ ! -L "$ATTEMPT_RECEIPT_PARENT" ] || {
+    echo "openrouter-exec: attempt receipt parent is unavailable" >&2
+    exit 2
+  }
+  REPOSITORY_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || {
+    echo "openrouter-exec: attempt receipt requires a git worktree" >&2
+    exit 2
+  }
+  RECEIPT_PARENT_REAL="$(cd "$ATTEMPT_RECEIPT_PARENT" && pwd -P)" || exit 2
+  case "$RECEIPT_PARENT_REAL/" in
+    "$REPOSITORY_ROOT/"|"$REPOSITORY_ROOT/"*) ;;
+    *) echo "openrouter-exec: attempt receipt escaped the git worktree" >&2; exit 2;;
+  esac
+  if [ -e "$ATTEMPT_RECEIPT" ] || [ -L "$ATTEMPT_RECEIPT" ]; then
+    echo "openrouter-exec: attempt receipt destination already exists" >&2
+    exit 2
+  fi
+fi
 if [ -z "${OPENROUTER_API_KEY:-}" ] && [ -z "${OPENROUTER_API_KEY_FILE:-}" ]; then
   echo "openrouter-exec: configured OpenRouter key unavailable; return to Codex" >&2
   exit 77
@@ -110,6 +142,8 @@ PATCH_PATHS_FILE="$(mktemp "$TASK_TMP_ROOT/openrouter-exec.paths.XXXXXX")"
 CACHED_PATHS_FILE="$(mktemp "$TASK_TMP_ROOT/openrouter-exec.cached.XXXXXX")"
 RECEIPT_FILE="$(mktemp "$TASK_TMP_ROOT/openrouter-exec.receipt.XXXXXX")"
 PATCH_FILE="$(mktemp "$TASK_TMP_ROOT/openrouter-exec.patch.XXXXXX")"
+BOUNDARY_ERROR_FILE="$(mktemp "$TASK_TMP_ROOT/openrouter-exec.boundary.XXXXXX")"
+ATTEMPT_RECEIPT_TMP=""
 MSG_FILE=""
 MUTATION_ACTIVE=0
 cleanup() {
@@ -121,7 +155,8 @@ cleanup() {
     }
   fi
   rm -f "$PROMPT_FILE" "$SYSTEM_FILE" "$ALLOWED_FILE" "$PATCH_PATHS_FILE" \
-    "$CACHED_PATHS_FILE" "$RECEIPT_FILE" "$PATCH_FILE" "$MSG_FILE"
+    "$CACHED_PATHS_FILE" "$RECEIPT_FILE" "$PATCH_FILE" \
+    "$BOUNDARY_ERROR_FILE" "$ATTEMPT_RECEIPT_TMP" "$MSG_FILE"
   exit "$original_rc"
 }
 trap cleanup EXIT
@@ -155,6 +190,32 @@ env -u OPENROUTER_SYSTEM OPENROUTER_SYSTEM_FILE="$SYSTEM_FILE" \
   < "$PROMPT_FILE" > "$PATCH_FILE"
 rc=$?
 set -e
+
+RECEIPT_VALID=0
+if [ -s "$RECEIPT_FILE" ] && jq -e '
+  .schemaVersion == 2 and
+  (.outcome | type == "string" and length > 0) and
+  (.invocationId | type == "string" and test("^[0-9a-f]{64}$")) and
+  (.requestedModel | type == "string" and length > 0) and
+  (.authorization.requestEnvelopeSha256 | test("^[0-9a-f]{64}$")) and
+  (.usage == null or (.usage | type == "object")) and
+  ([(.. | objects) | keys[] |
+    select(test("^(prompt|response|content|api_?key|secret)$"; "i"))] | length) == 0
+' "$RECEIPT_FILE" >/dev/null 2>&1; then
+  RECEIPT_VALID=1
+fi
+if [ "$RECEIPT_VALID" = "1" ] && [ -n "$ATTEMPT_RECEIPT" ]; then
+  ATTEMPT_RECEIPT_TMP="${ATTEMPT_RECEIPT}.tmp.$$"
+  (
+    umask 077
+    jq -c '.' "$RECEIPT_FILE" > "$ATTEMPT_RECEIPT_TMP"
+  ) || {
+    echo "openrouter-exec: could not preserve attempt receipt" >&2
+    exit 2
+  }
+  mv "$ATTEMPT_RECEIPT_TMP" "$ATTEMPT_RECEIPT"
+  ATTEMPT_RECEIPT_TMP=""
+fi
 case "$rc" in
   0) ;;
   28|1)
@@ -171,6 +232,10 @@ case "$rc" in
     ;;
 esac
 
+if [ "$RECEIPT_VALID" != "1" ]; then
+  echo "openrouter-exec: wrapper receipt invalid" >&2
+  exit 2
+fi
 jq -e '
   .schemaVersion == 2 and .outcome == "success" and
   .requestedModel != null and .responseModel != null and
@@ -179,17 +244,30 @@ jq -e '
   (.usage == null or (.usage | type == "object")) and
   ([(.. | objects) | keys[] |
     select(test("^(prompt|response|content|api_?key|secret)$"; "i"))] | length) == 0
-' "$RECEIPT_FILE" >/dev/null || {
+' "$RECEIPT_FILE" >/dev/null 2>&1 || {
   echo "openrouter-exec: wrapper receipt invalid" >&2
   exit 2
 }
 
-[ -s "$PATCH_FILE" ] || { echo "openrouter-exec: model returned no unified diff" >&2; exit 1; }
+[ -s "$PATCH_FILE" ] || {
+  echo "openrouter-exec: rejected model patch: empty-diff" >&2
+  exit 65
+}
 if "$BOUNDARY" --policy "$POLICY" --changed-files "$ALLOWED_FILE" \
-    --diff-file "$PATCH_FILE" --output-paths "$PATCH_PATHS_FILE"; then
+    --diff-file "$PATCH_FILE" --output-paths "$PATCH_PATHS_FILE" \
+    2> "$BOUNDARY_ERROR_FILE"; then
   :
 else
   rc=$?
+  PATCH_REJECTION_REASON="$(sed -n \
+    's/^delegation-boundary: input-invalid:\([a-z0-9-][a-z0-9-]*\)$/\1/p' \
+    "$BOUNDARY_ERROR_FILE" | tail -n 1)"
+  case "$PATCH_REJECTION_REASON" in
+    headerless-diff|empty-diff|non-unified-diff|diff-file-header|diff-file-prefix|diff-git-header|diff-git-prefix|diff-header-order|diff-header-mismatch|diff-quoted-path|binary-or-symlink-diff|malformed-hunk|hunk-count-mismatch)
+      echo "openrouter-exec: rejected model patch: $PATCH_REJECTION_REASON" >&2
+      exit 65
+      ;;
+  esac
   if [ "$rc" -eq 2 ] || [ "$rc" -eq 3 ]; then
     echo "openrouter-exec: model patch exceeded chunk/security boundary; return to Codex" >&2
     exit 77
@@ -202,7 +280,10 @@ fi
 # `--index` refuses an approved file whose worktree already differs from the
 # index, so a disjoint caller edit in that file cannot hitchhike into the
 # model-authored commit.
-git apply --check --index "$PATCH_FILE"
+if ! git apply --check --index "$PATCH_FILE"; then
+  echo "openrouter-exec: rejected model patch: patch-does-not-apply" >&2
+  exit 65
+fi
 git apply --index "$PATCH_FILE"
 MUTATION_ACTIVE=1
 if git diff --cached --quiet; then

--- a/plugins/pipeline/references/openrouter-exec.sh
+++ b/plugins/pipeline/references/openrouter-exec.sh
@@ -250,8 +250,8 @@ jq -e '
 }
 
 [ -s "$PATCH_FILE" ] || {
-  echo "openrouter-exec: rejected model patch: empty-diff" >&2
-  exit 65
+  echo "openrouter-exec: model returned no unified diff" >&2
+  exit 1
 }
 if "$BOUNDARY" --policy "$POLICY" --changed-files "$ALLOWED_FILE" \
     --diff-file "$PATCH_FILE" --output-paths "$PATCH_PATHS_FILE" \
@@ -265,7 +265,6 @@ else
   case "$PATCH_REJECTION_REASON" in
     headerless-diff|empty-diff|non-unified-diff|diff-file-header|diff-file-prefix|diff-git-header|diff-git-prefix|diff-header-order|diff-header-mismatch|diff-quoted-path|binary-or-symlink-diff|malformed-hunk|hunk-count-mismatch)
       echo "openrouter-exec: rejected model patch: $PATCH_REJECTION_REASON" >&2
-      exit 65
       ;;
   esac
   if [ "$rc" -eq 2 ] || [ "$rc" -eq 3 ]; then
@@ -282,7 +281,7 @@ fi
 # model-authored commit.
 if ! git apply --check --index "$PATCH_FILE"; then
   echo "openrouter-exec: rejected model patch: patch-does-not-apply" >&2
-  exit 65
+  exit 1
 fi
 git apply --index "$PATCH_FILE"
 MUTATION_ACTIVE=1

--- a/tests/test_openrouter_noninteractive.py
+++ b/tests/test_openrouter_noninteractive.py
@@ -17,6 +17,8 @@ import unittest
 REPO = Path(__file__).resolve().parents[1]
 OPENROUTER = REPO / "plugins/openrouter"
 PIPELINE_EXEC = REPO / "plugins/pipeline/references/openrouter-exec.sh"
+CASCADE = REPO / "plugins/pipeline/references/cascade-dispatch.sh"
+KERNEL = REPO / "plugins/workflow-kernel/skills/workflow-kernel/references/workflow-kernel-launcher.sh"
 BOUNDARY = OPENROUTER / "skills/openrouter-delegate/references/delegation-boundary.sh"
 POLICY = OPENROUTER / "skills/openrouter-delegate/references/delegation-security-policy.json"
 WRAPPER = OPENROUTER / "skills/openrouter-delegate/references/openrouter-wrapper.sh"
@@ -45,7 +47,8 @@ class FixtureHandler(http.server.BaseHTTPRequestHandler):
             {"id": "gen-fixture", "model": model, "provider": "fixture/provider",
              "choices": [{"delta": {"content": type(self).response_text}}]},
             {"id": "gen-fixture", "model": model, "provider": "fixture/provider",
-             "usage": {"prompt_tokens": 11, "completion_tokens": 7, "total_tokens": 18},
+             "usage": {"prompt_tokens": 11, "completion_tokens": 7,
+                       "total_tokens": 18, "cost": 0.0042},
              "choices": [{"delta": {}, "finish_reason": "stop"}]},
         ]
         body = "".join(f"data: {json.dumps(event)}\n\n" for event in events) + "data: [DONE]\n\n"
@@ -238,18 +241,25 @@ env -u OPENROUTER_SYSTEM OPENROUTER_SYSTEM_FILE="{system}" OPENROUTER_WORKLOAD=d
         return repo
 
     def run_pipeline(self, repo: Path, diff: str, env: dict[str, str] | None = None,
-                     prompt: str = "Implement the bounded harmless fixture.") -> subprocess.CompletedProcess[str]:
+                     prompt: str = "Implement the bounded harmless fixture.",
+                     attempt_receipt: Path | None = None) -> subprocess.CompletedProcess[str]:
         FixtureHandler.response_text = diff
         run_env = env or self.env()
         run_env["OPENROUTER_EXEC_ALLOWED_PATHS"] = "allowed.txt"
-        return subprocess.run([str(PIPELINE_EXEC), "--model", "z-ai/glm-5.2", "--timeout", "10"],
+        argv = [str(PIPELINE_EXEC), "--model", "z-ai/glm-5.2", "--timeout", "10"]
+        if attempt_receipt is not None:
+            argv += ["--attempt-receipt", str(attempt_receipt.relative_to(repo))]
+        return subprocess.run(argv,
                               cwd=repo, input=prompt, text=True,
                               capture_output=True, env=run_env)
 
     def test_pipeline_accepts_allowed_diff_and_emits_wrapper_evidence(self) -> None:
         repo = self.init_repo()
+        attempt_dir = repo / "attempts"
+        attempt_dir.mkdir()
+        attempt_receipt = attempt_dir / "success.json"
         diff = "diff --git a/allowed.txt b/allowed.txt\n--- a/allowed.txt\n+++ b/allowed.txt\n@@ -1 +1 @@\n-before\n+after"
-        result = self.run_pipeline(repo, diff)
+        result = self.run_pipeline(repo, diff, attempt_receipt=attempt_receipt)
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertEqual((repo / "allowed.txt").read_text(), "after\n")
         receipt = json.loads(result.stdout)
@@ -257,9 +267,165 @@ env -u OPENROUTER_SYSTEM OPENROUTER_SYSTEM_FILE="{system}" OPENROUTER_WORKLOAD=d
         self.assertEqual(receipt["actualModel"], "z-ai/glm-5.2")
         self.assertEqual(receipt["usage"]["total_tokens"], 18)
         self.assertRegex(receipt["requestEnvelopeSha256"], r"^[0-9a-f]{64}$")
+        retained = json.loads(attempt_receipt.read_text())
+        self.assertEqual(retained["usage"]["total_tokens"], 18)
+        self.assertEqual(retained["usage"]["cost"], 0.0042)
         serialized = json.dumps(receipt).lower()
         for forbidden in ("broker", "implement the bounded", "api_key", "secret", diff.lower()):
             self.assertNotIn(forbidden, serialized)
+
+    def test_headerless_provider_result_retains_one_measured_failed_attempt(self) -> None:
+        repo = self.init_repo()
+        attempts = repo / "plans/r4/receipts/openrouter"
+        attempts.mkdir(parents=True)
+        attempt_receipt = attempts / "chunk-a-attempt-1.json"
+        probe = repo / "probe.json"
+        probe.write_text(json.dumps({
+            "codex": {"state": "ok", "remaining_pct": 100},
+            "openrouter": {"state": "ok", "balance_usd": 1.0},
+        }))
+        task_tmp = repo / "task-tmp"
+        task_tmp.mkdir()
+        prompt_marker = "PROMPT_MARKER /private/acme/customer/repository"
+        response_marker = "RAW_HEADERLESS_DIFF_MARKER"
+        api_key_marker = "test"  # OPENROUTER_BASE accepts only the fixture key.
+        FixtureHandler.response_text = response_marker + "\n-old\n+new\n"
+        env = self.env()
+        env.update({
+            "OPENROUTER_API_KEY": api_key_marker,
+            "OPENROUTER_EXEC_ALLOWED_PATHS": "allowed.txt",
+            "OPENROUTER_RUN_ID": "r4-headerless",
+            "OPENROUTER_LANE_ID": "chunk-a",
+            "TMPDIR": str(task_tmp),
+        })
+        before_head = subprocess.check_output(
+            ["git", "-C", str(repo), "rev-parse", "HEAD"], text=True,
+        ).strip()
+        result = subprocess.run([
+            str(CASCADE), "--class", "openrouter", "--prompt", prompt_marker,
+            "--host", "codex", "--timeout", "10", "--probe-file", str(probe),
+            "--attempt-receipt", str(attempt_receipt.relative_to(repo)),
+        ], cwd=repo, text=True, capture_output=True, env=env)
+
+        self.assertEqual(result.returncode, 65, result.stderr)
+        self.assertEqual(FixtureHandler.contacts, 1)
+        self.assertIn("headerless-diff", result.stderr)
+        self.assertNotIn("engine error", result.stderr.lower())
+        self.assertNotIn("ladder exhausted", result.stderr.lower())
+        self.assertEqual((repo / "allowed.txt").read_text(), "before\n")
+        self.assertEqual(subprocess.check_output(
+            ["git", "-C", str(repo), "rev-parse", "HEAD"], text=True,
+        ).strip(), before_head)
+        self.assertEqual(list(task_tmp.iterdir()), [])
+
+        retained = json.loads(attempt_receipt.read_text())
+        request_digest = retained["authorization"]["requestEnvelopeSha256"]
+        self.assertEqual(retained["requestedModel"], "deepseek/deepseek-v4-flash-0731")
+        self.assertEqual(retained["responseModel"], "deepseek/deepseek-v4-flash-0731")
+        self.assertEqual(retained["servingProvider"], "fixture/provider")
+        self.assertEqual(retained["usage"], {
+            "prompt_tokens": 11, "completion_tokens": 7,
+            "total_tokens": 18, "cost": 0.0042,
+        })
+
+        state_dir = repo / ".workflow-kernel/runs/r4-headerless"
+        init = subprocess.run([
+            str(KERNEL), "init", str(state_dir), "--run-id", "r4-headerless",
+            "--mode", "shadow", "--occurred-at", "2026-08-14T01:00:00Z",
+        ], cwd=repo, text=True, capture_output=True)
+        self.assertEqual(init.returncode, 0, init.stderr)
+        receipts = repo / "plans/r4/authoritative-receipts.json"
+        recorded = subprocess.run([
+            str(KERNEL), "record-attempt", "--receipts", str(receipts),
+            "--run-id", "r4-headerless", "--occurred-at", "2026-08-14T01:00:01Z",
+            "--authoritative-receipt", "receipts/chunks/chunk-a-attempt-1.json",
+            "--stage", "progress", "--status", "failed", "--lane", "chunk-a",
+            "--chunk-id", "chunk-a", "--node-id", "chunk-a", "--attempt", "1",
+            "--host", "codex", "--duration-seconds", "0.25",
+            "--requested-executor", "openrouter", "--attempted-executor", "openrouter",
+            "--implemented-by", "openrouter", "--matrix-snapshot-date", "2026-08-03",
+            "--rung-rationale", "cost", "--fallback-reason", "headerless-diff",
+            "--openrouter-receipt", str(attempt_receipt),
+            "--request-envelope-sha256", request_digest,
+            "--state-dir", str(state_dir),
+        ], cwd=repo, text=True, capture_output=True)
+        self.assertEqual(recorded.returncode, 0, recorded.stderr)
+        stream = json.loads(receipts.read_text())
+        self.assertEqual(len(stream), 2)
+        self.assertEqual(stream[0]["status"], "failed")
+        self.assertEqual(stream[0]["fallback_reason"], "headerless-diff")
+        self.assertEqual(stream[1]["measurement_source"], "openrouter_api_receipt")
+        self.assertEqual(stream[1]["requested_provider"], "openrouter")
+        self.assertEqual(stream[1]["attempted_provider"], "openrouter")
+        self.assertEqual(stream[1]["provider"], "fixture/provider")
+        self.assertEqual(stream[1]["model"], "deepseek/deepseek-v4-flash-0731")
+        self.assertEqual(stream[1]["duration_seconds"], 0.25)
+        self.assertEqual(stream[1]["usage_count"], 18)
+        self.assertEqual(stream[1]["cost_usd"], 0.0042)
+
+        summary_path = repo / "plans/r4/run-cost-summary.json"
+        summarized = subprocess.run([
+            str(KERNEL), "run-cost-summary", "--events", str(receipts),
+            "--output", str(summary_path), "--repository-commit", before_head,
+        ], cwd=repo, text=True, capture_output=True)
+        self.assertEqual(summarized.returncode, 0, summarized.stderr)
+        summary = json.loads(summary_path.read_text())
+        self.assertEqual(len(summary["lanes"]), 1)
+        lane = summary["lanes"][0]
+        self.assertEqual(lane["usage_count"], 18)
+        self.assertEqual(lane["cost_usd"], 0.0042)
+        self.assertEqual(lane["provider"], "fixture/provider")
+        self.assertEqual(lane["model"], "deepseek/deepseek-v4-flash-0731")
+        self.assertEqual(lane["duration_seconds"], 0.25)
+
+        durable_and_human = "\n".join((
+            attempt_receipt.read_text(), receipts.read_text(), summary_path.read_text(),
+            result.stdout, result.stderr, recorded.stdout, recorded.stderr,
+        ))
+        for forbidden in (
+            prompt_marker, response_marker, "Bearer " + api_key_marker,
+            "OPENROUTER_API_KEY=" + api_key_marker,
+            str(repo), str(self.root),
+        ):
+            self.assertNotIn(forbidden, durable_and_human)
+
+    def test_unapplicable_provider_diff_stops_after_one_retained_attempt(self) -> None:
+        repo = self.init_repo()
+        attempts = repo / "attempts"
+        attempts.mkdir()
+        attempt_receipt = attempts / "unapplicable.json"
+        probe = repo / "probe.json"
+        probe.write_text(json.dumps({
+            "codex": {"state": "ok", "remaining_pct": 100},
+            "openrouter": {"state": "ok", "balance_usd": 1.0},
+        }))
+        FixtureHandler.response_text = (
+            "diff --git a/allowed.txt b/allowed.txt\n"
+            "--- a/allowed.txt\n+++ b/allowed.txt\n"
+            "@@ -1 +1 @@\n-not-the-current-line\n+after"
+        )
+        env = self.env()
+        env["OPENROUTER_EXEC_ALLOWED_PATHS"] = "allowed.txt"
+        before_head = subprocess.check_output(
+            ["git", "-C", str(repo), "rev-parse", "HEAD"], text=True,
+        ).strip()
+
+        result = subprocess.run([
+            str(CASCADE), "--class", "openrouter", "--prompt", "bounded fixture",
+            "--host", "codex", "--timeout", "10", "--probe-file", str(probe),
+            "--attempt-receipt", str(attempt_receipt.relative_to(repo)),
+        ], cwd=repo, text=True, capture_output=True, env=env)
+
+        self.assertEqual(result.returncode, 65, result.stderr)
+        self.assertEqual(FixtureHandler.contacts, 1)
+        self.assertIn("patch-does-not-apply", result.stderr)
+        self.assertNotIn("ladder exhausted", result.stderr.lower())
+        self.assertTrue(attempt_receipt.is_file())
+        self.assertEqual(json.loads(attempt_receipt.read_text())["usage"]["cost"], 0.0042)
+        self.assertEqual((repo / "allowed.txt").read_text(), "before\n")
+        self.assertEqual(subprocess.check_output(
+            ["git", "-C", str(repo), "rev-parse", "HEAD"], text=True,
+        ).strip(), before_head)
 
     def test_pipeline_rejects_disallowed_path_before_application(self) -> None:
         repo = self.init_repo()

--- a/tests/test_openrouter_noninteractive.py
+++ b/tests/test_openrouter_noninteractive.py
@@ -18,6 +18,7 @@ REPO = Path(__file__).resolve().parents[1]
 OPENROUTER = REPO / "plugins/openrouter"
 PIPELINE_EXEC = REPO / "plugins/pipeline/references/openrouter-exec.sh"
 CASCADE = REPO / "plugins/pipeline/references/cascade-dispatch.sh"
+PIPELINE_PROFILE = REPO / "plugins/pipeline/references/harness-profile.json"
 KERNEL = REPO / "plugins/workflow-kernel/skills/workflow-kernel/references/workflow-kernel-launcher.sh"
 BOUNDARY = OPENROUTER / "skills/openrouter-delegate/references/delegation-boundary.sh"
 POLICY = OPENROUTER / "skills/openrouter-delegate/references/delegation-security-policy.json"
@@ -253,6 +254,25 @@ env -u OPENROUTER_SYSTEM OPENROUTER_SYSTEM_FILE="{system}" OPENROUTER_WORKLOAD=d
                               cwd=repo, input=prompt, text=True,
                               capture_output=True, env=run_env)
 
+    def run_cascade(self, repo: Path, response: str, attempts: Path,
+                    prompt: str = "bounded fixture",
+                    env: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
+        FixtureHandler.response_text = response
+        attempts.mkdir(parents=True)
+        probe = repo / "probe.json"
+        probe.write_text(json.dumps({
+            "codex": {"state": "ok", "remaining_pct": 100},
+            "openrouter": {"state": "ok", "balance_usd": 1.0},
+        }))
+        run_env = env or self.env()
+        run_env["OPENROUTER_EXEC_ALLOWED_PATHS"] = "allowed.txt"
+        template = attempts / "provider-{attempt}.json"
+        return subprocess.run([
+            str(CASCADE), "--class", "openrouter", "--prompt", prompt,
+            "--host", "codex", "--timeout", "10", "--probe-file", str(probe),
+            "--attempt-receipt-template", str(template.relative_to(repo)),
+        ], cwd=repo, text=True, capture_output=True, env=run_env)
+
     def test_pipeline_accepts_allowed_diff_and_emits_wrapper_evidence(self) -> None:
         repo = self.init_repo()
         attempt_dir = repo / "attempts"
@@ -276,20 +296,13 @@ env -u OPENROUTER_SYSTEM OPENROUTER_SYSTEM_FILE="{system}" OPENROUTER_WORKLOAD=d
 
     def test_headerless_provider_result_retains_one_measured_failed_attempt(self) -> None:
         repo = self.init_repo()
-        attempts = repo / "plans/r4/receipts/openrouter"
-        attempts.mkdir(parents=True)
-        attempt_receipt = attempts / "chunk-a-attempt-1.json"
-        probe = repo / "probe.json"
-        probe.write_text(json.dumps({
-            "codex": {"state": "ok", "remaining_pct": 100},
-            "openrouter": {"state": "ok", "balance_usd": 1.0},
-        }))
+        attempts = repo / "plans/r4/receipts/openrouter/chunk-a-cascade-1"
+        attempt_receipt = attempts / "provider-1.json"
         task_tmp = repo / "task-tmp"
         task_tmp.mkdir()
         prompt_marker = "PROMPT_MARKER /private/acme/customer/repository"
         response_marker = "RAW_HEADERLESS_DIFF_MARKER"
         api_key_marker = "test"  # OPENROUTER_BASE accepts only the fixture key.
-        FixtureHandler.response_text = response_marker + "\n-old\n+new\n"
         env = self.env()
         env.update({
             "OPENROUTER_API_KEY": api_key_marker,
@@ -301,17 +314,20 @@ env -u OPENROUTER_SYSTEM OPENROUTER_SYSTEM_FILE="{system}" OPENROUTER_WORKLOAD=d
         before_head = subprocess.check_output(
             ["git", "-C", str(repo), "rev-parse", "HEAD"], text=True,
         ).strip()
-        result = subprocess.run([
-            str(CASCADE), "--class", "openrouter", "--prompt", prompt_marker,
-            "--host", "codex", "--timeout", "10", "--probe-file", str(probe),
-            "--attempt-receipt", str(attempt_receipt.relative_to(repo)),
-        ], cwd=repo, text=True, capture_output=True, env=env)
+        result = self.run_cascade(
+            repo, response_marker + "\n-old\n+new\n", attempts,
+            prompt=prompt_marker, env=env,
+        )
 
-        self.assertEqual(result.returncode, 65, result.stderr)
+        self.assertEqual(result.returncode, 64, result.stderr)
         self.assertEqual(FixtureHandler.contacts, 1)
-        self.assertIn("headerless-diff", result.stderr)
+        self.assertEqual(result.stderr.count("headerless-diff"), 1)
         self.assertNotIn("engine error", result.stderr.lower())
         self.assertNotIn("ladder exhausted", result.stderr.lower())
+        fallback = json.loads(result.stdout)
+        self.assertEqual(fallback["dispatch"], "native")
+        self.assertEqual(fallback["probe_rail"], "codex")
+        self.assertEqual(sorted(attempts.iterdir()), [attempt_receipt])
         self.assertEqual((repo / "allowed.txt").read_text(), "before\n")
         self.assertEqual(subprocess.check_output(
             ["git", "-C", str(repo), "rev-parse", "HEAD"], text=True,
@@ -389,39 +405,63 @@ env -u OPENROUTER_SYSTEM OPENROUTER_SYSTEM_FILE="{system}" OPENROUTER_WORKLOAD=d
         ):
             self.assertNotIn(forbidden, durable_and_human)
 
-    def test_unapplicable_provider_diff_stops_after_one_retained_attempt(self) -> None:
+    def test_unapplicable_provider_diff_retries_with_distinct_receipts(self) -> None:
         repo = self.init_repo()
         attempts = repo / "attempts"
-        attempts.mkdir()
-        attempt_receipt = attempts / "unapplicable.json"
-        probe = repo / "probe.json"
-        probe.write_text(json.dumps({
-            "codex": {"state": "ok", "remaining_pct": 100},
-            "openrouter": {"state": "ok", "balance_usd": 1.0},
-        }))
-        FixtureHandler.response_text = (
+        response = (
             "diff --git a/allowed.txt b/allowed.txt\n"
             "--- a/allowed.txt\n+++ b/allowed.txt\n"
             "@@ -1 +1 @@\n-not-the-current-line\n+after"
         )
-        env = self.env()
-        env["OPENROUTER_EXEC_ALLOWED_PATHS"] = "allowed.txt"
         before_head = subprocess.check_output(
             ["git", "-C", str(repo), "rev-parse", "HEAD"], text=True,
         ).strip()
 
-        result = subprocess.run([
-            str(CASCADE), "--class", "openrouter", "--prompt", "bounded fixture",
-            "--host", "codex", "--timeout", "10", "--probe-file", str(probe),
-            "--attempt-receipt", str(attempt_receipt.relative_to(repo)),
-        ], cwd=repo, text=True, capture_output=True, env=env)
+        result = self.run_cascade(repo, response, attempts)
 
-        self.assertEqual(result.returncode, 65, result.stderr)
-        self.assertEqual(FixtureHandler.contacts, 1)
-        self.assertIn("patch-does-not-apply", result.stderr)
+        expected_models = json.loads(PIPELINE_PROFILE.read_text())[
+            "hosts"
+        ]["codex"]["roles"]["openrouter_exec"]["models"]
+        self.assertEqual(result.returncode, 64, result.stderr)
+        self.assertEqual(FixtureHandler.contacts, len(expected_models))
+        self.assertEqual(
+            result.stderr.count("patch-does-not-apply"), len(expected_models),
+        )
         self.assertNotIn("ladder exhausted", result.stderr.lower())
-        self.assertTrue(attempt_receipt.is_file())
-        self.assertEqual(json.loads(attempt_receipt.read_text())["usage"]["cost"], 0.0042)
+        self.assertEqual(json.loads(result.stdout)["dispatch"], "native")
+        receipts = [attempts / f"provider-{index}.json"
+                    for index in range(1, len(expected_models) + 1)]
+        self.assertEqual(sorted(attempts.iterdir()), receipts)
+        self.assertEqual(
+            [json.loads(path.read_text())["requestedModel"] for path in receipts],
+            expected_models,
+        )
+        self.assertTrue(all(
+            json.loads(path.read_text())["usage"]["cost"] == 0.0042
+            for path in receipts
+        ))
+        self.assertEqual((repo / "allowed.txt").read_text(), "before\n")
+        self.assertEqual(subprocess.check_output(
+            ["git", "-C", str(repo), "rev-parse", "HEAD"], text=True,
+        ).strip(), before_head)
+
+    def test_blank_provider_diff_preserves_codex_fallback_and_receipt(self) -> None:
+        repo = self.init_repo()
+        attempts = repo / "attempts"
+        before_head = subprocess.check_output(
+            ["git", "-C", str(repo), "rev-parse", "HEAD"], text=True,
+        ).strip()
+
+        result = self.run_cascade(repo, " ", attempts)
+
+        self.assertEqual(result.returncode, 64, result.stderr)
+        self.assertEqual(FixtureHandler.contacts, 1)
+        self.assertIn("empty-diff", result.stderr)
+        self.assertEqual(json.loads(result.stdout)["dispatch"], "native")
+        self.assertEqual(
+            sorted(attempts.iterdir()),
+            [attempts / "provider-1.json"],
+        )
         self.assertEqual((repo / "allowed.txt").read_text(), "before\n")
         self.assertEqual(subprocess.check_output(
             ["git", "-C", str(repo), "rev-parse", "HEAD"], text=True,

--- a/tests/test_openrouter_usage.py
+++ b/tests/test_openrouter_usage.py
@@ -837,6 +837,7 @@ class RecordAttemptTests(unittest.TestCase):
 
     def _argv(self, receipts, lane, minute, **extra):
         run_id = extra.pop("run_id", "record-attempt-1")
+        status = extra.pop("status", "completed")
         if "openrouter_receipt" in extra and "state_dir" not in extra:
             scope_root = Path(extra.pop("_scope_root", Path(receipts).parent))
             if not (scope_root / ".git").exists():
@@ -851,7 +852,7 @@ class RecordAttemptTests(unittest.TestCase):
             "--run-id", run_id,
             "--occurred-at", "2026-08-07T09:%02d:00Z" % minute,
             "--authoritative-receipt", "receipts/%s.json" % lane,
-            "--stage", "review_dispatch", "--status", "completed",
+            "--stage", "review_dispatch", "--status", status,
             "--lane", lane, "--chunk-id", "chunk-a", "--node-id", lane,
             "--attempt", "1", "--host", "claude",
             "--duration-seconds", "5.0",
@@ -1441,6 +1442,32 @@ class RecordAttemptTests(unittest.TestCase):
             self.assertEqual(lane["measurement_source"], "attempt_unmeasured")
             self.assertIsNone(lane["cost_usd"])
             self.assertIsNone(lane["usage_count"])
+        finally:
+            shutil.rmtree(directory, ignore_errors=True)
+
+    def test_failed_attempt_without_usage_is_explicitly_unmeasured(self):
+        """Missing provider evidence is visible and is never estimated."""
+        import os
+        import shutil
+        import tempfile
+
+        directory = tempfile.mkdtemp()
+        receipts = os.path.join(directory, "authoritative-receipts.json")
+        try:
+            code, _, error = _invoke(self._argv(
+                receipts, "failed-openrouter", 1, status="failed",
+                fallback_reason="receipt-unavailable",
+            ))
+            self.assertEqual(code, 0, error)
+            stream = self._stream(receipts)
+            self.assertEqual(len(stream), 2)
+            self.assertEqual(stream[0]["status"], "failed")
+            self.assertEqual(stream[1]["measurement_source"], "attempt_unmeasured")
+            self.assertFalse(stream[1]["usage_estimated"])
+            for field in (
+                "usage_count", "input_usage_count", "output_usage_count", "cost_usd",
+            ):
+                self.assertNotIn(field, stream[1])
         finally:
             shutil.rmtree(directory, ignore_errors=True)
 

--- a/tools/validate-dm-review-codex-perspective.sh
+++ b/tools/validate-dm-review-codex-perspective.sh
@@ -366,7 +366,7 @@ require_text "$review_skill" 'smallest adequate repair' "P1/P2 requires the smal
 require_text "$consolidator" 'Reject scope-expanding repairs' "consolidation rejects unrelated product scope"
 require_text "$REPO_ROOT/plugins/dm-review/.claude-plugin/plugin.json" '"version": "1.62.1"' "canonical dm-review version is 1.62.1"
 require_text "$REPO_ROOT/plugins/dm-review/.codex-plugin/plugin.json" '"version": "1.62.1"' "generated dm-review version is 1.62.1"
-require_text "$REPO_ROOT/plugins/pipeline/.claude-plugin/plugin.json" '"version": "1.51.1"' "canonical Pipeline version is 1.51.1"
+require_text "$REPO_ROOT/plugins/pipeline/.claude-plugin/plugin.json" '"version": "1.51.2"' "canonical Pipeline version is 1.51.2"
 require_text "$REPO_ROOT/plugins/pipeline/.codex-plugin/plugin.json" '"dm-review": ">=1.62.0"' "generated Pipeline dependency floor is current"
 
 printf "Synthesis identity fixtures\n"


### PR DESCRIPTION
## Summary
- retain each validated content-free OpenRouter wrapper receipt before post-provider patch validation
- preserve stable structural rejection reasons through cascade dispatch and record failed attempts once through Workflow Kernel
- preserve the existing model retry and native Codex fallback outcomes; numbered receipt templates keep retried provider attempts distinct
- cover measured headerless rejection, blank-output fallback, non-applying model-ladder traversal, explicit unmeasured attempts, success retention, cleanup, and no double counting
- advance Pipeline to 1.51.2 and update the active efficiency-program queue

## Verification
- PYTHONPATH=plugins/workflow-kernel/skills/workflow-kernel/references python3 -m unittest tests.test_openrouter_noninteractive
- PYTHONPATH=plugins/workflow-kernel/skills/workflow-kernel/references python3 -m unittest tests.test_openrouter_usage
- ./tools/validate-openrouter-cascade.sh
- ./tools/validate-routing-economics.sh
- ./tools/validate-workflow-kernel.py
- ./tools/validate-dual-compat.sh
- ./tools/validate-composition.sh --all
- git diff --check
- focused review repairs rechecked against deterministic fixtures

No live or paid OpenRouter call was made.