### PR TITLE
fix(openrouter): expose content-safe HTTP failure reasons

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -435,7 +435,7 @@
     {
       "name": "openrouter",
       "source": "./plugins/openrouter",
-      "version": "1.14.4",
+      "version": "1.14.5",
       "author": {
         "name": "Design Machines",
         "url": "https://designmachines.studio"

--- a/plugins/openrouter/.claude-plugin/plugin.json
+++ b/plugins/openrouter/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "openrouter",
   "description": "Configured-key OpenRouter provider plugin with automatic sensitive-payload refusal, Kimi K3-led security and bulk analysis, Terra quality fallback, Luna economical mechanical routing, and an optional official MCP control plane.",
-  "version": "1.14.4",
+  "version": "1.14.5",
   "author": {
     "name": "Design Machines",
     "url": "https://designmachines.studio"

--- a/plugins/openrouter/.codex-plugin/plugin.json
+++ b/plugins/openrouter/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "openrouter",
-  "version": "1.14.4",
+  "version": "1.14.5",
   "description": "Configured-key OpenRouter provider plugin with automatic sensitive-payload refusal, Kimi K3-led security and bulk analysis, Terra quality fallback, Luna economical mechanical routing, and an optional official MCP control plane.",
   "author": {
     "name": "Design Machines",

--- a/plugins/openrouter/README.md
+++ b/plugins/openrouter/README.md
@@ -58,3 +58,27 @@ Every live caller selects one coherent installed plugin root with workflow-kerne
   immediately pass those same files to the wrapper.
 - Use provider-side per-key spending limits for runaway-cost control.
 - Optional OpenRouter MCP: `codex mcp add openrouter --url https://mcp.openrouter.ai/mcp`, then `codex mcp login openrouter`. Its expiring OAuth key does not replace the persistent team API key.
+
+## Budgets and content-safe HTTP failures
+
+OpenRouter account credit balance, organization monthly budget, and per-key
+spending limit are independent controls. A positive credit balance and a
+successful `/auth/key` lookup do not prove that the organization monthly budget
+or the key's spending limit has headroom. When the organization monthly budget
+is exhausted, its administrator must raise or reset that limit; buying credits
+or replacing an otherwise valid key is not the remedy for that condition.
+
+HTTP failure receipts keep `failureKind: http_error` and expose only the closed,
+nullable `failureReason` vocabulary:
+
+- `organization_monthly_budget_exceeded`
+- `key_permission_denied`
+- `guardrail_blocked`
+- `insufficient_credits`
+- `rate_limited`
+- `unknown_http_error`
+
+The wrapper derives stderr from fixed labels for those values. Provider
+messages, moderation reasons or patterns, `flagged_input`, arbitrary error
+metadata, `openrouter_metadata`, prompts, and raw response bodies remain inside
+the private temporary run directory and are not printed or stored in receipts.

--- a/plugins/openrouter/agents/workflow/openrouter-agent-runner.md
+++ b/plugins/openrouter/agents/workflow/openrouter-agent-runner.md
@@ -316,6 +316,51 @@ WRAPPER_RECEIPT=$(mktemp)
 printf '%s' "$TARGET_BODY" > "$SYS_FILE"
 printf '%s' "$USER_PROMPT" > "$USER_FILE"
 
+read_http_failure_reason() {
+  jq -er '
+    select(
+      .schemaVersion == 2
+      and .outcome == "error"
+      and .failureKind == "http_error"
+    )
+    | .failureReason
+    | select(
+        . == "organization_monthly_budget_exceeded"
+        or . == "key_permission_denied"
+        or . == "guardrail_blocked"
+        or . == "insufficient_credits"
+        or . == "rate_limited"
+        or . == "unknown_http_error"
+      )
+  ' "$1"
+}
+
+map_wrapper_failure_reason() {
+  case "$1" in
+    organization_monthly_budget_exceeded)
+      printf '%s' "The OpenRouter organization monthly budget is exhausted; its administrator must raise or reset that limit"
+      ;;
+    key_permission_denied)
+      printf '%s' "OpenRouter denied permission for the configured key"
+      ;;
+    guardrail_blocked)
+      printf '%s' "OpenRouter blocked the request with a guardrail"
+      ;;
+    insufficient_credits)
+      printf '%s' "OpenRouter reports insufficient account or key credits"
+      ;;
+    rate_limited)
+      printf '%s' "OpenRouter rate limited the request"
+      ;;
+    unknown_http_error)
+      printf '%s' "OpenRouter returned an unknown HTTP error"
+      ;;
+    *)
+      printf '%s' "All models exhausted, key missing, or HTTP error"
+      ;;
+  esac
+}
+
 if "$BOUNDARY_HELPER" --mode artifact-delegation \
     --policy "$SECURITY_POLICY_RESOLVED" \
     --content-file "$SYS_FILE" \
@@ -365,6 +410,7 @@ FALLBACK_USED=false
 GENERATION_ID=""
 SERVING_PROVIDER=""
 SERVING_PROVIDER_PROVENANCE=""
+WRAPPER_FAILURE_REASON=""
 if [ "$EXIT_CODE" -eq 0 ] && [ -s "$WRAPPER_RECEIPT" ]; then
   ACTUAL_MODEL=$(jq -er '.responseModel' "$WRAPPER_RECEIPT")
   FALLBACK_USED=$(jq -er '.fallbackUsed | if type == "boolean" then tostring else error("invalid fallbackUsed") end' "$WRAPPER_RECEIPT")
@@ -373,6 +419,8 @@ if [ "$EXIT_CODE" -eq 0 ] && [ -s "$WRAPPER_RECEIPT" ]; then
   SERVING_PROVIDER_PROVENANCE=$(jq -er '.servingProviderProvenance' "$WRAPPER_RECEIPT")
 elif [ "$EXIT_CODE" -eq 0 ]; then
   EXIT_CODE=1
+elif [ "$EXIT_CODE" -eq 1 ] && [ -s "$WRAPPER_RECEIPT" ]; then
+  WRAPPER_FAILURE_REASON=$(read_http_failure_reason "$WRAPPER_RECEIPT" 2>/dev/null || true)
 fi
 ```
 
@@ -382,7 +430,7 @@ fi
 |---|---|---|
 | `0` | Success | Continue to output validation |
 | `28` | Timeout | `Timed out at ${target_timeout}s` |
-| `1` | Models exhausted, key missing, or HTTP error | `All models exhausted, key missing, or HTTP error` |
+| `1` | Models exhausted, key missing, or HTTP error | Validated HTTP receipt reason, otherwise `All models exhausted, key missing, or HTTP error` |
 | `2` | Invalid runner arguments | `Invocation error -- bad runner arguments` |
 | other | API or transport error | `Wrapper exited $EXIT_CODE` |
 
@@ -390,7 +438,9 @@ fi
 case "$EXIT_CODE" in
   0) ;;
   28) FAILURE_REASON="Timed out at ${target_timeout}s" ;;
-  1) FAILURE_REASON="All models exhausted, key missing, or HTTP error" ;;
+  1)
+    FAILURE_REASON=$(map_wrapper_failure_reason "$WRAPPER_FAILURE_REASON")
+    ;;
   2) FAILURE_REASON="Invocation error -- bad runner arguments" ;;
   *) FAILURE_REASON="Wrapper exited $EXIT_CODE" ;;
 esac

--- a/plugins/openrouter/skills/openrouter-delegate/references/invocation-protocol.md
+++ b/plugins/openrouter/skills/openrouter-delegate/references/invocation-protocol.md
@@ -122,7 +122,13 @@ protocol below before invoking it.
   stream becomes review evidence.
 - `OPENROUTER_RECEIPT_FILE`: optional path for a content-free JSON success or
   failure receipt. Failure receipts record timeout/error classification without
-  prompt, partial completion, inferred provider, or usage content.
+  prompt, partial completion, inferred provider, or usage content. The nullable
+  `failureReason` is non-null only for HTTP failures and is restricted to
+  `organization_monthly_budget_exceeded`, `key_permission_denied`,
+  `guardrail_blocked`, `insufficient_credits`, `rate_limited`, or
+  `unknown_http_error`. Provider messages, moderation details, and error
+  metadata are inspected only inside the private temporary run directory and
+  are never durable output.
 
 ## Security Hardening
 
@@ -154,6 +160,13 @@ all use one pass:
 No OpenRouter caller asks for user approval. The configured-key path has no
 broker dependency. Provider-side per-key spending limits are the recommended
 runaway-cost control.
+
+Account credit balance, an organization's monthly budget, and a per-key
+spending limit are separate controls. A positive account balance and a
+successful `/auth/key` lookup establish neither organization-budget headroom
+nor remaining key-limit headroom. An exhausted organization monthly budget
+must be raised or reset by that organization's administrator; buying credits or
+replacing an otherwise valid key does not address that distinct limit.
 
 ### Codex network allowlist
 
@@ -207,7 +220,7 @@ POST https://openrouter.ai/api/v1/chat/completions
 |------|---------|--------|
 | `0` | Success | stdout is the model's text content. |
 | `28` | Timeout | Report the first-byte, idle, or overall timeout from the failure receipt; proceed without OpenRouter input. Do not issue a blind client retry. |
-| `1` | Exhausted / error | Bad API response or non-recoverable HTTP. The wrapper prints `### RUNNER FAILURE ...` to stderr. Skip gracefully. |
+| `1` | Exhausted / error | Bad API response or non-recoverable HTTP. The wrapper prints `### RUNNER FAILURE ...` using only a hard-coded label derived from the closed `failureReason` enum. Skip gracefully. |
 | `2` | Bad args / origin rejection | Missing arguments or an `anthropic/*` primary or fallback. |
 
 When a fallback is present, OpenRouter receives both models in one ordered

--- a/plugins/openrouter/skills/openrouter-delegate/references/openrouter-wrapper.sh
+++ b/plugins/openrouter/skills/openrouter-delegate/references/openrouter-wrapper.sh
@@ -326,6 +326,7 @@ build_provider() {
 
 write_failure_receipt() {
   local outcome="$1" failure_kind="$2" timeout_kind="$3" http_status="${4:-}"
+  local failure_reason="${5:-}"
   local receipt_tmp
   [ -z "${OPENROUTER_RECEIPT_FILE:-}" ] && return 0
   receipt_tmp="${OPENROUTER_RECEIPT_FILE}.tmp.$$"
@@ -335,6 +336,7 @@ write_failure_receipt() {
       --arg outcome "$outcome" \
       --arg invocation "$INVOCATION_ID" \
       --arg failure "$failure_kind" \
+      --arg reason "$failure_reason" \
       --arg timeout "$timeout_kind" \
       --arg http "$http_status" \
       --arg requested "$MODEL" \
@@ -349,6 +351,7 @@ write_failure_receipt() {
         invocationId: $invocation,
         outcome: $outcome,
         failureKind: $failure,
+        failureReason: (if $reason == "" then null else $reason end),
         timeout: (if $timeout == "" then null else {kind: $timeout} end),
         httpStatus: (if $http == "" then null else ($http | tonumber) end),
         requestedModel: $requested,
@@ -404,6 +407,7 @@ write_success_receipt() {
         invocationId: $invocation,
         outcome: "success",
         failureKind: null,
+        failureReason: null,
         timeout: null,
         httpStatus: 200,
         generationId: .id,
@@ -584,8 +588,51 @@ if [ "$curl_rc" -ne 0 ]; then
   exit 1
 fi
 if [ "$http" != "200" ]; then
-  write_failure_receipt error "http_error" "" "$http" || true
-  echo "### RUNNER FAILURE ($MODEL, HTTP $http)" >&2
+  http_failure_reason="unknown_http_error"
+  case "$http" in
+    402) http_failure_reason="insufficient_credits" ;;
+    429) http_failure_reason="rate_limited" ;;
+    *)
+      if jq -e --argjson status "$http" '
+        type == "object"
+        and (.error | type) == "object"
+        and (.error.code | type) == "number"
+        and .error.code == $status
+        and (.error.message | type) == "string"
+        and ((.error.metadata? // {}) | type) == "object"
+      ' "$stream_file" >/dev/null 2>&1; then
+        if jq -e '.error.metadata.error_type? == "payment_required"' \
+          "$stream_file" >/dev/null 2>&1; then
+          http_failure_reason="insufficient_credits"
+        elif jq -e '.error.metadata.error_type? == "rate_limit_exceeded"' \
+          "$stream_file" >/dev/null 2>&1; then
+          http_failure_reason="rate_limited"
+        elif [ "$http" = "403" ] && jq -e '
+          .error.message
+          | test("^[[:space:]]*Budget limit exceeded \\(monthly limit\\)\\. Contact your org admin\\.[[:space:]]*$")
+        ' "$stream_file" >/dev/null 2>&1; then
+          http_failure_reason="organization_monthly_budget_exceeded"
+        elif [ "$http" = "403" ] && jq -e '
+          (.error.metadata.error_type? == "content_policy_violation")
+          or (.error.message | startswith("Request blocked:"))
+        ' "$stream_file" >/dev/null 2>&1; then
+          http_failure_reason="guardrail_blocked"
+        elif [ "$http" = "403" ]; then
+          http_failure_reason="key_permission_denied"
+        fi
+      fi
+      ;;
+  esac
+  case "$http_failure_reason" in
+    organization_monthly_budget_exceeded) http_failure_label="organization monthly budget exceeded" ;;
+    key_permission_denied) http_failure_label="key permission denied" ;;
+    guardrail_blocked) http_failure_label="guardrail blocked" ;;
+    insufficient_credits) http_failure_label="insufficient credits" ;;
+    rate_limited) http_failure_label="rate limited" ;;
+    unknown_http_error) http_failure_label="unknown HTTP error" ;;
+  esac
+  write_failure_receipt error "http_error" "" "$http" "$http_failure_reason" || true
+  echo "### RUNNER FAILURE ($MODEL, HTTP $http: $http_failure_label)" >&2
   exit 1
 fi
 

--- a/tests/test_openrouter_noninteractive.py
+++ b/tests/test_openrouter_noninteractive.py
@@ -153,6 +153,8 @@ class FixtureHandler(http.server.BaseHTTPRequestHandler):
     authorizations: list[str | None] = []
     response_text = "fixture response"
     response_mode = "complete"
+    response_status = 200
+    response_body: dict | str = {}
     block_response = False
     request_seen = threading.Event()
     release_response = threading.Event()
@@ -166,6 +168,18 @@ class FixtureHandler(http.server.BaseHTTPRequestHandler):
         type(self).request_seen.set()
         if type(self).block_response:
             type(self).release_response.wait(timeout=5)
+        if type(self).response_status != 200:
+            response_body = type(self).response_body
+            encoded = (
+                response_body if isinstance(response_body, str)
+                else json.dumps(response_body)
+            ).encode()
+            self.send_response(type(self).response_status)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(encoded)))
+            self.end_headers()
+            self.wfile.write(encoded)
+            return
         model = payload.get("model") or payload.get("models", ["z-ai/glm-5.2"])[0]
         content_event = {
             "id": "gen-fixture", "model": model, "provider": "fixture/provider",
@@ -219,6 +233,8 @@ class OpenRouterNonInteractiveTest(unittest.TestCase):
         FixtureHandler.authorizations = []
         FixtureHandler.response_text = "fixture response"
         FixtureHandler.response_mode = "complete"
+        FixtureHandler.response_status = 200
+        FixtureHandler.response_body = {}
         FixtureHandler.block_response = False
         FixtureHandler.request_seen.clear()
         FixtureHandler.release_response.clear()
@@ -289,6 +305,7 @@ env -u OPENROUTER_SYSTEM OPENROUTER_SYSTEM_FILE="{system}" OPENROUTER_WORKLOAD=d
         self.assertNotRegex(result.stdout + result.stderr, r"approval_required|APPROVAL REQUIRED|exit 78|batch|broker")
         receipt = json.loads(result.receipt_path.read_text())  # type: ignore[attr-defined]
         self.assertRegex(receipt["authorization"]["requestEnvelopeSha256"], r"^[0-9a-f]{64}$")
+        self.assertIsNone(receipt["failureReason"])
         self.assertEqual(receipt["usage"]["total_tokens"], 18)
         serialized = json.dumps(receipt).lower()
         for forbidden in ("review harmless", "fixture response", "api_key", "secret"):
@@ -316,6 +333,7 @@ env -u OPENROUTER_SYSTEM OPENROUTER_SYSTEM_FILE="{system}" OPENROUTER_WORKLOAD=d
                 receipt = json.loads(result.receipt_path.read_text())  # type: ignore[attr-defined]
                 self.assertEqual(receipt["outcome"], "error")
                 self.assertEqual(receipt["failureKind"], "incomplete_stream")
+                self.assertIsNone(receipt["failureReason"])
                 self.assertIsNone(receipt["usage"])
                 serialized = json.dumps(receipt)
                 self.assertNotIn("PARTIAL_RESPONSE_MARKER", serialized)
@@ -329,8 +347,82 @@ env -u OPENROUTER_SYSTEM OPENROUTER_SYSTEM_FILE="{system}" OPENROUTER_WORKLOAD=d
         receipt = json.loads(result.receipt_path.read_text())  # type: ignore[attr-defined]
         self.assertEqual(receipt["outcome"], "error")
         self.assertEqual(receipt["failureKind"], "stream_error")
+        self.assertIsNone(receipt["failureReason"])
         self.assertIsNone(receipt["usage"])
         self.assertNotIn("PARTIAL_RESPONSE_MARKER", json.dumps(receipt))
+
+    def test_http_failures_expose_only_closed_content_safe_reasons(self) -> None:
+        prompt_marker = "PRIVATE_PROMPT_MARKER_68"
+        reflected_marker = "REFLECTED_INPUT_MARKER_68"
+        cases = (
+            (
+                "organization budget", 403,
+                {"error": {"code": 403, "message":
+                 " \nBudget limit exceeded (monthly limit). Contact your org admin.\t "}},
+                "organization_monthly_budget_exceeded",
+                "organization monthly budget exceeded",
+            ),
+            (
+                "generic permission", 403,
+                {"error": {"code": 403, "message": "Provider permission detail"}},
+                "key_permission_denied", "key permission denied",
+            ),
+            (
+                "guardrail", 403,
+                {"error": {"code": 403, "message": f"Request blocked: {reflected_marker}",
+                 "metadata": {"error_type": "content_policy_violation",
+                              "patterns": [reflected_marker],
+                              "flagged_input": reflected_marker}},
+                 "openrouter_metadata": {"summary": reflected_marker}},
+                "guardrail_blocked", "guardrail blocked",
+            ),
+            (
+                "malformed", 403, f"not-json {reflected_marker}",
+                "unknown_http_error", "unknown HTTP error",
+            ),
+            (
+                "mismatched envelope", 403,
+                {"error": {"code": 401, "message": "Mismatched private detail"}},
+                "unknown_http_error", "unknown HTTP error",
+            ),
+            (
+                "insufficient credits", 402,
+                {"error": {"code": 402, "message": "Private payment detail",
+                 "metadata": {"error_type": "payment_required"}}},
+                "insufficient_credits", "insufficient credits",
+            ),
+            (
+                "rate limit", 429,
+                {"error": {"code": 429, "message": "Private rate detail",
+                 "metadata": {"error_type": "rate_limit_exceeded"}}},
+                "rate_limited", "rate limited",
+            ),
+        )
+        for name, status, body, reason, label in cases:
+            with self.subTest(name=name):
+                FixtureHandler.response_status = status
+                FixtureHandler.response_body = body
+                result = self.transport(prompt_marker)
+                self.assertEqual(result.returncode, 1)
+                self.assertEqual(result.stdout, "")
+                receipt_text = result.receipt_path.read_text()  # type: ignore[attr-defined]
+                receipt = json.loads(receipt_text)
+                self.assertEqual(receipt["failureKind"], "http_error")
+                self.assertEqual(receipt["failureReason"], reason)
+                self.assertEqual(
+                    result.stderr,
+                    f"### RUNNER FAILURE (z-ai/glm-5.2, HTTP {status}: {label})\n",
+                )
+                visible = result.stdout + result.stderr + receipt_text
+                raw_body = body if isinstance(body, str) else json.dumps(body)
+                for forbidden in (
+                    prompt_marker, reflected_marker, raw_body, "flagged_input",
+                    "openrouter_metadata", '"metadata"',
+                    "Budget limit exceeded", "Contact your org admin",
+                    "Provider permission detail", "Mismatched private detail",
+                    "Private payment detail", "Private rate detail",
+                ):
+                    self.assertNotIn(forbidden, visible)
 
     def test_transport_keeps_bearer_value_out_of_curl_argv_and_environment(self) -> None:
         wrapper = WRAPPER.read_text()

--- a/tools/test-openrouter-agent-runner-boundary.sh
+++ b/tools/test-openrouter-agent-runner-boundary.sh
@@ -88,4 +88,51 @@ grep -Fq -- 'artifact-delegation' "$FIXTURE/args"
 [ "$(wc -l < "$FIXTURE/screened-digests" | tr -d ' ')" = "2" ]
 cmp "$FIXTURE/screened-digests" "$FIXTURE/wrapper-digests"
 
-echo "  OK    OpenRouter agent runner performs one behavioral boundary scan"
+{
+  printf '%s\n' '#!/usr/bin/env bash' 'set -euo pipefail'
+  sed -n '/^read_http_failure_reason() {/,/^}/p' "$SOURCE"
+  sed -n '/^map_wrapper_failure_reason() {/,/^}/p' "$SOURCE"
+  cat <<'EOF'
+receipt="$1"
+expected="$2"
+[ "$(read_http_failure_reason "$receipt")" = "$expected" ]
+EOF
+} > "$FIXTURE/read-failure-reason"
+chmod +x "$FIXTURE/read-failure-reason"
+
+for reason in \
+  organization_monthly_budget_exceeded key_permission_denied guardrail_blocked \
+  insufficient_credits rate_limited unknown_http_error; do
+  jq -n --arg reason "$reason" '{
+    schemaVersion: 2,
+    outcome: "error",
+    failureKind: "http_error",
+    failureReason: $reason
+  }' > "$FIXTURE/receipt"
+  "$FIXTURE/read-failure-reason" "$FIXTURE/receipt" "$reason"
+done
+
+for invalid in unexpected_reason null; do
+  if [ "$invalid" = null ]; then
+    value=null
+  else
+    value='"unexpected_reason"'
+  fi
+  printf '{"schemaVersion":2,"outcome":"error","failureKind":"http_error","failureReason":%s}\n' \
+    "$value" > "$FIXTURE/receipt"
+  ! "$FIXTURE/read-failure-reason" "$FIXTURE/receipt" "$invalid" >/dev/null 2>&1
+done
+printf 'not-json\n' > "$FIXTURE/receipt"
+! "$FIXTURE/read-failure-reason" "$FIXTURE/receipt" ignored >/dev/null 2>&1
+
+{
+  sed -n '/^map_wrapper_failure_reason() {/,/^}/p' "$SOURCE"
+  printf '%s\n' 'map_wrapper_failure_reason organization_monthly_budget_exceeded'
+} > "$FIXTURE/map-failure-reason"
+organization_reason=$(bash "$FIXTURE/map-failure-reason")
+[ "$organization_reason" = "The OpenRouter organization monthly budget is exhausted; its administrator must raise or reset that limit" ]
+case "$organization_reason" in
+  *"buy"*|*"credit"*|*"replace"*|*"key"*) exit 1 ;;
+esac
+
+echo "  OK    OpenRouter agent runner performs one behavioral boundary scan and validates closed HTTP failure reasons"

--- a/tools/test-openrouter-agent-runner-boundary.sh
+++ b/tools/test-openrouter-agent-runner-boundary.sh
@@ -135,4 +135,53 @@ case "$organization_reason" in
   *"buy"*|*"credit"*|*"replace"*|*"key"*) exit 1 ;;
 esac
 
-echo "  OK    OpenRouter agent runner performs one behavioral boundary scan and validates closed HTTP failure reasons"
+cat > "$REFS/openrouter-wrapper.sh" <<'EOF'
+#!/usr/bin/env bash
+jq -n '{
+  schemaVersion: 2,
+  outcome: "error",
+  failureKind: "http_error",
+  failureReason: "organization_monthly_budget_exceeded"
+}' > "$OPENROUTER_RECEIPT_FILE"
+printf '%s\n' 'PRIVATE_PROVIDER_BODY_MARKER' >&2
+exit 1
+EOF
+chmod +x "$REFS/openrouter-wrapper.sh"
+
+{
+  printf '%s\n' '#!/usr/bin/env bash' 'set -uo pipefail'
+  printf '%s\n' \
+    'target_agent_name="doc-sync-reviewer"' \
+    'target_model="openai/gpt-5.6-luna"' \
+    'fallback_model="openai/gpt-5.6-terra"' \
+    'target_timeout=10' \
+    'review_run_id="runner-http-failure-test"' \
+    'TARGET_BODY="Review documentation consistency."' \
+    'USER_PROMPT="Review this harmless fixture."' \
+    'SECURITY_POLICY_RESOLVED="$OPENROUTER_ROOT/skills/openrouter-delegate/references/delegation-security-policy.json"'
+  sed -n '/^WRAPPER_PATH=/,/^EXIT_CODE=\$?/p' "$SOURCE"
+  sed -n '/^ACTUAL_MODEL=/,/^fi$/p' "$SOURCE"
+  sed -n '/^case "\$EXIT_CODE" in/,/^fi$/p' "$SOURCE"
+} > "$FIXTURE/run-http-failure"
+chmod +x "$FIXTURE/run-http-failure"
+
+runner_failure_output=$(HOME="$FIXTURE/home" OPENROUTER_ROOT="$OPENROUTER_ROOT" \
+  BOUNDARY_HELPER="$FIXTURE/boundary" BOUNDARY_COUNT="$FIXTURE/http-count" \
+  BOUNDARY_ARGS="$FIXTURE/http-args" WRAPPER_SENTINEL="$FIXTURE/http-wrapper-called" \
+  EVENT_LOG="$FIXTURE/http-events" SCREENED_FILES="$FIXTURE/http-screened-files" \
+  SCREENED_DIGESTS="$FIXTURE/http-screened-digests" WRAPPER_DIGESTS="$FIXTURE/http-wrapper-digests" \
+  "$FIXTURE/run-http-failure")
+
+case "$runner_failure_output" in
+  *"### RUNNER FAILURE"*) ;;
+  *) exit 1 ;;
+esac
+case "$runner_failure_output" in
+  *"OpenRouter runner (doc-sync-reviewer): The OpenRouter organization monthly budget is exhausted; its administrator must raise or reset that limit. Review unavailable."*) ;;
+  *) exit 1 ;;
+esac
+case "$runner_failure_output" in
+  *"PRIVATE_PROVIDER_BODY_MARKER"*|*"All models exhausted, key missing, or HTTP error"*) exit 1 ;;
+esac
+
+echo "  OK    OpenRouter agent runner scans once and propagates closed HTTP failure reasons"


### PR DESCRIPTION
## Summary

- classify non-200 OpenRouter responses inside the private wrapper run directory into a closed, content-safe failure reason
- propagate only validated receipt reasons into the dm-review runner while preserving existing fallback and incomplete-review behavior
- document distinct account-credit, organization-budget, and per-key-limit states; release OpenRouter 1.14.5
- add loopback and runner-contract regressions for classification and provider-content redaction

## Verification

- python3 tests/test_openrouter_noninteractive.py
- bash tools/test-openrouter-agent-runner-boundary.sh
- ./tools/validate-openrouter-cascade.sh
- ./tools/validate-openrouter-resolution.sh
- ./tools/validate-workflow-contracts.sh
- ./tools/generate-codex-manifests.py --check
- ./tools/generate-codex-command-skills.py --check
- ./tools/check-dependencies.sh
- ./tools/validate-dual-compat.sh
- git diff --check
- ./tools/validate-composition.sh --all

Closes #68

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Design-Machines-Studio/codesmith/depot/pr/69"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789373234&installation_model_id=428410&pr_number=69&repository=Design-Machines-Studio%2Fdepot&return_to=https%3A%2F%2Fgithub.com%2FDesign-Machines-Studio%2Fdepot%2Fpull%2F69&signature=4030773b0b82ba87cbe702fe7b92be3e59d0f8a5f52b434734d6abe30dc6ec47"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->