### PR TITLE
fix(dm-review): restore zero-deferral findings

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -283,12 +283,12 @@
     {
       "name": "dm-review",
       "source": "./plugins/dm-review",
-      "version": "1.62.1",
+      "version": "1.63.0",
       "author": {
         "name": "Design Machines",
         "url": "https://designmachines.studio"
       },
-      "description": "Code review orchestrator with reachable-threat P1/P2 evidence, minimum-adequate repairs, proportional convergence, full security and browser coverage, and stable finding receipts",
+      "description": "Code review orchestrator with evidence-backed severity, minimum-adequate repairs, zero-deferral convergence, full security and browser coverage, and stable finding receipts",
       "capabilities_summary": {
         "skills": 3,
         "agents": 15,
@@ -361,7 +361,7 @@
     {
       "name": "pipeline",
       "source": "./plugins/pipeline",
-      "version": "1.52.0",
+      "version": "1.53.0",
       "author": {
         "name": "Design Machines",
         "url": "https://designmachines.studio"

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ quality pulses. 3 skills, 15 agents, 6 commands.
 - `/dm-review-quick` -- Quick review with two core judgment lanes plus applicable UI/build/domain verification; bounded security-sensitive paths escalate to full review
 - `/dm-review-fix` -- Resolve pending review findings from todos/
 - `/dm-review-visual` -- Visual browser testing on rendered pages
-- `/dm-review-loop` -- Review-fix convergence until no P1/P2 findings remain; P3 stays advisory
+- `/dm-review-loop` -- Review-fix convergence until no retained P1/P2/P3 findings remain; no deferrals
 - `/dm-review-quality-pulse` -- Run the repository quality-pulse workflow
 
 ### the-local
@@ -211,7 +211,7 @@ Autonomous feature development pipeline. 4 skills, 2 agents, 5 commands.
 - **promptcraft** -- Generates self-contained execution prompts with overlap-aware dependency ordering
 - **eval-sweep** -- Ledger-first system-wide route, breakpoint, and accessibility evaluation
 - **plan-adversary** (agent) -- Adversarial review of plans and prompts, iterating to convergence
-- **execution-orchestrator** (agent) -- Autonomous worktree execution with batched P1/P2 review fixes, advisory P3 evidence, and tiered repository verification
+- **execution-orchestrator** (agent) -- Autonomous worktree execution with batched P1/P2/P3 review fixes, zero-deferral convergence, and tiered repository verification
 - `/pipeline` -- Full autonomous pipeline: assess, research, plan, prompt, review, execute, deliver
 - `/pipeline-assess` -- Pre-plan assessment of current state
 - `/pipeline-prompts` -- Generate execution prompts from an existing plan

--- a/docs/dependency-graph.md
+++ b/docs/dependency-graph.md
@@ -66,7 +66,7 @@ graph LR
 | dm-review | openrouter | optional | `>=1.14.2` |
 | ghostwriter | design-machines | optional | `>=1.5.0` |
 | ned | superpowers | optional | `>=1.0.0` |
-| pipeline | dm-review | required | `>=1.62.0` |
+| pipeline | dm-review | required | `>=1.63.0` |
 | pipeline | ned | required | `>=1.4.0` |
 | pipeline | workflow-kernel | required | `>=0.16.0` |
 | pipeline | design-machines | optional | `>=1.3.0` |

--- a/plugins/dm-review/.claude-plugin/plugin.json
+++ b/plugins/dm-review/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dm-review",
-  "description": "Code review orchestrator with reachable-threat P1/P2 evidence, minimum-adequate repairs, proportional convergence, full security and browser coverage, and stable finding receipts",
-  "version": "1.62.1",
+  "description": "Code review orchestrator with evidence-backed severity, minimum-adequate repairs, zero-deferral convergence, full security and browser coverage, and stable finding receipts",
+  "version": "1.63.0",
   "author": {
     "name": "Design Machines",
     "url": "https://designmachines.io"

--- a/plugins/dm-review/.codex-plugin/plugin.json
+++ b/plugins/dm-review/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dm-review",
-  "version": "1.62.1",
-  "description": "Code review orchestrator with reachable-threat P1/P2 evidence, minimum-adequate repairs, proportional convergence, full security and browser coverage, and stable finding receipts",
+  "version": "1.63.0",
+  "description": "Code review orchestrator with evidence-backed severity, minimum-adequate repairs, zero-deferral convergence, full security and browser coverage, and stable finding receipts",
   "author": {
     "name": "Design Machines",
     "url": "https://designmachines.io"
@@ -326,8 +326,8 @@
   },
   "interface": {
     "displayName": "DM Review",
-    "shortDescription": "Code review orchestrator with reachable-threat P1/P2 evidence, minimum-adequate repairs, proportional convergence, full ",
-    "longDescription": "Code review orchestrator with reachable-threat P1/P2 evidence, minimum-adequate repairs, proportional convergence, full security and browser coverage, and stable finding receipts",
+    "shortDescription": "Code review orchestrator with evidence-backed severity, minimum-adequate repairs, zero-deferral convergence, full securi",
+    "longDescription": "Code review orchestrator with evidence-backed severity, minimum-adequate repairs, zero-deferral convergence, full security and browser coverage, and stable finding receipts",
     "developerName": "Design Machines",
     "category": "Developer Tools",
     "capabilities": [

--- a/plugins/dm-review/agents/review/architecture-reviewer.md
+++ b/plugins/dm-review/agents/review/architecture-reviewer.md
@@ -27,9 +27,14 @@ You run under a hard budget. Treat every tool call as spend you track.
 
 # Architecture Reviewer
 
-You are an architecture reviewer. Verify that code changes preserve real component and trust boundaries without turning preferred layering into mandatory architecture. SOLID principles, file/function lengths, layer counts, interfaces, and service/repository patterns are heuristics for investigation, not automatic P1/P2 findings.
+You are an architecture reviewer. Verify that code changes preserve real component and trust boundaries without turning preferred layering into mandatory architecture. SOLID principles, file/function lengths, layer counts, interfaces, and service/repository patterns are heuristics for investigation, not findings by themselves.
 
-Every P1/P2 must identify the affected current user or operator, reachable actor/input/path, realistic harm or regression, and smallest adequate repair. If those cannot be named, downgrade the architecture preference to P3 or do not report it.
+Every retained finding must identify an observable current defect, its location
+or reachable path, and the smallest adequate repair. P1/P2 must additionally
+identify the affected current user or operator and realistic harm or regression.
+If those thresholds are not met, do not report an architecture preference as a
+finding. P3 is required work for a bounded minor defect, not a parking lot for
+optional redesign.
 
 ## Review Scope
 
@@ -85,7 +90,7 @@ Violations:
 
 When reviewing Assembly production code (`internal/fixtures/` or `internal/baseplate/`):
 
-**File Size Heuristic:** Handler files above 200 lines and service files above 500 lines deserve inspection, but the number alone is not a finding and is never automatically P1/P2. Report only a concrete current defect such as an unsafe boundary, untestable coupling that caused a regression, or an execution failure; use P3 for an evidenced maintainability improvement without current harm.
+**File Size Heuristic:** Handler files above 200 lines and service files above 500 lines deserve inspection, but the number alone is not a finding. Report only a concrete current defect such as an unsafe boundary, untestable coupling that caused a regression, or an execution failure. Do not create P3 work for file size or a general maintainability preference alone.
 
 **Reorg-Only PR Verification (P2):** When a PR's stated purpose is decomposing an oversized file (the fix for a File Size Limits finding), hold it to the behavior-preserving reorg contract:
 
@@ -106,7 +111,7 @@ when it has no domain logic or transaction ownership. Every other applicable
 control still applies, including concrete action/resource authorization for a
 protected user or operator write.
 
-**Module Boundary Violations:** A fixture importing another fixture's package is a heuristic. Raise P1/P2 only when the import creates a concrete current data, authorization, lifecycle, or execution failure; otherwise report the coupling as P3. For example, inspect `internal/fixtures/governance/` importing `internal/fixtures/documents/`, but do not infer hostile code.
+**Module Boundary Violations:** A fixture importing another fixture's package is a heuristic. Report it only when the import creates a concrete current data, authorization, lifecycle, execution, or bounded maintainability defect. For example, inspect `internal/fixtures/governance/` importing `internal/fixtures/documents/`, but do not infer hostile code or report coupling merely because another layer would look cleaner.
 
 **ScopedDB Bypass:** Raise P1/P2 when fixture code importing `database/sql` or using `*sql.DB` exposes a reachable cross-prefix read/write, authorization bypass, or corruptible state that `ScopedDB` currently prevents. Mere direct access in trusted first-party Fixture code is not automatically a finding. Exception: baseplate code (`internal/baseplate/`) and test utilities may use raw `*sql.DB`.
 
@@ -116,11 +121,11 @@ request parsing, input validation, rendering, or the narrow one-statement
 direct `ScopedDB` case allowed by the applicability matrix. Suggest a service
 when a real boundary exists.
 
-**Shared Component Isolation:** An `internal/components/` file importing fixture-specific types is normally a P3 coupling heuristic. Escalate only when direct evidence shows a current boundary regression; do not mandate primitive props or a new abstraction by default.
+**Shared Component Isolation:** An `internal/components/` file importing fixture-specific types is a heuristic. Report it only when direct evidence shows a current boundary regression or other observable defect; do not mandate primitive props or a new abstraction by default.
 
-**Module-Owned Model Placement:** DTO or model placement outside `internal/fixtures/{name}/model/` is P3 at most without a demonstrated current failure. Do not require a move solely for architectural consistency.
+**Module-Owned Model Placement:** DTO or model placement outside `internal/fixtures/{name}/model/` is not a finding without a demonstrated current defect. Do not require a move solely for architectural consistency.
 
-**Page Template Placement:** A page-level Templ template outside `internal/fixtures/{name}/pages/` is P3 at most without a demonstrated current failure. Clear direct placement is valid.
+**Page Template Placement:** A page-level Templ template outside `internal/fixtures/{name}/pages/` is not a finding without a demonstrated current defect. Clear direct placement is valid.
 
 **Fixture Ownership Boundary:** Flag fixture access to baseplate internals as P1/P2 only when it exposes a reachable authorization, credential, destructive-data, or corruptible-state path. Otherwise treat `Dependencies` interfaces as the existing preferred mechanism, not proof that direct trusted code is hostile.
 
@@ -134,7 +139,7 @@ matrix must authorize before its protected write.
 
 **Look for:** `Authorize()` calls inside `func (h *Handler)` or `func (h *handler)` methods that precede `h.service.Foo()` calls -- the Authorize should be inside `service.Foo()`, not the handler.
 
-**Missing Auth Boundary Map Receipt (P3):** When reviewing changes that touch `auth/`, `admin/`, `account/`, `install/`, `member/`, or `module`-level permission paths, check whether the PR description, a commit body, or a checked-in receipt includes an Auth Boundary Map receipt. Its absence is advisory process evidence, not proof of an auth defect. Raise P1/P2 only for a concrete reachable authorization failure in the code.
+**Auth Boundary Map Receipt:** When reviewing changes that touch `auth/`, `admin/`, `account/`, `install/`, `member/`, or `module`-level permission paths, check whether the PR description, a commit body, or a checked-in receipt includes an Auth Boundary Map receipt. Its absence is a coverage note, not a product finding or proof of an auth defect. Report a finding only for a concrete reachable authorization failure in the code.
 
 The receipt enumerates: mapped surfaces, middleware gates, Authorizer action/resource pairs, default-deny UI capabilities, stale-session/operator/install edge cases addressed, test files, and residual risk. See the assembly development skill for the template.
 
@@ -142,7 +147,7 @@ The receipt helps a reviewer learn which surfaces were considered, but no reposi
 
 If Phase 1b located the receipt somewhere other than the PR body (a merge-commit body, `plans/*/receipt.md`), that satisfies this check -- cite where you found it.
 
-**Fixture SDK Conformance Gap:** When approved scope changes an SDK trust boundary or a current reachable input can violate an existing invariant, verify the smallest relevant negative case. Trusted first-party Fixture code does not imply a hostile marketplace. Raise P2 only when the missing proof permits a concrete current regression or realistic reachable harm; otherwise treat broader conformance coverage as P3 advice.
+**Fixture SDK Conformance Gap:** When approved scope changes an SDK trust boundary or a current reachable input can violate an existing invariant, verify the smallest relevant negative case. Trusted first-party Fixture code does not imply a hostile marketplace. Raise P2 only when the missing proof permits a concrete current regression or realistic reachable harm; otherwise omit broader conformance coverage from findings.
 
 - An unprefixed or foreign table prefix is rejected by `ScopedDB`
 - Stream subjects outside the fixture's own prefix are rejected at registration
@@ -155,7 +160,7 @@ Escalate to **P1** for a fail-open default: a zero-value `Authorizer`, a nil or 
 
 A change that makes a verification claim must prove the specific reachable invariant it claims. Do not require an unrelated conformance-harness family.
 
-**Hand-Rolled JS Where Datastar Suffices:** In Go + Templ + Datastar projects, a new `<script>` block or `.js` file whose behavior maps to `${CLAUDE_PLUGIN_ROOT}/plugins/dm-review/skills/review/references/datastar-pro.md` is a framework heuristic. Raise P1/P2 only for a demonstrated current behavior, security, or accessibility defect; otherwise a declarative replacement is P3 advice.
+**Hand-Rolled JS Where Datastar Suffices:** In Go + Templ + Datastar projects, a new `<script>` block or `.js` file whose behavior maps to `${CLAUDE_PLUGIN_ROOT}/plugins/dm-review/skills/review/references/datastar-pro.md` is a framework heuristic. Report it only for a demonstrated current behavior, security, accessibility, or bounded maintainability defect; otherwise do not require a declarative rewrite.
 
 #### Craft CMS Projects
 Expected layers:
@@ -215,10 +220,13 @@ Violations:
 
 1. Understand the project's architecture before flagging violations -- read the directory structure and imports
 2. Don't enforce textbook architecture on small projects -- pragmatism over purity
-3. A layer violation is P1 or P2 only when it causes a concrete current failure, reachable harm, or approved-scope regression. Otherwise it is P3 advice or not a finding.
+3. Report a layer violation only when it causes a concrete current failure,
+   reachable harm, approved-scope regression, or bounded minor defect. Otherwise
+   it is not a finding.
 4. Every finding must name the specific principle or rule being violated
 5. Suggest where the code should live instead, not just "this is in the wrong place"
-6. If the project doesn't have clear layers yet, note it as P3 and suggest the target architecture
+6. If the project does not have clear layers yet, do not invent a target
+   architecture unless an observable current defect requires one
 7. Don't penalize Go projects for not having a service layer if handlers are simple CRUD
 8. "Proper solution" means the smallest clear solution that repairs the evidenced current defect. Reject fixes that add layers or scope without a current consumer and reachable harm.
 9. For prototypes, recommend new migrations and clean installs over patching around schema issues

--- a/plugins/dm-review/agents/review/go-build-verifier.md
+++ b/plugins/dm-review/agents/review/go-build-verifier.md
@@ -44,7 +44,7 @@ If `.templ` files were changed:
 ```bash
 templ generate
 ```
-Check for generation errors. If `templ` is not installed, note it as a P3 finding and continue.
+Check for generation errors. If `templ` is not installed, record a coverage gap and continue; tool absence is not a product P3 finding.
 
 ### Step 2: Go Vet
 Run static analysis:
@@ -89,7 +89,7 @@ Report any compilation errors.
 
 - **P1** -- Compilation failure (`go build` or `templ generate` fails)
 - **P2** -- `go vet` warnings (these indicate likely bugs)
-- **P3** -- Tool not available (templ not installed)
+- **P3** -- Observable minor generation or build hygiene defect with a concrete repair
 
 ## Rules
 

--- a/plugins/dm-review/agents/review/security-auditor.md
+++ b/plugins/dm-review/agents/review/security-auditor.md
@@ -39,7 +39,7 @@ Every P1/P2 finding must state:
 - the actual trust boundary crossed; and
 - the smallest adequate repair.
 
-Hypothetical actors, future marketplaces, enterprise-scale concerns, generic OWASP possibilities, and defence-in-depth preferences are P3 at most and usually not findings. Do not weaken real boundaries: reachable authentication or authorization bypass, credential disclosure, unsafe destructive operations, corruptible state or backups, public untrusted input, release/update integrity failures, and false verification claims remain blocking at their supported severity.
+Hypothetical actors, future marketplaces, enterprise-scale concerns, generic OWASP possibilities, and defence-in-depth preferences are not findings by themselves. Retain one only when direct evidence establishes an observable current defect. Do not weaken real boundaries: reachable authentication or authorization bypass, credential disclosure, unsafe destructive operations, corruptible state or backups, public untrusted input, release/update integrity failures, and false verification claims remain blocking at their supported severity.
 
 ## Review Scope
 

--- a/plugins/dm-review/agents/review/test-coverage-reviewer.md
+++ b/plugins/dm-review/agents/review/test-coverage-reviewer.md
@@ -97,7 +97,7 @@ If no test infrastructure exists, skip this review entirely and report "Skipped 
 
 - **P1** -- Existing tests are now broken (renamed function, changed signature, deleted dependency)
 - **P2** -- Changed code has no corresponding tests and the project has testing infrastructure for that area
-- **P3** -- Missing edge case tests, test quality issues
+- **P3** -- An observable changed-path edge case or test-quality defect with a bounded test repair
 
 ## Rules
 
@@ -108,3 +108,6 @@ If no test infrastructure exists, skip this review entirely and report "Skipped 
 5. If a file is a pure data structure (no logic), tests are not required
 6. Flag broken tests as P1 -- they indicate the change may have unintended effects
 7. Report the specific function/handler/component that lacks tests, not just "file needs tests"
+8. Every retained P3 is required work. Do not report hypothetical edge cases,
+   target coverage percentages, or test-style preferences without an observable
+   changed-path defect and a smallest adequate test repair.

--- a/plugins/dm-review/agents/review/visual-browser-tester.md
+++ b/plugins/dm-review/agents/review/visual-browser-tester.md
@@ -85,7 +85,10 @@ The dispatch skill injects `## Visual Finding Rules` (spec-primary evaluation, t
 
 Your lens is the **rendering level**, complementing the ux-quality-reviewer's design-quality lens: extract the spec's component variants, visual hierarchy, spacing choices, color treatments, and described outcomes; take an element-level `browser_take_screenshot` (CSS selector or coordinates) for each decision that maps to a visible element; state explicitly what you see; flag deviations P1. This catches cases where CSS inheritance, layout context, or scheme color differences produce a different visual result than the code suggests.
 
-Every visual finding keeps complete evidence and provenance. P1/P2 require fixes; P3 is advisory and does not block `CLEAN`. See `plugins/dm-review/skills/review/references/severity-mapping.md` for the escalation rules.
+Every retained visual P1/P2/P3 finding keeps complete evidence and provenance,
+enters the fix queue, and blocks `CLEAN` until verified. See
+`plugins/dm-review/skills/review/references/severity-mapping.md` for the
+escalation rules.
 
 ### Phase B: Responsive Testing
 
@@ -268,6 +271,6 @@ Load each tool with `ToolSearch` before calling it (`ToolSearch query: "+pw brow
 6. Report the exact URL, breakpoint, and element for every finding.
 7. Console errors are P2 unless they are uncaught exceptions (P1).
 8. Do not modify page content; this is a read-only testing agent.
-9. If axe-core cannot be loaded via `browser_evaluate`, note it P3 and continue with manual checks.
+9. If axe-core cannot be loaded via `browser_evaluate`, record a coverage gap and continue with manual checks; tool absence is not a product P3 finding.
 10. Reset the page between component tests -- navigate back to the URL before testing a different component.
 11. Screenshot every state change -- screenshots are your evidence.

--- a/plugins/dm-review/agents/workflow/review-consolidator.md
+++ b/plugins/dm-review/agents/workflow/review-consolidator.md
@@ -146,7 +146,8 @@ Free-form reason codes are invalid. Every merge or discard names the retained
 canonical finding (when one exists), cites the evidence, and explains the
 decision. `not-reproducible` requires the Phase 5 verify-before-close evidence
 at HEAD. `out-of-scope` records a rejected reviewer input; it never defers an
-in-scope P1/P2 finding or changes the recommendation. P3 remains advisory.
+in-scope P1/P2/P3 finding or changes the recommendation. Every retained
+severity is mandatory work.
 
 Exact duplicates merge without count inflation. Findings at the same location
 with distinct root causes remain separate. Same-line and adjacent-line rules
@@ -179,7 +180,12 @@ both sources, without losing either raw artifact reference.
 
 Apply the severity mapping rules from `${CLAUDE_SKILL_DIR}/references/severity-mapping.md`. This covers all agent-specific term mappings (voice editor, CSS reviewer, governance domain, design review phases, etc.).
 
-Before retaining any P1/P2, verify that it names the affected current user or operator, reachable actor/input/path, realistic harm or regression, and smallest adequate repair; security findings must also name the actual trust boundary. Downgrade unsupported preferences to P3 or discard them when they have no current impact.
+Before retaining any finding, verify that it names an observable current defect,
+its location or reachable path, and the smallest adequate repair. P1/P2 must
+also name the affected current user or operator and realistic harm or
+regression; security P1/P2 must name the actual trust boundary. Discard
+unsupported preferences and speculative scope rather than retaining optional
+P3 debt.
 
 ### Step 4: Determine Merge Recommendation
 
@@ -212,7 +218,9 @@ complete.
 
 ## Rules
 
-1. Every finding from every agent must appear in the report -- don't drop anything
+1. Every source finding from every agent must appear in the sealed raw inventory
+   and synthesis decision trail. Only retained findings appear as actionable
+   work; discarded inputs keep their closed reason and provenance.
 2. Deduplication merges findings without count inflation; its decision trail
    preserves every source position and raw reference
 3. The merge recommendation is mechanical -- follow the logic exactly
@@ -221,8 +229,8 @@ complete.
 6. Include agents that found nothing in the summary table with "Clean" status
 7. Include skipped agents in the summary table with "Skipped" status and reason; include dead/capped agents with "Died" or "Partial" status and never relaunch them
 8. Count deduplicated findings, not raw findings (don't double-count)
-9. **P3 findings get full detail blocks** -- same format as P1/P2 (file, issue, fix, reference), with source identity, raw reference, evidence, synthesis disposition, counts, and provenance. Never abbreviate P3 to one-liners or send it to the fix queue.
-10. **Reject scope-expanding repairs** -- a P1/P2 repair must be the smallest adequate change for the evidenced defect and approved behavior. Discard unrelated hardening and new product scope from the fix queue. A reviewer may retain a larger alternative as P3 advice, but it does not enter convergence or escalate merely because it is described as more architectural or "proper."
+9. **P3 findings get full detail blocks** -- same format as P1/P2 (file, issue, fix, reference), with source identity, raw reference, evidence, synthesis disposition, counts, and provenance. Every retained P3 enters the fix queue.
+10. **Reject scope-expanding repairs** -- every P1/P2/P3 repair must be the smallest adequate change for the evidenced defect and approved behavior. Discard unrelated hardening, new product scope, and larger preference-only alternatives instead of retaining optional debt.
 11. **Dual-perspective findings are additive** -- Codex-native and OpenRouter review lanes are peers. Dedup overlapping findings; never discard a unique finding merely because the other coding provider did not mention it. Optional Claude voice/editorial findings remain additive but are non-coding.
 12. **Contradictions are reportable evidence** -- never flatten disagreement
     into one unattributed conclusion; preserve source severities, selected
@@ -230,8 +238,8 @@ complete.
 13. **Provenance is literal** -- if a requested provider falls back, retain the
     requested, attempted, and implemented-by values. Never silently relabel a
     Codex fallback as OpenRouter work.
-14. **The handoff is bounded** -- list every P1/P2 once when there are at most
-    eight; otherwise show the highest-impact eight, the exact remaining count,
-    and the complete-report pointer. Show P3 only as a count plus evidence
-    pointer there. Never expand provider tables, transcripts, synthesis ledgers,
+14. **The handoff is bounded** -- list every retained P1/P2/P3 once when there
+    are at most eight; otherwise show the highest-impact eight, the exact
+    remaining count, and the complete-report pointer. Never expand provider
+    tables, transcripts, synthesis ledgers,
     cleanup tables, or raw reports in the visible handoff.

--- a/plugins/dm-review/commands/dm-review-fix.md
+++ b/plugins/dm-review/commands/dm-review-fix.md
@@ -10,7 +10,8 @@ Fix pending review findings tracked in `todos/` from a previous `/dm-review` run
 
 ## Finding Policy
 
-This command fixes pending P1 and P2 findings. P3 advisories remain visible in the review report and receipts but never enter this fix queue.
+This command fixes every pending P1, P2, and P3 finding. Severity controls fix
+order, not whether the finding is owed.
 
 ## Process
 
@@ -24,33 +25,39 @@ written. See `docs/skill-authoring.md`.
 ### 1. Find Pending Findings
 
 ```bash
-ls todos/*-pending-p1-*.md todos/*-pending-p2-*.md 2>/dev/null
+ls todos/*-pending-p1-*.md todos/*-pending-p2-*.md todos/*-pending-p3-*.md 2>/dev/null
 ```
-
-Historical `todos/*-pending-p3-*.md` files from releases before 1.59.0 are
-advisory artifacts. Leave them owner-managed and report them separately; they
-do not enter this fix queue or block completion.
 
 If no pending findings exist, tell the user and stop.
 
 If an argument was provided:
 - Number (e.g., `001`) -- resolve only that finding
 - Priority (e.g., `p1`) -- resolve all findings of that priority
-- No argument -- resolve all pending findings, P1 first
+- No argument -- resolve all pending findings in P1, P2, then P3 order
 
 ### 2. Plan Fixes
 
 For each pending finding:
 1. Read the todo file
-2. Confirm it names the affected current user/operator, reachable actor/input/path, realistic harm or regression, and smallest adequate repair; security findings must also name the actual trust boundary. Unsupported architecture preferences or hypothetical hardening do not enter the fix batch.
+2. Confirm it names an observable current defect, its location or reachable path,
+   and the smallest adequate repair. P1/P2 findings must additionally name the
+   affected current user/operator and realistic harm or regression; security
+   P1/P2 findings must name the actual trust boundary. Reject unsupported
+   architecture preferences or hypothetical hardening rather than treating
+   them as pending work.
 3. Read the affected source file(s)
 4. Plan the fix
+
+If current evidence disproves a pending finding or shows that it was duplicate,
+speculative, or outside the approved scope, record the evidence-backed rejection
+in the summary and remove that pending todo. Rejection closes invalid input; it
+must never be used to avoid a valid repair.
 
 Group related findings that touch the same files -- fix them together.
 
 ### 3. Implement Fixes
 
-Fix all pending findings in priority order: P1 first, then P2.
+Fix all pending findings in priority order: P1 first, then P2, then P3.
 
 For each finding:
 
@@ -71,6 +78,8 @@ After resolving all findings:
 Resolved N of M findings:
 - [done] 001-p1-description
 - [done] 002-p2-description
+- [done] 003-p3-description
+- [rejected] 004-p3-description -- <current evidence proving invalidity>
 
 Remaining: X pending findings
 ```

--- a/plugins/dm-review/commands/dm-review-loop.md
+++ b/plugins/dm-review/commands/dm-review-loop.md
@@ -8,9 +8,14 @@ argument-hint: "[optional: --full, --max-iterations N, PR number, branch, or pat
 
 Automates the cycle of reviewing code, fixing required findings, and re-reviewing affected lanes until clean.
 
-## Finding Policy
+## Zero-Deferral Finding Policy
 
-P1 blocks merge and P2 must be fixed before merge. P3 remains fully retained advisory evidence but never enters the fix queue, triggers another iteration, or blocks convergence; the compact handoff shows its exact count and evidence pointer. The loop is clean when no P1/P2 findings remain and all required verification and coverage gates are complete.
+Every retained P1, P2, and P3 finding enters the fix queue and must be resolved.
+Severity controls priority, not whether work is owed. The loop is clean only
+when no findings remain and every required verification and coverage gate is
+complete. Invalid, duplicate, disproved, and scope-expanding reviewer
+suggestions must be rejected during consolidation; retaining one and calling it
+advisory is forbidden.
 
 The default convergence path is one repair batch followed by one affected-lane recheck. Repeat broad review only when the original required review was incomplete or the repair changed a real sensitive boundary.
 
@@ -49,7 +54,7 @@ mode = "quick" (or "full" if --full flag present)
 target = remaining arguments after flag parsing
 prior_findings_signature = null  # for stalled-convergence detection
 prior_review_head = null  # HEAD commit the prior iteration reviewed
-prior_finding_owner_lanes = empty set  # owners of P1/P2 findings just repaired
+prior_finding_owner_lanes = empty set  # owners of P1/P2/P3 findings just repaired
 rerun_lanes = null  # null = full fan-out; a set = narrowed lane selection
 selective_rerun = false
 review_is_full_fanout = false
@@ -97,17 +102,17 @@ while iteration < max_iterations:
       selective_rerun = false
       rerun_reasons = every lane in selected_full_set -> ["initial_full_fanout"]
     else:
-      # (a) every lane that owned a P1/P2 finding repaired in the prior fix
+      # (a) every lane that owned a P1/P2/P3 finding repaired in the prior fix
       #     step, plus every lane owning a finding that remains pending. Capture
       #     repaired owners before dm-review-fix removes their todo files.
-      For every repaired or pending P1/P2 finding, require source_agents is a non-empty list and
+      For every repaired or pending P1/P2/P3 finding, require source_agents is a non-empty list and
         every named owner resolves to exactly one member of selected_full_set.
         An unknown owner, alias, or criterion-level ID shared by multiple
         logical lanes is a selection error. In particular, bare
         security-auditor is ambiguous because security-auditor-codex-signoff
         and security-auditor-openrouter are separate logical lanes.
       lanes_a = prior_finding_owner_lanes union the validated exact source_agents
-                lane IDs from remaining pending P1/P2 findings
+                lane IDs from remaining pending P1/P2/P3 findings
       # (b) every lane whose file-trigger set matches a file the fixes touched.
       #     dm-review-fix does not commit, so a committed-range diff alone
       #     would silently miss every uncommitted fix. Consult both.
@@ -234,8 +239,8 @@ while iteration < max_iterations:
     BEFORE invoking observe-review. The persisted receipt field
     `selection_fallback_reason` is the loop-local fallback_reason value.
 
-  # Check for required findings. P3 advisories exist only in the report/receipts.
-  required_finding_files = todos/*-pending-p1-*.md plus todos/*-pending-p2-*.md
+  # Check for required findings. Every retained severity participates.
+  required_finding_files = todos/*-pending-p1-*.md plus todos/*-pending-p2-*.md plus todos/*-pending-p3-*.md
   Count findings in required_finding_files
 
   current_signature = sorted list of required_finding_files
@@ -244,7 +249,7 @@ while iteration < max_iterations:
     if required_verification_complete == false:
       Report the nested review's REVIEW INCOMPLETE or exact coverage failure
       STOP -- needs attention
-    Report: "Clean after {iteration} iteration(s). No open P1/P2 findings; P3 advisories retained."
+    Report: "Clean after {iteration} iteration(s). No open P1/P2/P3 findings."
     STOP -- success
 
   # Stalled-convergence short-circuit (token saver):
@@ -260,14 +265,14 @@ while iteration < max_iterations:
                               required_finding_files
 
   # The default convergence contract is one repair batch followed by one
-  # affected-lane recheck. Remaining or newly supported P1/P2 after that
+  # affected-lane recheck. Remaining or newly supported findings after that
   # recheck require operator attention, not an automatic second repair batch.
   if iteration > 1 and explicit_iteration_override == false:
     Report: "{findings} supported finding(s) remain after the targeted recheck. Manual decision required."
     List remaining todo files
     STOP -- needs attention
 
-  # Fix required findings only (P1/P2).
+  # Fix every retained finding (P1/P2/P3).
   Run /dm-review-fix with workflowClass and workflow_class_defaulted forwarded unchanged
   # dm-review-fix resolves and cleans up todo files
 
@@ -287,7 +292,7 @@ while iteration < max_iterations:
       the truthful selective_rerun value and reason
       "max_iterations_affected_lane_verification", after coverage validates; append it to
       authoritative-receipts.json BEFORE observe-review.
-    Count remaining todos/*-pending-p1-*.md and todos/*-pending-p2-*.md
+    Count remaining todos/*-pending-p1-*.md, todos/*-pending-p2-*.md, and todos/*-pending-p3-*.md
     if findings == 0:
       if required_verification_complete == false:
         Report the nested review's REVIEW INCOMPLETE or exact coverage failure
@@ -302,9 +307,9 @@ while iteration < max_iterations:
 
 #### Selective Lane Re-run (iteration 2+)
 
-Iteration 1 is always a full fan-out in the selected mode. From iteration 2 onward the loop re-reviews only what the fixes could have affected. Before each fix step, preserve the exact owner lanes of every pending P1/P2 finding so deleting a resolved todo cannot erase its verification obligation. The re-run lane set is the union of:
+Iteration 1 is always a full fan-out in the selected mode. From iteration 2 onward the loop re-reviews only what the fixes could have affected. Before each fix step, preserve the exact owner lanes of every pending P1/P2/P3 finding so deleting a resolved todo cannot erase its verification obligation. The re-run lane set is the union of:
 
-- **(a) Finding-owning lanes** -- every lane named in the `source_agents` frontmatter of a P1/P2 finding repaired by the prior fix step, plus every lane owning a P1/P2 finding that remains pending. The loop snapshots repaired owners before `dm-review-fix` deletes completed todos.
+- **(a) Finding-owning lanes** -- every lane named in the `source_agents` frontmatter of a P1/P2/P3 finding repaired by the prior fix step, plus every lane owning a P1/P2/P3 finding that remains pending. The loop snapshots repaired owners before `dm-review-fix` deletes completed todos.
 - **(b) File-trigger lanes** -- every lane whose file-trigger set matches any file the fixes touched since the prior review. `dm-review-fix` does not commit, so the touched-file set is the union of `git diff --name-only <prior-review-head>..HEAD` and the paths reported by `git status --porcelain`. A committed-range diff alone would report an empty change set for a perfectly normal uncommitted fix pass, and would then narrow on false evidence.
 
 Before either rule may narrow coverage, recompute a non-empty `selected_full_set` containing only unique exact logical lane IDs. Every owner in every pending finding's `source_agents` must resolve to exactly one member of that set. Unknown owners, aliases, and criterion-level IDs shared by more than one logical lane are not narrowing signals; each fails open to full coverage with an explicit `fallback_reason`. The naming trap is deliberate: `security-auditor-codex-signoff` and `security-auditor-openrouter` are two logical lanes sharing one criterion, so bare `security-auditor` is ambiguous and fails open. An empty computed lane set is never dispatched.
@@ -334,7 +339,7 @@ The restriction is passed as the internal loop-to-review input `review_lane_allo
 
 **Current state of the receiving interface -- read this before claiming a saving.** Review Phase 3 now receives `review_lane_allowlist` under the validation contract above. The loop still never assumes that a restriction was honored: after every pass it consumes the authoritative coverage receipt and derives attempted and skipped lanes from that evidence. If the receiver reports the input absent, invalid, or not applied, the loop sets `selective_rerun` to false and persists the receiver's exact fallback reason. Input-byte savings may be claimed only from a receipt proving the narrowed input was applied.
 
-**Convergence requires no open P1/P2 findings and complete required coverage for the verification pass.** P3 advisories never trigger another pass. A selective affected-lane pass may establish convergence when every required selected lane completes; missing required coverage reports `REVIEW INCOMPLETE`. Repeat the whole full fan-out only when the prior full review was incomplete or a repair changed a security-sensitive boundary.
+**Convergence requires no open P1/P2/P3 findings and complete required coverage for the verification pass.** Every retained finding triggers repair and affected-lane verification. A selective affected-lane pass may establish convergence when every required selected lane completes; missing required coverage reports `REVIEW INCOMPLETE`. Repeat the whole full fan-out only when the prior full review was incomplete or a repair changed a security-sensitive boundary.
 
 #### Selective Re-run Receipt
 
@@ -351,7 +356,7 @@ Each pass report carries:
 - `promoted_to_full: true` only when an incomplete prior full review or a security-boundary repair requires another full fan-out.
 - `lanes_rerun` -- the exact logical lane IDs from the coverage receipt's ATTEMPTED rows, not the loop's intended set. A receiver that silently drops an intended lane therefore cannot falsely report it as re-run.
 - `lanes_skipped` -- for a proven selective pass only, `coverage_selected_set` minus the applied allowlist: the lanes deliberately omitted by narrowing. Each skipped lane records `no_rule_a_or_b_match` and receives no kernel `record-attempt` call. Every non-selective full fan-out reports an empty skip set. A lane selected or allowlisted but missing from ATTEMPTED because dispatch never began is neither re-run nor skipped; the nested review reports `REVIEW INCOMPLETE`.
-- `rerun_reasons` -- a per-lane map using only `a_prior_unresolved_finding`, `b_fix_file_trigger`, `initial_full_fanout`, and `selection_fail_open`. The stable `a_prior_unresolved_finding` receipt value covers a prior P1/P2 finding owner whether the finding was repaired or remains unresolved. A lane selected by more than one rule records every applicable reason. Full fan-outs use `initial_full_fanout`; fail-open full fan-outs use `selection_fail_open`.
+- `rerun_reasons` -- a per-lane map using only `a_prior_unresolved_finding`, `b_fix_file_trigger`, `initial_full_fanout`, and `selection_fail_open`. The stable `a_prior_unresolved_finding` receipt value covers a prior P1/P2/P3 finding owner whether the finding was repaired or remains unresolved. A lane selected by more than one rule records every applicable reason. Full fan-outs use `initial_full_fanout`; fail-open full fan-outs use `selection_fail_open`.
 - `selection_fallback_reason: <reason>` whenever selection failed open to a full fan-out or the receiver rejected or ignored selective input, and `full_fanout_override: true` whenever `DM_REVIEW_LOOP_FULL_FANOUT=1` disabled selection. `selection_fallback_reason` is the persisted receipt field for the loop-local `fallback_reason`. The local variable resets at the start of every iteration so a fail-open on one iteration never leaks into the next iteration's receipt.
 
 Example (affected-lane verification):
@@ -405,6 +410,7 @@ dm-review-loop: N finding(s) remain after M iteration(s).
 Mode: quick|full
 Remaining:
 - 001-pending-p2-description
+- 002-pending-p3-description
 
 These findings could not be auto-resolved. Manual review needed.
 ```

--- a/plugins/dm-review/commands/dm-review-quick.md
+++ b/plugins/dm-review/commands/dm-review-quick.md
@@ -37,9 +37,12 @@ Do not infer extra security triggers from generic handlers, shell scripts,
 dependency manifests, or configuration files. Quick review is early feedback;
 the one final full pre-merge review remains the complete security boundary.
 
-## Finding Policy
+## Zero-Deferral Finding Policy
 
-Quick mode uses the same severities as full mode: P1 blocks merge, P2 must be fixed before merge, and P3 remains a fully detailed advisory that does not enter the fix queue or prevent `CLEAN`.
+Quick mode follows the full policy: every retained P1, P2, and P3 finding
+enters the fix queue and must be resolved before `CLEAN`. Reject invalid or
+scope-expanding reviewer suggestions during consolidation; do not retain them
+as optional P3 debt.
 
 ## Process
 

--- a/plugins/dm-review/commands/dm-review-visual.md
+++ b/plugins/dm-review/commands/dm-review-visual.md
@@ -10,7 +10,10 @@ Run the visual testing protocol on rendered web pages using Playwright browser t
 
 ## Zero-Deferral Policy (default)
 
-Visual P1/P2 findings require fixes before merge. P3 remains fully detailed advisory evidence and does not prevent `CLEAN`. See `plugins/dm-review/skills/review/references/severity-mapping.md` for the policy.
+Every retained visual P1, P2, and P3 finding requires a fix before `CLEAN`.
+Reject preferences without an observable defect instead of recording optional
+debt. See `plugins/dm-review/skills/review/references/severity-mapping.md` for
+the policy.
 
 ## Process
 

--- a/plugins/dm-review/commands/dm-review.md
+++ b/plugins/dm-review/commands/dm-review.md
@@ -8,14 +8,20 @@ argument-hint: "[optional: PR number, branch name, or file path]"
 
 Run a comprehensive code review using all applicable agents for the current project stack.
 
-## Finding Policy
+## Zero-Deferral Finding Policy
 
-P1 blocks merge and P2 must be fixed before merge. P3 is advisory: retain its complete evidence, provenance, count, and detail, but do not create mandatory work, drive convergence, or prevent `CLEAN`. `/dm-review` surfaces all findings; `/dm-review-fix` resolves pending P1/P2 findings; `/dm-review-loop` automates fix-until-clean for required work.
+Every retained P1, P2, and P3 finding is mandatory work. `/dm-review` surfaces
+and tracks it, `/dm-review-fix` resolves it, and `/dm-review-loop` repairs and
+rechecks until no findings remain. Severity controls ordering and impact; it
+never turns a valid finding into optional debt. Reject a speculative,
+duplicate, disproved, or out-of-scope reviewer suggestion during consolidation
+instead of retaining it as a finding and deferring it. There is no deferral
+flag and no clean-with-P3s outcome.
 
 The merge recommendation reflects this policy:
 
 - **Zero findings:** `CLEAN` -- safe to merge.
-- **P3 only (no P1/P2):** `CLEAN` -- retain every P3 in complete evidence; show only the exact count and evidence pointer in the compact handoff.
+- **P3 only:** `APPROVE WITH FIXES`. Must fix.
 - **P2 present:** `APPROVE WITH FIXES`. Must fix.
 - **P1 present:** `BLOCKS MERGE`. Must fix.
 

--- a/plugins/dm-review/skills/dm-review-fix/SKILL.md
+++ b/plugins/dm-review/skills/dm-review-fix/SKILL.md
@@ -25,7 +25,8 @@ Fix pending review findings tracked in `todos/` from a previous `/dm-review` run
 
 ## Finding Policy
 
-This command fixes pending P1 and P2 findings. P3 advisories remain visible in the review report and receipts but never enter this fix queue.
+This command fixes every pending P1, P2, and P3 finding. Severity controls fix
+order, not whether the finding is owed.
 
 ## Process
 
@@ -39,33 +40,39 @@ written. See `docs/skill-authoring.md`.
 ### 1. Find Pending Findings
 
 ```bash
-ls todos/*-pending-p1-*.md todos/*-pending-p2-*.md 2>/dev/null
+ls todos/*-pending-p1-*.md todos/*-pending-p2-*.md todos/*-pending-p3-*.md 2>/dev/null
 ```
-
-Historical `todos/*-pending-p3-*.md` files from releases before 1.59.0 are
-advisory artifacts. Leave them owner-managed and report them separately; they
-do not enter this fix queue or block completion.
 
 If no pending findings exist, tell the user and stop.
 
 If an argument was provided:
 - Number (e.g., `001`) -- resolve only that finding
 - Priority (e.g., `p1`) -- resolve all findings of that priority
-- No argument -- resolve all pending findings, P1 first
+- No argument -- resolve all pending findings in P1, P2, then P3 order
 
 ### 2. Plan Fixes
 
 For each pending finding:
 1. Read the todo file
-2. Confirm it names the affected current user/operator, reachable actor/input/path, realistic harm or regression, and smallest adequate repair; security findings must also name the actual trust boundary. Unsupported architecture preferences or hypothetical hardening do not enter the fix batch.
+2. Confirm it names an observable current defect, its location or reachable path,
+   and the smallest adequate repair. P1/P2 findings must additionally name the
+   affected current user/operator and realistic harm or regression; security
+   P1/P2 findings must name the actual trust boundary. Reject unsupported
+   architecture preferences or hypothetical hardening rather than treating
+   them as pending work.
 3. Read the affected source file(s)
 4. Plan the fix
+
+If current evidence disproves a pending finding or shows that it was duplicate,
+speculative, or outside the approved scope, record the evidence-backed rejection
+in the summary and remove that pending todo. Rejection closes invalid input; it
+must never be used to avoid a valid repair.
 
 Group related findings that touch the same files -- fix them together.
 
 ### 3. Implement Fixes
 
-Fix all pending findings in priority order: P1 first, then P2.
+Fix all pending findings in priority order: P1 first, then P2, then P3.
 
 For each finding:
 
@@ -86,6 +93,8 @@ After resolving all findings:
 Resolved N of M findings:
 - [done] 001-p1-description
 - [done] 002-p2-description
+- [done] 003-p3-description
+- [rejected] 004-p3-description -- <current evidence proving invalidity>
 
 Remaining: X pending findings
 ```

--- a/plugins/dm-review/skills/dm-review-loop/SKILL.md
+++ b/plugins/dm-review/skills/dm-review-loop/SKILL.md
@@ -23,9 +23,14 @@ argument-hint: "[optional: --full, --max-iterations N, PR number, branch, or pat
 
 Automates the cycle of reviewing code, fixing required findings, and re-reviewing affected lanes until clean.
 
-## Finding Policy
+## Zero-Deferral Finding Policy
 
-P1 blocks merge and P2 must be fixed before merge. P3 remains fully retained advisory evidence but never enters the fix queue, triggers another iteration, or blocks convergence; the compact handoff shows its exact count and evidence pointer. The loop is clean when no P1/P2 findings remain and all required verification and coverage gates are complete.
+Every retained P1, P2, and P3 finding enters the fix queue and must be resolved.
+Severity controls priority, not whether work is owed. The loop is clean only
+when no findings remain and every required verification and coverage gate is
+complete. Invalid, duplicate, disproved, and scope-expanding reviewer
+suggestions must be rejected during consolidation; retaining one and calling it
+advisory is forbidden.
 
 The default convergence path is one repair batch followed by one affected-lane recheck. Repeat broad review only when the original required review was incomplete or the repair changed a real sensitive boundary.
 
@@ -64,7 +69,7 @@ mode = "quick" (or "full" if --full flag present)
 target = remaining arguments after flag parsing
 prior_findings_signature = null  # for stalled-convergence detection
 prior_review_head = null  # HEAD commit the prior iteration reviewed
-prior_finding_owner_lanes = empty set  # owners of P1/P2 findings just repaired
+prior_finding_owner_lanes = empty set  # owners of P1/P2/P3 findings just repaired
 rerun_lanes = null  # null = full fan-out; a set = narrowed lane selection
 selective_rerun = false
 review_is_full_fanout = false
@@ -112,17 +117,17 @@ while iteration < max_iterations:
       selective_rerun = false
       rerun_reasons = every lane in selected_full_set -> ["initial_full_fanout"]
     else:
-      # (a) every lane that owned a P1/P2 finding repaired in the prior fix
+      # (a) every lane that owned a P1/P2/P3 finding repaired in the prior fix
       #     step, plus every lane owning a finding that remains pending. Capture
       #     repaired owners before dm-review-fix removes their todo files.
-      For every repaired or pending P1/P2 finding, require source_agents is a non-empty list and
+      For every repaired or pending P1/P2/P3 finding, require source_agents is a non-empty list and
         every named owner resolves to exactly one member of selected_full_set.
         An unknown owner, alias, or criterion-level ID shared by multiple
         logical lanes is a selection error. In particular, bare
         security-auditor is ambiguous because security-auditor-codex-signoff
         and security-auditor-openrouter are separate logical lanes.
       lanes_a = prior_finding_owner_lanes union the validated exact source_agents
-                lane IDs from remaining pending P1/P2 findings
+                lane IDs from remaining pending P1/P2/P3 findings
       # (b) every lane whose file-trigger set matches a file the fixes touched.
       #     dm-review-fix does not commit, so a committed-range diff alone
       #     would silently miss every uncommitted fix. Consult both.
@@ -249,8 +254,8 @@ while iteration < max_iterations:
     BEFORE invoking observe-review. The persisted receipt field
     `selection_fallback_reason` is the loop-local fallback_reason value.
 
-  # Check for required findings. P3 advisories exist only in the report/receipts.
-  required_finding_files = todos/*-pending-p1-*.md plus todos/*-pending-p2-*.md
+  # Check for required findings. Every retained severity participates.
+  required_finding_files = todos/*-pending-p1-*.md plus todos/*-pending-p2-*.md plus todos/*-pending-p3-*.md
   Count findings in required_finding_files
 
   current_signature = sorted list of required_finding_files
@@ -259,7 +264,7 @@ while iteration < max_iterations:
     if required_verification_complete == false:
       Report the nested review's REVIEW INCOMPLETE or exact coverage failure
       STOP -- needs attention
-    Report: "Clean after {iteration} iteration(s). No open P1/P2 findings; P3 advisories retained."
+    Report: "Clean after {iteration} iteration(s). No open P1/P2/P3 findings."
     STOP -- success
 
   # Stalled-convergence short-circuit (token saver):
@@ -275,14 +280,14 @@ while iteration < max_iterations:
                               required_finding_files
 
   # The default convergence contract is one repair batch followed by one
-  # affected-lane recheck. Remaining or newly supported P1/P2 after that
+  # affected-lane recheck. Remaining or newly supported findings after that
   # recheck require operator attention, not an automatic second repair batch.
   if iteration > 1 and explicit_iteration_override == false:
     Report: "{findings} supported finding(s) remain after the targeted recheck. Manual decision required."
     List remaining todo files
     STOP -- needs attention
 
-  # Fix required findings only (P1/P2).
+  # Fix every retained finding (P1/P2/P3).
   Run /dm-review-fix with workflowClass and workflow_class_defaulted forwarded unchanged
   # dm-review-fix resolves and cleans up todo files
 
@@ -302,7 +307,7 @@ while iteration < max_iterations:
       the truthful selective_rerun value and reason
       "max_iterations_affected_lane_verification", after coverage validates; append it to
       authoritative-receipts.json BEFORE observe-review.
-    Count remaining todos/*-pending-p1-*.md and todos/*-pending-p2-*.md
+    Count remaining todos/*-pending-p1-*.md, todos/*-pending-p2-*.md, and todos/*-pending-p3-*.md
     if findings == 0:
       if required_verification_complete == false:
         Report the nested review's REVIEW INCOMPLETE or exact coverage failure
@@ -317,9 +322,9 @@ while iteration < max_iterations:
 
 #### Selective Lane Re-run (iteration 2+)
 
-Iteration 1 is always a full fan-out in the selected mode. From iteration 2 onward the loop re-reviews only what the fixes could have affected. Before each fix step, preserve the exact owner lanes of every pending P1/P2 finding so deleting a resolved todo cannot erase its verification obligation. The re-run lane set is the union of:
+Iteration 1 is always a full fan-out in the selected mode. From iteration 2 onward the loop re-reviews only what the fixes could have affected. Before each fix step, preserve the exact owner lanes of every pending P1/P2/P3 finding so deleting a resolved todo cannot erase its verification obligation. The re-run lane set is the union of:
 
-- **(a) Finding-owning lanes** -- every lane named in the `source_agents` frontmatter of a P1/P2 finding repaired by the prior fix step, plus every lane owning a P1/P2 finding that remains pending. The loop snapshots repaired owners before `dm-review-fix` deletes completed todos.
+- **(a) Finding-owning lanes** -- every lane named in the `source_agents` frontmatter of a P1/P2/P3 finding repaired by the prior fix step, plus every lane owning a P1/P2/P3 finding that remains pending. The loop snapshots repaired owners before `dm-review-fix` deletes completed todos.
 - **(b) File-trigger lanes** -- every lane whose file-trigger set matches any file the fixes touched since the prior review. `dm-review-fix` does not commit, so the touched-file set is the union of `git diff --name-only <prior-review-head>..HEAD` and the paths reported by `git status --porcelain`. A committed-range diff alone would report an empty change set for a perfectly normal uncommitted fix pass, and would then narrow on false evidence.
 
 Before either rule may narrow coverage, recompute a non-empty `selected_full_set` containing only unique exact logical lane IDs. Every owner in every pending finding's `source_agents` must resolve to exactly one member of that set. Unknown owners, aliases, and criterion-level IDs shared by more than one logical lane are not narrowing signals; each fails open to full coverage with an explicit `fallback_reason`. The naming trap is deliberate: `security-auditor-codex-signoff` and `security-auditor-openrouter` are two logical lanes sharing one criterion, so bare `security-auditor` is ambiguous and fails open. An empty computed lane set is never dispatched.
@@ -349,7 +354,7 @@ The restriction is passed as the internal loop-to-review input `review_lane_allo
 
 **Current state of the receiving interface -- read this before claiming a saving.** Review Phase 3 now receives `review_lane_allowlist` under the validation contract above. The loop still never assumes that a restriction was honored: after every pass it consumes the authoritative coverage receipt and derives attempted and skipped lanes from that evidence. If the receiver reports the input absent, invalid, or not applied, the loop sets `selective_rerun` to false and persists the receiver's exact fallback reason. Input-byte savings may be claimed only from a receipt proving the narrowed input was applied.
 
-**Convergence requires no open P1/P2 findings and complete required coverage for the verification pass.** P3 advisories never trigger another pass. A selective affected-lane pass may establish convergence when every required selected lane completes; missing required coverage reports `REVIEW INCOMPLETE`. Repeat the whole full fan-out only when the prior full review was incomplete or a repair changed a security-sensitive boundary.
+**Convergence requires no open P1/P2/P3 findings and complete required coverage for the verification pass.** Every retained finding triggers repair and affected-lane verification. A selective affected-lane pass may establish convergence when every required selected lane completes; missing required coverage reports `REVIEW INCOMPLETE`. Repeat the whole full fan-out only when the prior full review was incomplete or a repair changed a security-sensitive boundary.
 
 #### Selective Re-run Receipt
 
@@ -366,7 +371,7 @@ Each pass report carries:
 - `promoted_to_full: true` only when an incomplete prior full review or a security-boundary repair requires another full fan-out.
 - `lanes_rerun` -- the exact logical lane IDs from the coverage receipt's ATTEMPTED rows, not the loop's intended set. A receiver that silently drops an intended lane therefore cannot falsely report it as re-run.
 - `lanes_skipped` -- for a proven selective pass only, `coverage_selected_set` minus the applied allowlist: the lanes deliberately omitted by narrowing. Each skipped lane records `no_rule_a_or_b_match` and receives no kernel `record-attempt` call. Every non-selective full fan-out reports an empty skip set. A lane selected or allowlisted but missing from ATTEMPTED because dispatch never began is neither re-run nor skipped; the nested review reports `REVIEW INCOMPLETE`.
-- `rerun_reasons` -- a per-lane map using only `a_prior_unresolved_finding`, `b_fix_file_trigger`, `initial_full_fanout`, and `selection_fail_open`. The stable `a_prior_unresolved_finding` receipt value covers a prior P1/P2 finding owner whether the finding was repaired or remains unresolved. A lane selected by more than one rule records every applicable reason. Full fan-outs use `initial_full_fanout`; fail-open full fan-outs use `selection_fail_open`.
+- `rerun_reasons` -- a per-lane map using only `a_prior_unresolved_finding`, `b_fix_file_trigger`, `initial_full_fanout`, and `selection_fail_open`. The stable `a_prior_unresolved_finding` receipt value covers a prior P1/P2/P3 finding owner whether the finding was repaired or remains unresolved. A lane selected by more than one rule records every applicable reason. Full fan-outs use `initial_full_fanout`; fail-open full fan-outs use `selection_fail_open`.
 - `selection_fallback_reason: <reason>` whenever selection failed open to a full fan-out or the receiver rejected or ignored selective input, and `full_fanout_override: true` whenever `DM_REVIEW_LOOP_FULL_FANOUT=1` disabled selection. `selection_fallback_reason` is the persisted receipt field for the loop-local `fallback_reason`. The local variable resets at the start of every iteration so a fail-open on one iteration never leaks into the next iteration's receipt.
 
 Example (affected-lane verification):
@@ -420,6 +425,7 @@ dm-review-loop: N finding(s) remain after M iteration(s).
 Mode: quick|full
 Remaining:
 - 001-pending-p2-description
+- 002-pending-p3-description
 
 These findings could not be auto-resolved. Manual review needed.
 ```

--- a/plugins/dm-review/skills/dm-review-quick/SKILL.md
+++ b/plugins/dm-review/skills/dm-review-quick/SKILL.md
@@ -52,9 +52,12 @@ Do not infer extra security triggers from generic handlers, shell scripts,
 dependency manifests, or configuration files. Quick review is early feedback;
 the one final full pre-merge review remains the complete security boundary.
 
-## Finding Policy
+## Zero-Deferral Finding Policy
 
-Quick mode uses the same severities as full mode: P1 blocks merge, P2 must be fixed before merge, and P3 remains a fully detailed advisory that does not enter the fix queue or prevent `CLEAN`.
+Quick mode follows the full policy: every retained P1, P2, and P3 finding
+enters the fix queue and must be resolved before `CLEAN`. Reject invalid or
+scope-expanding reviewer suggestions during consolidation; do not retain them
+as optional P3 debt.
 
 ## Process
 

--- a/plugins/dm-review/skills/dm-review-visual/SKILL.md
+++ b/plugins/dm-review/skills/dm-review-visual/SKILL.md
@@ -25,7 +25,10 @@ Run the visual testing protocol on rendered web pages using Playwright browser t
 
 ## Zero-Deferral Policy (default)
 
-Visual P1/P2 findings require fixes before merge. P3 remains fully detailed advisory evidence and does not prevent `CLEAN`. See `plugins/dm-review/skills/review/references/severity-mapping.md` for the policy.
+Every retained visual P1, P2, and P3 finding requires a fix before `CLEAN`.
+Reject preferences without an observable defect instead of recording optional
+debt. See `plugins/dm-review/skills/review/references/severity-mapping.md` for
+the policy.
 
 ## Process
 

--- a/plugins/dm-review/skills/dm-review/SKILL.md
+++ b/plugins/dm-review/skills/dm-review/SKILL.md
@@ -23,14 +23,20 @@ argument-hint: "[optional: PR number, branch name, or file path]"
 
 Run a comprehensive code review using all applicable agents for the current project stack.
 
-## Finding Policy
+## Zero-Deferral Finding Policy
 
-P1 blocks merge and P2 must be fixed before merge. P3 is advisory: retain its complete evidence, provenance, count, and detail, but do not create mandatory work, drive convergence, or prevent `CLEAN`. `/dm-review` surfaces all findings; `/dm-review-fix` resolves pending P1/P2 findings; `/dm-review-loop` automates fix-until-clean for required work.
+Every retained P1, P2, and P3 finding is mandatory work. `/dm-review` surfaces
+and tracks it, `/dm-review-fix` resolves it, and `/dm-review-loop` repairs and
+rechecks until no findings remain. Severity controls ordering and impact; it
+never turns a valid finding into optional debt. Reject a speculative,
+duplicate, disproved, or out-of-scope reviewer suggestion during consolidation
+instead of retaining it as a finding and deferring it. There is no deferral
+flag and no clean-with-P3s outcome.
 
 The merge recommendation reflects this policy:
 
 - **Zero findings:** `CLEAN` -- safe to merge.
-- **P3 only (no P1/P2):** `CLEAN` -- retain every P3 in complete evidence; show only the exact count and evidence pointer in the compact handoff.
+- **P3 only:** `APPROVE WITH FIXES`. Must fix.
 - **P2 present:** `APPROVE WITH FIXES`. Must fix.
 - **P1 present:** `BLOCKS MERGE`. Must fix.
 

--- a/plugins/dm-review/skills/quality-pulse/SKILL.md
+++ b/plugins/dm-review/skills/quality-pulse/SKILL.md
@@ -16,7 +16,8 @@ rendering inputs.
 
 A quality pulse is **not a merge recommendation**. Informational telemetry is
 not an interactive review finding and must not be added to the normal dm-review
-P1/P2 fix ledger or P3 advisory report.
+P1/P2/P3 fix ledger. If a later interactive review accepts an observation as a
+finding, the normal zero-deferral policy applies.
 
 ## Inputs
 

--- a/plugins/dm-review/skills/review/SKILL.md
+++ b/plugins/dm-review/skills/review/SKILL.md
@@ -9,11 +9,28 @@ argument-hint: "[scope: PR number, branch, path, or blank]"
 
 A single-command code review system that launches parallel specialized agents tailored to Design Machines stacks: Go+Templ+Datastar, Craft CMS+Twig, and Live Wires CSS.
 
-## Finding Policy
+## Zero-Deferral Finding Policy
 
-P1 blocks merge and P2 must be fixed before merge. P3 is advisory: preserve its complete evidence, provenance, count, and detail in the report, but do not create mandatory work, drive convergence, or prevent `CLEAN`. See `${CLAUDE_SKILL_DIR}/references/severity-mapping.md` for the decision tree and `${CLAUDE_SKILL_DIR}/references/output-format.md` for the merge-recommendation logic.
+Every retained P1, P2, and P3 finding is mandatory work and prevents `CLEAN`
+until fixed and rechecked. Severity controls priority and merge language; it
+never makes a valid finding optional. Reject speculative, duplicate, disproved,
+preference-only, or scope-expanding reviewer input during consolidation instead
+of retaining it as a finding and deferring it. There is no deferral flag and no
+clean-with-P3s outcome. See `${CLAUDE_SKILL_DIR}/references/severity-mapping.md`
+for the decision tree and `${CLAUDE_SKILL_DIR}/references/output-format.md` for
+the merge-recommendation logic.
 
-Every P1/P2 must name the affected current user or operator, the reachable actor/input/path, the realistic harm or regression, and the smallest adequate repair. A security P1/P2 must also name the actual trust boundary. For Design Machines work, default to the current context unless approved scope says otherwise: two developers, primarily private first-party repositories, trusted Fixture authors, and self-hosted co-op applications serving roughly 4--50 people. Do not invent a public Fixture marketplace or hostile third-party plugin channel. Hypothetical actors, future marketplaces, enterprise scale, a generic OWASP possibility, or defence-in-depth preferences are P3 at most and usually not findings.
+Every retained finding must identify an observable current defect, its location
+or reachable path, and the smallest adequate repair. Every P1/P2 must also name
+the affected current user or operator and realistic harm or regression. A
+security P1/P2 must additionally name the actual trust boundary. For Design
+Machines work, default to the current context unless approved scope says
+otherwise: two developers, primarily private first-party repositories, trusted
+Fixture authors, and self-hosted co-op applications serving roughly 4--50
+people. Do not invent a public Fixture marketplace or hostile third-party
+plugin channel. Hypothetical actors, future marketplaces, enterprise scale, a
+generic OWASP possibility, defence-in-depth preferences, and abstractions with
+no current consumer are not findings.
 
 Keep real reachable boundaries blocking at their supported severity: authentication or authorization bypass, credential disclosure, unsafe destructive operations, corruptible state or backups, public untrusted input, release/update integrity failures, and false verification claims.
 
@@ -41,7 +58,7 @@ Match the review depth to the moment. Running full multi-round review on every c
 | **Per chunk during pipeline execution** | `dm-review-quick` | 2 core judgment lanes, plus applicable existing UI/build/domain verification lanes. |
 | **Pre-merge, once per PR** | full `dm-review` | All applicable agents + consolidation + memory capture. Run once, not per chunk. |
 | **Bulk second opinions / large-diff first pass** | Model selected by `routing-policy.json` | Family-independent security analysis plus style, duplication, pattern, and doc-consistency lanes. The exact diff is content-scanned immediately before external disclosure; sensitive file sections stay local while eligible sections proceed. Security completion always includes mandatory full-diff independent-family sign-off. |
-| **Bounded repair review** | full + one repair | Use one repair batch and one affected-lane recheck for supported P1/P2 findings. Repeat broad review only when the original required review was incomplete or the repair changed a real sensitive boundary. |
+| **Bounded repair review** | full + one repair | Use one repair batch and one affected-lane recheck for supported P1/P2/P3 findings. Repeat broad review only when the original required review was incomplete or the repair changed a real sensitive boundary. |
 
 **Escalation exception:** quick review is an early feedback gate, not the final
 security boundary. Every PR still receives one full pre-merge review. Escalate
@@ -112,7 +129,7 @@ All review agents and fix workflows must follow these principles:
 1. **Smallest adequate repair** -- Recommend the clearest direct change that resolves the evidenced current failure within approved scope. A one-use handler or concrete implementation is valid when clear and tested.
 2. **Relevant practices first** -- Apply framework conventions when they serve the current requirement or reachable risk; a preferred layer or abstraction is not a repair by itself.
 3. **Replace, don't preserve** -- When old code is the problem, recommend replacing it. Don't wrap broken patterns in compatibility layers.
-4. **No scope expansion** -- A required fix may touch only the approved behavior and the evidenced defect. Unrelated hardening, future-marketplace defenses, and new product scope remain P3 alternatives and do not enter convergence.
+4. **No scope expansion** -- A required fix may touch only the approved behavior and the evidenced defect. Reject unrelated hardening, future-marketplace defenses, and new product scope during consolidation; do not retain them as P3 findings.
 
 ### Prototype Hygiene
 
@@ -453,7 +470,7 @@ but `lanes` omits it, discard the entire allowlist, dispatch the unfiltered
 roster, and report `selective_lanes_omit_required_lane`. Never silently drop a
 required lane and never silently add it back to an otherwise honored allowlist.
 
-When the input is honored, dispatch only the exact lanes in `lanes`. Every member of the recomputed selected full set outside `lanes` is a deliberate selective non-dispatch, not a failed lane, and must be identified that way in the coverage receipt. A selective affected-lane repair verification can support `CLEAN` only after an earlier complete full review, when no P1/P2 findings remain and every required selected verification lane completes. It never substitutes for the initial full-review boundary.
+When the input is honored, dispatch only the exact lanes in `lanes`. Every member of the recomputed selected full set outside `lanes` is a deliberate selective non-dispatch, not a failed lane, and must be identified that way in the coverage receipt. A selective affected-lane repair verification can support `CLEAN` only after an earlier complete full review, when no P1/P2/P3 findings remain and every required selected verification lane completes. It never substitutes for the initial full-review boundary.
 
 #### Report Selection
 
@@ -1061,7 +1078,7 @@ Read from `$CONSOLIDATOR_PATH` and follow the instructions exactly:
 5. **Determine merge recommendation** using `${CLAUDE_SKILL_DIR}/references/output-format.md` §Merge Recommendation Logic. In summary:
    - Any P1 -> "BLOCKS MERGE"
    - Any P2 -> "APPROVE WITH FIXES"
-   - P3 only -> "CLEAN" with every P3 retained in complete evidence and an exact count plus pointer in the compact handoff
+   - Any P3 with no P1 -> "APPROVE WITH FIXES"
    - Zero findings -> "CLEAN"
 6. **Generate the unified report** following the template in `${CLAUDE_SKILL_DIR}/references/output-format.md`, including the compact required `Synthesis Decisions` section and full raw agent reports.
 
@@ -1118,7 +1135,9 @@ Acceptable evidence:
 - A focused test/build command that exercises the cited path.
 - Direct file inspection at the current `HEAD` showing the finding no longer applies.
 
-If evidence is missing or points the other way, keep the finding open. Route P1/P2 through the normal fix flow and retain P3 as advisory evidence. Record the command or file evidence in the report when marking anything stale or already fixed.
+If evidence is missing or points the other way, keep the finding open and route
+every retained severity through the normal fix flow. Record the command or file
+evidence in the report when marking anything stale or already fixed.
 
 **Airlift checkpoint (`dm-review-consolidation`):** Fire a tier-1 airlift checkpoint once the consolidated report exists so partially-complete review findings survive a usage cap, rate limit, or model switch. This is a guarded resolve-from-cache: it is tier-1 deterministic (pure local file + git work, NO model budget, no agent call, no network) and is skipped silently when airlift is absent (OPTIONAL dependency). On an early-warning trip (e.g. a budget threshold crossed mid-run), do not wait for the next phase boundary -- flush this checkpoint immediately so the consolidated findings are not lost.
 
@@ -1135,13 +1154,11 @@ The `[ -n "$ENGINE" ]` guard covers "airlift not installed"; the `[ -x "$ENGINE"
 
 ---
 
-### Phase 6: Issue Tracking (Full mode only)
-
-**Skip this phase in Quick mode.**
+### Phase 6: Issue Tracking
 
 After consolidation, determine tracking method automatically:
 
-**1. If `todos/` directory exists** in the project root -- use text file tracking automatically. Do NOT ask the user. Create todo files for P1 and P2 findings only. P3 advisories remain in the report and receipts.
+**1. If `todos/` directory exists** in the project root -- use text file tracking automatically. Do NOT ask the user. Create todo files for every retained P1, P2, and P3 finding.
 
 **2. If `todos/` does not exist** -- ask the user:
 
@@ -1149,8 +1166,10 @@ After consolidation, determine tracking method automatically:
 No todos/ directory found. How should I track these findings?
 1. Create todos/ directory with text file tracking
 2. GitHub Issues
-3. Skip tracking
 ```
+
+Tracking may change location, but it never waives the finding or permits a
+clean recommendation. Do not offer a skip or defer option.
 
 **Text file tracking:**
 
@@ -1160,7 +1179,7 @@ Before creating new todo files, clean up stale completed files from previous ses
 rm -- todos/*-done-*.md 2>/dev/null
 ```
 
-Create `todos/` directory if it doesn't exist. For each P1 and P2 finding, create a file following the template in `${CLAUDE_SKILL_DIR}/references/issue-tracking.md`:
+Create `todos/` directory if it doesn't exist. For each retained finding, create a file following the template in `${CLAUDE_SKILL_DIR}/references/issue-tracking.md`:
 
 ```
 todos/{id}-pending-{priority}-{slug}.md
@@ -1170,6 +1189,7 @@ Examples:
 ```
 todos/001-pending-p1-sql-injection-in-search.md
 todos/002-pending-p2-missing-csrf-protection.md
+todos/003-pending-p3-heading-rhythm.md
 ```
 
 After creating all files, summarize what was created:
@@ -1177,13 +1197,14 @@ After creating all files, summarize what was created:
 Created N todo files in todos/:
 - 001-pending-p1-... (description)
 - 002-pending-p2-... (description)
+- 003-pending-p3-... (description)
 
 Resolve with: /dm-review-fix
 ```
 
 **GitHub Issues:**
 
-For each P1 and P2 finding, create a GitHub Issue using `gh issue create`:
+For each retained P1, P2, and P3 finding, create a GitHub Issue using `gh issue create`:
 
 ```bash
 gh issue create --title "[P1] Finding title" \

--- a/plugins/dm-review/skills/review/references/graceful-degradation.md
+++ b/plugins/dm-review/skills/review/references/graceful-degradation.md
@@ -93,8 +93,10 @@ if any P1:
   BLOCKS MERGE
 elif any P2:
   APPROVE WITH FIXES
+elif any P3:
+  APPROVE WITH FIXES
 else:
-  CLEAN   (including P3-only, with complete advisory evidence retained)
+  CLEAN
 ```
 
 Then overlay failure status:

--- a/plugins/dm-review/skills/review/references/guardrails.md
+++ b/plugins/dm-review/skills/review/references/guardrails.md
@@ -48,7 +48,7 @@ Each agent runs in its own context. They don't share a budget.
 
 1. visual-browser-tester (LOW -- has its own fallback chain, requires dev server)
 2. voice-editor (LOW -- style, not correctness)
-3. test-coverage-reviewer (LOW -- advisory only)
+3. test-coverage-reviewer (LOW -- supplementary changed-path coverage)
 4. openrouter-bulk-analyst (MEDIUM -- supplementary full-diff analysis, requires the OpenRouter provider plugin)
 5. craft-reviewer (MEDIUM -- domain-specific)
 6. governance-domain (MEDIUM -- domain-specific)

--- a/plugins/dm-review/skills/review/references/issue-tracking.md
+++ b/plugins/dm-review/skills/review/references/issue-tracking.md
@@ -69,7 +69,7 @@ Examples:
 ```
 001-pending-p1-sql-injection-in-search.md
 002-pending-p2-missing-csrf-protection.md
-003-pending-p2-heading-hierarchy-broken.md
+003-pending-p3-heading-rhythm.md
 ```
 
 ---
@@ -80,7 +80,7 @@ Examples:
 |----------------|---------------|----------|
 | P1 -- Critical | `p1` | Yes -- always |
 | P2 -- Should Fix | `p2` | Yes -- always |
-| P3 -- Advisory | -- | No -- retain in report and receipts only |
+| P3 -- Required Fix | `p3` | Yes -- always |
 
 ---
 
@@ -108,9 +108,9 @@ Don't leave completed todo files accumulating. Clean up after every fix session.
 
 When tracking via GitHub Issues instead of text files:
 
-**Title format:** `[P1] Finding title` or `[P2] Finding title`
+**Title format:** `[P1] Finding title`, `[P2] Finding title`, or `[P3] Finding title`
 
-**Labels:** `review` + `p1` or `p2`
+**Labels:** `review` + `p1`, `p2`, or `p3`
 
 **Body structure:**
 
@@ -137,28 +137,28 @@ OWASP/WCAG/pattern reference.
 
 ---
 
-## Promoting a Finding to a Durable GitHub Issue
+## Moving a Finding to a Separate Repair Branch
 
-Required P1/P2 findings **in scope for the current branch** are fixed before merge. A separate case is a valid P1/P2 finding whose fix is a **structural refactor larger than the change under review** (a domain-model change, or splitting oversized files) -- new, durable work to track as a GitHub issue rather than smuggle into the branch or drop into an ephemeral todo file. P3 advisories are retained in the report and receipts and do not create issues or todos.
+Every retained P1/P2/P3 finding is fixed before the reviewed branch is ready to
+merge. A concrete finding whose smallest adequate repair is structurally larger
+than the current branch may move to a dedicated repair branch and durable
+GitHub Issue, but the original review remains non-clean until that repair merges
+and the affected lane verifies it. Tracking changes work location; it never
+defers or waives the finding.
 
 Promote a finding to a GitHub issue (instead of a `todos/` file) when **all** of these hold:
 
 - The fix touches a data model, public interface, or file structure beyond the diff under review.
 - Implementing it in the current branch would expand scope past the branch's stated purpose.
-- The finding is concrete enough to act on later without re-deriving it.
+- The dedicated repair is started now and blocks the original branch rather than becoming an unspecified follow-up.
 
-Do **not** promote a finding just to avoid fixing it. If the fix fits the current change, fix it now.
-
-**Examples from Assembly Baseplate review history:**
-
-- **#233** -- "measurable membership requirements store a target but completion is boolean." Correcting the model (track progress toward the target, not a boolean done-flag) is a schema + service change wider than the membership UI polish branch that surfaced it. Tracked as an open P2 issue, not forced into the polish PR.
-- **#234** -- "split oversized membership service + admin handler files." A multi-file decomposition (triggered by the architecture-reviewer File Size Limits check) that is its own unit of work. Tracked as an open P2 issue.
-
-The polish branch (PR #238) closed the in-scope membership findings (#235, #236) and left #233/#234 as tracked issues -- correct application of this rule.
+Do **not** create an issue merely to move a finding out of the current result.
+If the proposed work has no observable current defect or current consumer,
+discard it as preference-only or out of scope instead of creating debt.
 
 ## Batch Cleanup PR Pattern
 
-Tracked review-finding issues accumulate. Clear them in a **dedicated cleanup PR** rather than smuggling unrelated fixes into feature branches. One cleanup pass can close many issues at once.
+Historical review-finding issues may already exist. Clear them in a **dedicated cleanup PR** rather than smuggling unrelated fixes into feature branches. New dm-review runs do not create another deferred backlog.
 
 **Precedent:** PR #247/#248 (a pre-federation cleanup/review pass) merged the fixes and closed review-finding issues #106, #109, #110, #184, #207, #216, #217, #225, and #243-#246 together.
 
@@ -166,7 +166,7 @@ Conventions for a batch cleanup PR:
 
 - Reference every closed issue in the PR body (`Closes #106, Closes #109, ...`) so the tracker stays accurate.
 - Group the commits by finding or by surface, the same way feature PRs group by concern.
-- Run `/dm-review-loop` on the cleanup branch -- any new P1/P2 findings still require resolution.
+- Run `/dm-review-loop` on the cleanup branch -- every new P1/P2/P3 finding still requires resolution.
 - Schedule cleanup passes around natural milestones (here: before federation work) so debt does not cross a major boundary.
 - Dispose of the cleanup branch under `repo-cleanup-contract.md`. It is the one branch dm-review creates, so it is the one branch dm-review may delete -- and only once `git merge-base --is-ancestor <branch> main` exits 0. An unmerged cleanup branch is kept and reported, never force-deleted.
 
@@ -185,4 +185,4 @@ Reconcile all eight before declaring closure:
 7. **Changed-files vs claimed scope** -- diff the actual changed files (`gh pr view <n> --json files`) against what the PR body says it did. A "federation trust hardening" PR whose diff never touches `federation/` did not do what it claims; a reorg-only PR with logic edits in the diff broke its own contract.
 8. **Open-issue sweep on the surface** -- before claiming a *surface* (federation, install, membership) is done, list every open issue touching it, not just the ones this PR named. Closing the PR's three issues while five surface issues stay open is "this PR merged," not "this surface is done."
 
-**Worked example (federation):** Baseplate PR #252 (Session 2.9a federation backend) merged with green checks, but #253, #254, #255, #258, and #259 remain open follow-on issues. PR #271 (federation trust hardening / delivery repair) then merged but left #255 (key-rotation detection), #258 (federation file decomposition), and #270 (a user-owned historical P3 rollup) open. "Federation trust hardening merged" is true; "federation review findings closed" is false. Existing user-owned trackers remain owner-managed; the advisory policy does not delete them.
+**Worked example (federation):** Baseplate PR #252 (Session 2.9a federation backend) merged with green checks, but #253, #254, #255, #258, and #259 remained open follow-on issues. PR #271 (federation trust hardening / delivery repair) then merged but left #255 (key-rotation detection), #258 (federation file decomposition), and #270 (a user-owned historical P3 rollup) open. "Federation trust hardening merged" was true; "federation review findings closed" was false. Existing user-owned trackers remain owner-managed, but new retained findings cannot use that history as permission to defer.

--- a/plugins/dm-review/skills/review/references/output-format.md
+++ b/plugins/dm-review/skills/review/references/output-format.md
@@ -17,7 +17,7 @@ verdict from the complete report. Keep the explanation to one plain sentence.
 <One plain sentence explaining the verdict.>
 
 ### Actionable findings
-<For each retained P1/P2, once only: `path:anchor -- problem -- smallest adequate fix`>
+<For each retained P1/P2/P3, once only: `path:anchor -- problem -- smallest adequate fix`>
 <If none: `None.`>
 
 ### Coverage gap requiring action
@@ -28,15 +28,14 @@ verdict from the complete report. Keep the explanation to one plain sentence.
 
 ### Complete evidence
 `Full report: .claude/ux-review/report.md`.
-<If P3 exists: `P3 advisories: N -- <evidence pointer>.`>
+<If findings exist: `Open findings: N -- <evidence pointer>.`>
 ```
 
-When there are at most eight P1/P2 findings, list each exactly once. When there
-are more than eight, list the highest-impact eight, state `N additional P1/P2
-findings` with the exact remaining count, and point to the complete report.
-Never imply that omitted findings do not exist. P3 advisories appear only as an
-exact count and evidence pointer in this handoff; they remain fully detailed in
-the report and never enter the fix queue.
+When there are at most eight retained findings across all severities, list each
+exactly once. When there are more than eight, list the highest-impact eight,
+state `N additional findings` with the exact remaining count, and point to the
+complete report. Never imply that omitted findings do not exist. Chat keeps P3
+compact, but it follows the same fix queue and convergence path as P1/P2.
 
 Do not repeat provider tables, agent transcripts, synthesis ledgers, cleanup
 tables, or raw reports in the handoff. Write them to the established durable
@@ -50,7 +49,7 @@ Clean review:
 
 ```markdown
 ## CLEAN
-No P1/P2 findings were found, and all required lanes completed.
+No P1/P2/P3 findings were found, and all required lanes completed.
 ### Actionable findings
 None.
 ### Coverage gap requiring action
@@ -58,23 +57,24 @@ None.
 ### Recommended next action
 Merge the reviewed head.
 ### Complete evidence
-Full report: `.claude/ux-review/report.md` (P3 advisories: 0).
+Full report: `.claude/ux-review/report.md` (open findings: 0).
 ```
 
 Review with actionable findings:
 
 ```markdown
 ## APPROVE WITH FIXES
-Two P2 findings must be fixed before merge.
+Two P2 findings and one P3 finding must be fixed before merge.
 ### Actionable findings
 - `internal/members/handler.go:Create` -- validation accepts an empty name -- reject an empty trimmed value.
 - `web/templates/member.templ:member-form` -- error text is not associated with the field -- add the existing error ID to `aria-describedby`.
+- `web/templates/member.templ:member-actions` -- spacing breaks the established rhythm -- use the existing compact stack token.
 ### Coverage gap requiring action
 Safari browser evidence is blocked -- run the retained case on a Safari-capable host.
 ### Recommended next action
-Fix the two P2 findings, then rerun their affected lanes and the blocked browser case.
+Fix all three findings, then rerun their affected lanes and the blocked browser case.
 ### Complete evidence
-Full report: `.claude/ux-review/report.md` (P3 advisories: 2).
+Full report: `.claude/ux-review/report.md` (open findings: 3).
 ```
 
 ## Complete Report Template
@@ -129,7 +129,7 @@ Full report: `.claude/ux-review/report.md` (P3 advisories: 2).
 
 ---
 
-### P3 -- Advisory
+### P3 -- Required Fix
 
 #### [Finding Title]
 - **Finding ID:** `finding-v1:sha256(<normalized-key>)`
@@ -296,7 +296,7 @@ The consolidator preserves the original citation format from each agent.
 
 1. **P1 findings get full detail blocks** -- file, issue, fix, reference
 2. **P2 findings get detail blocks** -- same format as P1
-3. **P3 findings get full detail blocks** -- same format as P1/P2. Preserve source identity, raw reference, evidence, synthesis disposition, counts, and provenance even though P3 is advisory.
+3. **P3 findings get full detail blocks** -- same format as P1/P2. Preserve source identity, raw reference, evidence, synthesis disposition, counts, and provenance; every retained P3 enters the fix queue.
 4. **Clean agents are noted** in the summary table but don't get detail sections
 5. **Skipped agents are listed** with the reason (file type not changed, project type mismatch)
 6. **Deduplicated findings** show all source agents: `**Source:** a11y-css-reviewer, css-reviewer`
@@ -309,7 +309,7 @@ The consolidator preserves the original citation format from each agent.
     provenance, evidence, raw ref, agreement, disposition, closed reason code,
     and rationale; raw reviewer reports remain verbatim below
 11. **Human delivery is compact** -- the exact verdict, one-sentence explanation,
-    actionable P1/P2 findings, human-action coverage gaps, one recommended next
+    actionable P1/P2/P3 findings, human-action coverage gaps, one recommended next
     action, and complete-evidence pointer appear before the report
 
 ## Merge Recommendation Logic
@@ -318,13 +318,10 @@ The consolidator preserves the original citation format from each agent.
 if any P1 findings:
   recommendation = "BLOCKS MERGE"
   summary = "X critical issues must be fixed before merging."
-elif any P2 findings:
+elif any P2 or P3 findings:
   recommendation = "APPROVE WITH FIXES"
   summary = "X issue(s) must be addressed before merging."
 else:
   recommendation = "CLEAN"
-  if any P3 findings:
-    summary = "No P1/P2 findings. X P3 advisory finding(s) retained below."
-  else:
-    summary = "No issues found. Ready to merge."
+  summary = "No issues found. Ready to merge."
 ```

--- a/plugins/dm-review/skills/review/references/severity-mapping.md
+++ b/plugins/dm-review/skills/review/references/severity-mapping.md
@@ -2,18 +2,24 @@
 
 Rules for mapping each agent's native severity terminology to the unified P1/P2/P3 system.
 
-## Finding Policy
+## Zero-Deferral Finding Policy
 
-P1 blocks merge and P2 must be fixed before merge. P3 is advisory: preserve complete evidence, provenance, count, and detail, but do not create mandatory work, drive convergence, or prevent `CLEAN`. See `plugins/dm-review/commands/dm-review.md` for the full policy statement.
+Every retained P1, P2, and P3 finding must be fixed and rechecked before
+`CLEAN`. Severity controls ordering and merge language, not whether work is
+owed. Reject unsupported preferences and speculative scope during consolidation
+instead of retaining optional findings. See
+`plugins/dm-review/commands/dm-review.md` for the full policy statement.
 
-Every P1/P2 must include concrete current evidence:
+Every retained finding must include an observable current defect, its location
+or reachable path, and the smallest adequate repair. Every P1/P2 must also
+include concrete current evidence for:
 
 1. the affected current user or operator;
 2. the reachable actor, input, or path;
 3. the realistic harm or regression; and
 4. the smallest adequate repair.
 
-Security P1/P2 findings must additionally name the actual trust boundary. For Design Machines work, assume two developers, primarily first-party private repositories, trusted Fixture authors, and self-hosted co-op applications of roughly 4--50 people unless approved scope says otherwise. There is no public Fixture marketplace or hostile third-party plugin channel by default. Hypothetical actors, future marketplaces, enterprise scale, generic OWASP possibilities, and “defence in depth would be better” are P3 at most and usually not findings.
+Security P1/P2 findings must additionally name the actual trust boundary. For Design Machines work, assume two developers, primarily first-party private repositories, trusted Fixture authors, and self-hosted co-op applications of roughly 4--50 people unless approved scope says otherwise. There is no public Fixture marketplace or hostile third-party plugin channel by default. Hypothetical actors, future marketplaces, enterprise scale, generic OWASP possibilities, and “defence in depth would be better” are not findings by themselves; retain one only when direct evidence establishes an observable current defect.
 
 Real reachable authentication or authorization bypass, credential disclosure, unsafe destructive operations, corruptible state or backups, public untrusted input, release/update integrity failures, and false verification claims remain blocking at their supported severity.
 
@@ -24,8 +30,8 @@ Real reachable authentication or authorization bypass, credential disclosure, un
 | Level | Label | Meaning | Merge Impact |
 |-------|-------|---------|-------------|
 | **P1** | Blocks Merge | Must fix before merging | Review recommendation = BLOCKS MERGE |
-| **P2** | Should Fix | Fix soon, track if not immediate | Review recommendation = APPROVE WITH FIXES |
-| **P3** | Advisory | Improvement recommendation. Retain visibly with full evidence and provenance; no mandatory fix. | CLEAN when no P1/P2 |
+| **P2** | Important Fix | Must fix before merging | Review recommendation = APPROVE WITH FIXES |
+| **P3** | Required Fix | Observable minor defect or maintainability debt. Must fix before merging. | Review recommendation = APPROVE WITH FIXES |
 
 ---
 
@@ -50,10 +56,10 @@ This tree ensures that a missing error state on a critical form (user stranded =
 
 | Agent | Critical/P1 | Serious/P2 | Moderate/P3 |
 |-------|------------|------------|-------------|
-| **code-simplicity-reviewer** | Reachable correctness failure hidden by complexity | Unnecessary complexity with a demonstrated current regression or realistic harm | Numeric length/complexity thresholds, verbose but correct code, minor style preferences |
-| **security-auditor** | SQL injection, XSS, auth bypass, credential exposure | Missing CSRF token, permissive CORS, unvalidated input | Missing rate limiting, verbose error messages |
-| **pattern-recognition-specialist** | Circular dependencies, data races, resource leaks | Anti-patterns (God objects, feature envy), naming inconsistencies | Minor duplication, magic numbers in non-critical paths |
-| **architecture-reviewer** | Broken trust/module boundary with concrete current harm | Coupling or placement that causes a current regression or reachable failure | SOLID preferences, file/function size thresholds, layer counts, interfaces, service/repository patterns, suboptimal but functional structure |
+| **code-simplicity-reviewer** | Reachable correctness failure hidden by complexity | Unnecessary complexity with a demonstrated current regression or realistic harm | Bounded duplication or complexity with an observable current maintenance defect; numeric thresholds and style preferences alone are discarded |
+| **security-auditor** | SQL injection, XSS, auth bypass, credential exposure | Missing CSRF token, permissive CORS, unvalidated input | Minor reachable disclosure or abuse defect at an actual current boundary; generic hardening suggestions are discarded |
+| **pattern-recognition-specialist** | Circular dependencies, data races, resource leaks | Anti-patterns (God objects, feature envy), naming inconsistencies | Minor duplication that has diverged or a magic value that obscures changed behavior; preferences alone are discarded |
+| **architecture-reviewer** | Broken trust/module boundary with concrete current harm | Coupling or placement that causes a current regression or reachable failure | Bounded current boundary or maintainability defect; SOLID preferences, size thresholds, layer counts, and optional abstractions alone are discarded |
 | **doc-sync-reviewer** | API docs contradict implementation, CLAUDE.md has wrong paths | README outdated, missing docs for new features | Minor formatting, stale examples |
 | **test-coverage-reviewer** | Existing tests now fail | Changed code has no tests (when project has test infrastructure) | Missing edge case tests |
 | **go-build-verifier** | Compilation failure | `go vet` warnings | -- |
@@ -69,9 +75,9 @@ This tree ensures that a missing error state on a critical form (user stranded =
 | **a11y-html-reviewer** | accessibility-compliance | Missing form labels, keyboard traps, no alt on functional images | Broken heading hierarchy, missing landmarks, generic link text | Missing aria-describedby, suboptimal ARIA |
 | **a11y-css-reviewer** | accessibility-compliance | `outline: none` without replacement, failing contrast on primary text | Animations without motion check, reflow broken at 320px | Low contrast on secondary text, missing forced-colors |
 | **a11y-dynamic-content-reviewer** | accessibility-compliance | Click handlers on non-interactive elements, no live regions for state changes | Focus lost after morph, loading states silent | ARIA states not synced, suboptimal focus target |
-| **css-reviewer** | live-wires | -- (errors) | Cascade layer violations, class invention, naming rule breaks | Token recommendations, container query suggestions |
+| **css-reviewer** | live-wires | -- (errors) | Cascade layer violations, class invention, naming rule breaks | Observable token or responsive defect with a bounded repair; alternative patterns alone are discarded |
 | **voice-editor** | ghostwriter | -- | Spine failure (no point of view), AI pattern detected | Rhythm issues, minor register drift |
-| **governance-domain** | council | Legal compliance failure (wrong voting threshold) | Architecture violation (fixture boundaries) | Naming recommendations, values alignment |
+| **governance-domain** | council | Legal compliance failure (wrong voting threshold) | Architecture violation (fixture boundaries) | Observable terminology or values mismatch against approved policy; recommendations alone are discarded |
 
 ---
 
@@ -79,7 +85,7 @@ This tree ensures that a missing error state on a critical form (user stranded =
 
 | Agent | Phase | Critical/P1 | Serious/P2 | Moderate/P3 |
 |-------|-------|------------|------------|-------------|
-| **visual-browser-tester** | Live Wires CSS Compliance | -- | Invented classes when primitives exist, arbitrary values instead of tokens, media queries instead of container queries | Minor token recommendations, alternative primitive patterns (advisory) |
+| **visual-browser-tester** | Live Wires CSS Compliance | -- | Invented classes when primitives exist, arbitrary values instead of tokens, media queries instead of container queries | Observable minor token or primitive defect; preference-only alternatives are discarded |
 
 UX Design and Visual Design Quality phases have moved to **ux-quality-reviewer** (see dm-review Agents table above).
 
@@ -89,15 +95,15 @@ UX Design and Visual Design Quality phases have moved to **ux-quality-reviewer**
 
 1. **Any P1 from any agent** -> merge recommendation = `BLOCKS MERGE`
 2. **P2 present (any count, regardless of P3)** -> merge recommendation = `APPROVE WITH FIXES` (must fix before merge)
-3. **P3 only (no P1/P2)** -> merge recommendation = `CLEAN`. Render every P3 with complete evidence, source identity, raw reference, synthesis disposition, counts, and provenance.
+3. **P3 present with no P1** -> merge recommendation = `APPROVE WITH FIXES` (must fix before merge)
 4. **Zero findings** -> merge recommendation = `CLEAN`
 5. **Supported security P1** always escalates when it names the current reachable path, realistic harm, actual trust boundary, and smallest adequate repair -- no exceptions, no "we'll fix it later"
 6. **Accessibility P1** always escalates -- legal compliance (EAA, ADA)
 7. **Governance P1** always escalates -- statutory requirements
 8. **Visual P1** always escalates -- if layout is completely broken or keyboard traps exist in the rendered page
 
-## De-escalation Rules
+## Validity and De-escalation Rules
 
-1. P3 findings are shown in the report with full detail (same format as P1/P2) as visible advisories. They do not create todos/issues, enter the fix queue, drive convergence, or block merge.
+1. P3 findings use the same complete evidence, todo/issue, fix-queue, and convergence path as P1/P2. A preference or future improvement without an observable current defect is not a P3; discard it.
 2. Findings from agents that partially overlap (e.g., both a11y-css-reviewer and css-reviewer flag the same file) count as ONE finding at the higher severity.
-3. If a P1/P2 finding is already tracked in a known issue/TODO, note the tracker reference and still follow the required fix policy. Existing user-owned P3 trackers are left untouched; dm-review does not create new ones.
+3. If a retained finding is already tracked in a known issue/TODO, note the tracker reference and still follow the required fix policy. An existing tracker never makes the current review clean.

--- a/plugins/dm-review/skills/visual-test/SKILL.md
+++ b/plugins/dm-review/skills/visual-test/SKILL.md
@@ -116,7 +116,7 @@ Summary of screenshots taken during testing.
 
 After the report, suggest next steps:
 
-- If findings exist: "Fix the P1/P2 issues and re-run `/dm-review-visual` to verify."
+- If findings exist: "Fix every P1/P2/P3 issue and re-run `/dm-review-visual` to verify."
 - If clean: "Visual tests passed. Run `/dm-review` for a full code review."
 
 ## Reference Files

--- a/plugins/pipeline/.claude-plugin/plugin.json
+++ b/plugins/pipeline/.claude-plugin/plugin.json
@@ -1,13 +1,13 @@
 {
   "name": "pipeline",
   "description": "Autonomous feature development pipeline with approved-scope intake, minimum-adequate planning, bounded adversarial review, fresh tiered verification, browser recovery, and isolated execution",
-  "version": "1.52.0",
+  "version": "1.53.0",
   "author": {
     "name": "Design Machines",
     "url": "https://designmachines.io"
   },
   "pluginDependencies": {
-    "dm-review": ">=1.62.0",
+    "dm-review": ">=1.63.0",
     "ned": ">=1.4.0",
     "workflow-kernel": ">=0.16.0"
   },

--- a/plugins/pipeline/.codex-plugin/plugin.json
+++ b/plugins/pipeline/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pipeline",
-  "version": "1.52.0",
+  "version": "1.53.0",
   "description": "Autonomous feature development pipeline with approved-scope intake, minimum-adequate planning, bounded adversarial review, fresh tiered verification, browser recovery, and isolated execution",
   "author": {
     "name": "Design Machines",
@@ -167,7 +167,7 @@
     ]
   },
   "pluginDependencies": {
-    "dm-review": ">=1.62.0",
+    "dm-review": ">=1.63.0",
     "ned": ">=1.4.0",
     "workflow-kernel": ">=0.16.0"
   },

--- a/plugins/pipeline/agents/workflow/execution-orchestrator.md
+++ b/plugins/pipeline/agents/workflow/execution-orchestrator.md
@@ -82,9 +82,9 @@ review-fix loop below; record `final_review_mode: quick`,
 `final_review_effective_mode: full`, and
 `final_review_escalation: security-sensitive-path`.
 
-For an ordinary eligible quick result, collect the complete P1/P2 finding set,
+For an ordinary eligible quick result, collect the complete P1/P2/P3 finding set,
 apply one revision batch, run affected repository verification, and re-run the
-affected quick lanes once. P1/P2 must reach zero. Preserve P3 advisories. Record
+affected quick lanes once. Every retained finding must reach zero. Record
 `final_review_mode: quick`, `final_review_effective_mode: quick`, the
 approved rationale, selected lanes, and any unavailable required lane. Never
 substitute a single generic reviewer for the installed quick protocol.
@@ -117,7 +117,8 @@ for iteration in 1..max_iterations (default 2):
 
   if iteration == max_iterations:
     Skill(skill="dm-review:review", args="full <worktree-path>")  -- final verify
-    if pending after final: log each as DEFERRED with explicit justification
+    if pending after final: report NEEDS ATTENTION with each remaining finding
+      and stop; do not mark the chunk clean or merge it
 ```
 
 The stalled-convergence check is critical -- without it, the orchestrator can loop wasting tokens on findings that don't auto-resolve.
@@ -514,7 +515,7 @@ verification seam and blocks on degraded/missing lane coverage. High/high does
 both; other combinations retain standard depth. Never use the profile to
 select a provider/model/executor, create a routing override, relax security,
 alter workflow class, reduce browser/persona cases, skip focused/sensitive/final
-review, weaken required P1/P2 resolution or cleanup, alter economics, or add full review to
+review, weaken required P1/P2/P3 resolution or cleanup, alter economics, or add full review to
 every ordinary chunk.
 
 **Bootstrap limitation:** If this current bootstrap manifest predates
@@ -1526,11 +1527,12 @@ dm-review is reserved for the approved final review in Step 4 and also runs its
 coding lanes on Codex or OpenRouter.
 
 Every per-chunk review receives the approved requirements and compact alignment
-context inlined for that chunk. Flag as P1/P2, proportional to reachable harm:
+context inlined for that chunk. Flag as P1/P2/P3, proportional to reachable harm:
 work outside approved scope; conflict with explicit project constraints;
 unnecessary architecture; changes owned by another repository; or technically
-correct work that misses the chunk's approved outcome. Adjacent useful work is
-reported as an advisory and stays out of the diff.
+correct work that misses the chunk's approved outcome. Reject adjacent useful
+work from the finding set when it does not repair an observable defect in the
+approved scope; it stays out of the diff.
 
 **UI chunks and Logic chunks -- Codex review loop:**
 
@@ -1558,31 +1560,33 @@ Same as above, but after Codex review passes, also check cross-chunk wiring: are
 
 Run `/codex:review` once. If zero findings, proceed. If findings, fix and re-run once. No full loop.
 
-**Finding policy (all chunk types):** P1/P2 findings must be fixed. P3 is advisory and remains visible in the chunk receipt without entering the repair queue:
+**Zero-deferral finding policy (all chunk types):** Every retained P1/P2/P3
+finding must be fixed and verified before the chunk can be clean. There is no
+deferral flag and an existing tracker does not waive the repair:
 
 - **P1:** Security vulnerabilities, data corruption, breaking changes
 - **P2:** Performance issues, architectural concerns, reliability
-- **P3:** Simplification, cleanup, minor improvements (advisory)
+- **P3:** Observable minor defects with a bounded repair
 
-Every P1/P2 accepted into the repair queue must identify the affected current
-user or operator, reachable actor/input/path, realistic harm or regression,
-and smallest adequate repair. Security findings must also identify the actual
-trust boundary. A revision batch may touch only the approved behavior and the
-evidenced defect; unrelated hardening and new product scope are rejected.
+Every retained finding must identify an observable current defect, its location
+or reachable path, and the smallest adequate repair. P1/P2 must additionally
+identify the affected current user or operator and realistic harm or regression;
+security P1/P2 must name the actual trust boundary. Reject unsupported
+preferences, speculative hardening, future-scale concerns, and unrelated new
+product scope during consolidation instead of retaining them as P3 debt.
 
-**If P1/P2 findings remain after max iterations, do NOT silently continue.** Instead:
+**If P1/P2/P3 findings remain after max iterations, do NOT silently continue.** Instead:
 
 1. STOP chunk processing. Do NOT proceed to merge.
 2. Read each remaining finding and apply targeted fixes to the specific lines cited in the worktree -- do not re-implement sections wholesale or launch another subagent.
 3. Re-run `/codex:review` to verify manual fixes (or dm-review Skill pattern if Codex unavailable).
-4. If P1/P2 findings STILL remain after this manual pass, stop the run as needs attention. P2 cannot be deferred past merge.
-
-P3 advisories never trigger the manual repair pass or another review iteration.
+4. If any retained finding STILL remains after this manual pass, stop the run
+   as needs attention. No retained severity can be deferred past merge.
 
 **Evaluation receipt (structural interlock):** After completing the evaluation gate, you MUST output this exact line:
 
 ```text
-EVAL_GATE_PASSED: [chunk-id] | classification: [type] | iterations: [N] | findings_remaining: [N] | p3_advisories: [N]
+EVAL_GATE_PASSED: [chunk-id] | classification: [type] | iterations: [N] | findings_remaining: [N] | p3_findings: [N]
 ```
 
 Append `requestedProvider: <provider>`, `attemptedProvider: <provider>`,
@@ -1721,7 +1725,7 @@ After completing all checks, output this structured receipt:
 BROWSER_VERIFIED: [chunk-id] | screenshots: [N] | element_screenshots: [N] | spec_checks: [N passed]/[N total] | visual_criteria: [N passed]/[N total] | issues: [list or "none"]
 ```
 
-Report all findings as P1 (spec deviation, page doesn't load), P2 (visual criterion failure, console errors, broken interactions), or P3 (minor visual friction). Add only P1/P2 findings to the review fix queue; retain P3 in the evidence.
+Report all findings as P1 (spec deviation, page doesn't load), P2 (visual criterion failure, console errors, broken interactions), or P3 (observable minor visual defect). Add every retained finding to the review fix queue. Reject taste-only preferences that lack an observable defect.
 
 For required browser-tooling failure, first persist safe attempt evidence, then quit the primary browser process/engine session (closing a tab is insufficient), launch a fresh primary profile with a changed session identity and retry once, then recheck the target and try a genuinely different configured engine. If restart or alternate launch cannot be proved, record that explicitly. Exhaustion ends `human_help_required` with all attempts and exact missing case IDs; it is never skipped, approved, empty coverage, or curl-verified. Product/application assertion failures are terminal findings and do not trigger browser restart. Curl and reachability are diagnostics only and never satisfy `BROWSER_VERIFIED`.
 
@@ -1945,7 +1949,8 @@ goal/outcome as P2 even when tests pass.
 
 This catches cross-chunk integration issues that focused per-chunk reviews miss.
 
-Fix every P1/P2 finding. Preserve each P3 with full evidence and provenance as an advisory.
+Fix every retained P1/P2/P3 finding. Reject unsupported or preference-only
+suggestions during consolidation instead of carrying them as debt.
 
 The review output follows the unified format (per `plugins/dm-review/skills/review/references/output-format.md`):
 
@@ -1953,7 +1958,7 @@ The review output follows the unified format (per `plugins/dm-review/skills/revi
 - **Findings by severity:** P1, P2, P3 with file:line references
 - **Agent Summary:** agents run, status, finding counts
 
-If P1/P2 issues are found:
+If P1/P2/P3 issues are found:
 
 1. Collect the complete finding set from the review pass and fix it as one
    revision batch on the feature branch.
@@ -1966,10 +1971,11 @@ If P1/P2 issues are found:
 4. Re-run only the affected lanes on the exact newly tested SHA. Repeat the
    whole selected roster only when prior coverage was incomplete; if a repair
    changes a security-sensitive boundary, escalate to or repeat full mode.
-5. Stop when no P1/P2 findings remain and every required affected lane and
+5. Stop when no P1/P2/P3 findings remain and every required affected lane and
    repository/browser/remote verification gate is complete.
 
-If P1/P2 findings remain after the bounded repair pass, stop as needs attention. P3 advisories do not participate in convergence.
+If any retained P1/P2/P3 finding remains after the bounded repair pass, stop as
+needs attention. Every retained severity participates in convergence.
 
 **Verification:** You MUST be able to state: "Final dm-review completed. Requested mode: [full/quick]. Effective mode: [full/quick]. Result: [CLEAN/N findings]."
 
@@ -1986,8 +1992,8 @@ if [ -n "$ENGINE" ] && [ -x "$ENGINE" ]; then bash "$ENGINE" write --phase "revi
 
 **Merge recommendation emission:** After the final review, emit ONE of these recommendation strings:
 
-- `CLEAN` -- no P1/P2 findings remain; P3 advisories may remain visible. Dev server and all required visual/verification coverage passed.
-- `APPROVE WITH FIXES` -- zero P1 and at least one P2 remains. P2 must be fixed before merge.
+- `CLEAN` -- no P1/P2/P3 findings remain. Dev server and all required visual/verification coverage passed.
+- `APPROVE WITH FIXES` -- zero P1 and at least one P2 or P3 remains. Every retained finding must be fixed before merge.
 - `BLOCKS MERGE` -- any P1 remains.
 - `BLOCKED PENDING CALLER VERIFICATION` -- any required browser case has a `human_help_required` receipt or lacks complete passing browser evidence. Emit this regardless of review findings. The caller must resolve the blocked case and complete browser verification before merge is considered safe. Do NOT use the phrase "merge is safe", "ready to merge", or equivalent in any output while this flag is set.
 - `BLOCKED PENDING REMOTE VERIFICATION` -- any non-browser lane with
@@ -2085,7 +2091,7 @@ or `/pipeline-run` caller applies it and records the capture outcome.
 
 ### 5.2 Codify (run only if the run had friction)
 
-A clean run with no P1/P2 findings, one review iteration per chunk, and no resolved ambiguities needs no
+A clean run with no P1/P2/P3 findings, one review iteration per chunk, and no resolved ambiguities needs no
 codify -- skip to the mark below. Otherwise run the codify loop so this run's lessons harden the next
 one. **Trigger codify when ANY of:** a chunk took >1 review iteration, the final review surfaced
 findings, a subagent emitted an `ambiguity_resolved` receipt flag, or a guardrail/lint guard had to
@@ -2228,7 +2234,7 @@ Use this schema after Docker reconciliation, artifact cleanup, Git cleanup, and 
 - Ephemeral removed: <count> files
 - Pre-shadow run-scoped removed: <count> files
 - Feature-scoped retained: <count> files
-- Deferred findings: none | <list with justifications>
+- Remaining findings: none | <list; any entry means NEEDS ATTENTION>
 - Docker resources: created <N>, removed <M>, missing <K>, retained/blocked <J>
 - Reconciliation: <complete|blocked|unavailable> -- <reason>
 
@@ -2452,9 +2458,9 @@ one short line: what failed and whether usage/cost was reported; the existing
 `Recommended next action` remains the single action.
 
 The visible summary normally stays within roughly 250 words. Exceed that only
-for actionable P1/P2 findings or a real blocker. Do not omit required action.
+for actionable P1/P2/P3 findings or a real blocker. Do not omit required action.
 Keep chunk tables, `Steps Completed`, provider accounting, cleanup inventory,
-evaluation receipts, P3 detail, browser receipts, synthesis/provenance ledgers,
+evaluation receipts, expanded finding detail, browser receipts, synthesis/provenance ledgers,
 and raw reports in the evidence artifacts. The compact summary must still name
 any coverage gap or blocked browser evidence that requires human action and
 must never report blocked cleanup as complete.
@@ -2464,7 +2470,7 @@ Successful-run specimen:
 ```markdown
 ## Done
 The membership validation change is committed and ready for review.
-**Verification:** Unit tests and the approved final review passed; no P1/P2 findings remain.
+**Verification:** Unit tests and the approved final review passed; no P1/P2/P3 findings remain.
 **Branch or PR:** `enhance/member-validation` -- PR #123
 **Recommended next action:** Review and merge PR #123.
 **Evidence:** receipt, requirements crosscheck, postmortem, and detailed review under `plans/member-validation/`.

--- a/plugins/pipeline/commands/pipeline-fix.md
+++ b/plugins/pipeline/commands/pipeline-fix.md
@@ -62,7 +62,7 @@ The Plan (Phase 3) MUST have one section per numbered finding. Structure:
 ```markdown
 ## Fix 1: <finding title>
 **Source:** <findings-doc>#finding-1
-**Status:** pending | resolved | partial | deferred
+**Status:** pending | resolved | rejected
 **Approach:** <2-3 sentences>
 **Files touched:** <list>
 **Acceptance criteria:**
@@ -84,11 +84,15 @@ In Phase 7, append a Findings Resolution Table to the delivery report:
 | # | Finding | Status | Evidence | Before | After |
 |---|---------|--------|----------|--------|-------|
 | 1 | <title> | resolved | screenshot:plans/<slug>/baselines-post-fix/route-desktop.png | baselines-pre-fix/... | baselines-post-fix/... |
-| 2 | <title> | partial | grep:... | ... | ... |
-| 3 | <title> | deferred | -- | ... | -- |
+| 2 | <title> | rejected | <evidence that it is invalid, duplicate, or outside approved scope> | ... | ... |
 ```
 
-Rows marked `deferred` require explicit user sign-off. Use AskUserQuestion: "Finding #N is marked deferred. Reason: justification. Approve deferral, or re-plan?" Do NOT deliver with unexplained deferrals. Zero-deferral applies to fix-passes -- see `plugins/dm-review/skills/review/references/severity-mapping.md`.
+Every retained finding must be `resolved` before delivery. `rejected` is valid
+only when current evidence disproves the report, establishes an exact duplicate,
+or shows that it never described an observable defect in the approved scope.
+Record that evidence in the row. Do not use `rejected` as a softer deferral and
+do not offer a deferral option. See
+`plugins/dm-review/skills/review/references/severity-mapping.md`.
 
 ## Delegate to /pipeline
 
@@ -102,7 +106,7 @@ In addition to `/pipeline`'s normal self-audit, verify:
 - Did I capture pre-fix baselines for every affected route?
 - Did I capture post-fix screenshots for every affected route?
 - Does every finding have a row in the Findings Resolution Table?
-- Are all `deferred` rows explicitly approved by the user?
+- Is every retained finding `resolved`, with every `rejected` row backed by evidence that it is not a valid in-scope finding?
 - For findings that were behavioral bugs, did the fix follow `superpowers:systematic-debugging` (root cause, not symptom)? Is each `resolved` row backed by fresh evidence per `superpowers:verification-before-completion`, not an assertion? See `docs/skill-authoring.md`.
 
 If any answer is "no," do not deliver. Fix-pass quality hinges on the 1:1 mapping from findings to fixes.

--- a/plugins/pipeline/commands/pipeline-run.md
+++ b/plugins/pipeline/commands/pipeline-run.md
@@ -19,7 +19,7 @@ verification result, branch or PR, and one recommended next action. Link the
 existing `receipt.md`, `final-requirements-crosscheck.md`,
 `run-postmortem.md`, and detailed review when present. For blocked work, name
 the exact blocker, the smallest operator action, and the preserved resumable
-location. Normally stay within roughly 250 words, except for required P1/P2
+location. Normally stay within roughly 250 words, except for required P1/P2/P3
 findings or a real blocker.
 
 Do not repeat `Steps Completed`, provider accounting, cleanup inventory, every
@@ -76,7 +76,7 @@ Before executing, verify:
     `decisionProfile.consequence: high`; a security-sensitive final diff
     escalates it to full and records the escalation. Legacy manifests default
     to `full` with `final_review_mode_defaulted=true`. This field never weakens
-    per-chunk sensitive review, repository/browser evidence, P1/P2 resolution,
+    per-chunk sensitive review, repository/browser evidence, P1/P2/P3 resolution,
     or cleanup.
 
 If any check fails, report the issue and stop.
@@ -192,7 +192,7 @@ references.
 
 **Review adapter:** Codex sessions do not expose a generic nested `Skill(skill="dm-review:review", ...)` callable. Use this risk-tiered contract in the current orchestrator context:
 
-- For ordinary non-sensitive chunks, run one focused read-only Codex review against the chunk diff and allow at most one P1/P2 repair/recheck pass. Preserve pending/done todo receipts.
+- For ordinary non-sensitive chunks, run one focused read-only Codex review against the chunk diff and allow at most one P1/P2/P3 repair/recheck pass. Preserve pending/done todo receipts.
 - For sensitive-path chunks, run the full inline `plugins/dm-review/skills/review/SKILL.md` protocol against the chunk worktree, with at most two passes.
 - For the final gate, read `finalReviewMode`. `full` runs the review skill's
   full-mode protocol. `quick` loads and executes the installed
@@ -200,7 +200,7 @@ references.
   a bounded security-sensitive path, escalate to full and receipt the effective
   mode.
 - Use `multi_agent_v1.spawn_agent` for the focused Codex reviewer or for review agents selected by the chosen dm-review protocol when available.
-- Fix P1/P2 findings and retain complete P3 advisory evidence. Verify repairs with affected lanes; repeat the full fan-out only if its coverage was incomplete or a repair changed a security-sensitive boundary.
+- Fix every retained P1/P2/P3 finding and verify repairs with affected lanes; repeat the full fan-out only if its coverage was incomplete or a repair changed a security-sensitive boundary. Reject unsupported preference-only suggestions during consolidation instead of deferring them.
 - Write/read the same `todos/*-pending-*.md` and `todos/*-done-*.md` receipts that dm-review uses.
 
 Do not report "Skill tool unavailable" in Codex when this adapter can run. That message is only valid if the session lacks both nested skill invocation and enough local access to execute the dm-review inline protocol.

--- a/plugins/pipeline/commands/pipeline.md
+++ b/plugins/pipeline/commands/pipeline.md
@@ -51,7 +51,7 @@ what to do.
   recommended next action, and links or paths to the receipt, requirements
   crosscheck, postmortem, and detailed review when present.
 - A blocked message names the exact blocker, the smallest operator action that
-  can clear it, and where resumable work is preserved. Required P1/P2 findings,
+  can clear it, and where resumable work is preserved. Required P1/P2/P3 findings,
   coverage gaps, blocked browser evidence, cleanup truth, and provenance remain
   in the linked durable evidence.
 - Put `Recommended next action` before any additional option. Show other options
@@ -59,7 +59,7 @@ what to do.
   multiple-choice menu.
 
 The visible summary should normally fit within roughly 250 words. Exceed that
-only to expose actionable P1/P2 findings or a real blocker. Never hide required
+only to expose actionable P1/P2/P3 findings or a real blocker. Never hide required
 action to meet the budget. Do not print `Steps Completed`, provider accounting,
 cleanup inventories, every evaluation receipt, or raw review output in chat by
 default; keep them in `receipt.md`, `run-postmortem.md`, the requirements
@@ -500,7 +500,7 @@ prompt generation may copy them but must never infer replacements.
 `finalReviewMode: full|quick` plus a non-empty `finalReviewRationale`. `full` is
 the default. `quick` requires explicit user/approved-plan intent and is invalid
 when `decisionProfile.consequence` is `high`. It preserves all per-chunk
-sensitive-path review, repository/browser verification, P1/P2 resolution, and
+sensitive-path review, repository/browser verification, P1/P2/P3 resolution, and
 cleanup. If the final diff matches dm-review's bounded security-sensitive path
 set, the quick protocol escalates to full and records the escalation.
 
@@ -517,7 +517,7 @@ Do not turn high uncertainty into debate or a full review per chunk. Decision
 leverage never selects a provider/model/executor, creates a routing override,
 relaxes security, alters `workflowClass`, overrides browser/persona coverage,
 changes cleanup, or changes economics. The existing quick/focused review,
-sensitive-path, final-review, required P1/P2 resolution, run-size, and exact-owned Docker
+sensitive-path, final-review, required P1/P2/P3 resolution, run-size, and exact-owned Docker
 rules remain unchanged.
 
 **Plan self-review (before presenting):** Re-read your own plan and check:

--- a/plugins/pipeline/references/artifact-lifecycle.md
+++ b/plugins/pipeline/references/artifact-lifecycle.md
@@ -165,7 +165,7 @@ authoritative Step 5b fields.
 - Ephemeral removed: N files
 - Pre-shadow run-scoped removed: N files
 - Feature-scoped retained: N files
-- Deferred findings: none | <list>
+- Remaining findings: none | <list; any entry means NEEDS ATTENTION>
 - Docker resources: created N, removed M, missing K, retained/blocked J
 - Docker inventory: before <digest/count>, after <digest/count>
 - Reconciliation: complete | blocked | unavailable (reason)

--- a/plugins/pipeline/skills/pipeline-fix/SKILL.md
+++ b/plugins/pipeline/skills/pipeline-fix/SKILL.md
@@ -77,7 +77,7 @@ The Plan (Phase 3) MUST have one section per numbered finding. Structure:
 ```markdown
 ## Fix 1: <finding title>
 **Source:** <findings-doc>#finding-1
-**Status:** pending | resolved | partial | deferred
+**Status:** pending | resolved | rejected
 **Approach:** <2-3 sentences>
 **Files touched:** <list>
 **Acceptance criteria:**
@@ -99,11 +99,15 @@ In Phase 7, append a Findings Resolution Table to the delivery report:
 | # | Finding | Status | Evidence | Before | After |
 |---|---------|--------|----------|--------|-------|
 | 1 | <title> | resolved | screenshot:plans/<slug>/baselines-post-fix/route-desktop.png | baselines-pre-fix/... | baselines-post-fix/... |
-| 2 | <title> | partial | grep:... | ... | ... |
-| 3 | <title> | deferred | -- | ... | -- |
+| 2 | <title> | rejected | <evidence that it is invalid, duplicate, or outside approved scope> | ... | ... |
 ```
 
-Rows marked `deferred` require explicit user sign-off. Use AskUserQuestion: "Finding #N is marked deferred. Reason: justification. Approve deferral, or re-plan?" Do NOT deliver with unexplained deferrals. Zero-deferral applies to fix-passes -- see `plugins/dm-review/skills/review/references/severity-mapping.md`.
+Every retained finding must be `resolved` before delivery. `rejected` is valid
+only when current evidence disproves the report, establishes an exact duplicate,
+or shows that it never described an observable defect in the approved scope.
+Record that evidence in the row. Do not use `rejected` as a softer deferral and
+do not offer a deferral option. See
+`plugins/dm-review/skills/review/references/severity-mapping.md`.
 
 ## Delegate to /pipeline
 
@@ -117,7 +121,7 @@ In addition to `/pipeline`'s normal self-audit, verify:
 - Did I capture pre-fix baselines for every affected route?
 - Did I capture post-fix screenshots for every affected route?
 - Does every finding have a row in the Findings Resolution Table?
-- Are all `deferred` rows explicitly approved by the user?
+- Is every retained finding `resolved`, with every `rejected` row backed by evidence that it is not a valid in-scope finding?
 - For findings that were behavioral bugs, did the fix follow `superpowers:systematic-debugging` (root cause, not symptom)? Is each `resolved` row backed by fresh evidence per `superpowers:verification-before-completion`, not an assertion? See `docs/skill-authoring.md`.
 
 If any answer is "no," do not deliver. Fix-pass quality hinges on the 1:1 mapping from findings to fixes.

--- a/plugins/pipeline/skills/pipeline-run/SKILL.md
+++ b/plugins/pipeline/skills/pipeline-run/SKILL.md
@@ -34,7 +34,7 @@ verification result, branch or PR, and one recommended next action. Link the
 existing `receipt.md`, `final-requirements-crosscheck.md`,
 `run-postmortem.md`, and detailed review when present. For blocked work, name
 the exact blocker, the smallest operator action, and the preserved resumable
-location. Normally stay within roughly 250 words, except for required P1/P2
+location. Normally stay within roughly 250 words, except for required P1/P2/P3
 findings or a real blocker.
 
 Do not repeat `Steps Completed`, provider accounting, cleanup inventory, every
@@ -91,7 +91,7 @@ Before executing, verify:
     `decisionProfile.consequence: high`; a security-sensitive final diff
     escalates it to full and records the escalation. Legacy manifests default
     to `full` with `final_review_mode_defaulted=true`. This field never weakens
-    per-chunk sensitive review, repository/browser evidence, P1/P2 resolution,
+    per-chunk sensitive review, repository/browser evidence, P1/P2/P3 resolution,
     or cleanup.
 
 If any check fails, report the issue and stop.
@@ -207,7 +207,7 @@ references.
 
 **Review adapter:** Codex sessions do not expose a generic nested `Skill(skill="dm-review:review", ...)` callable. Use this risk-tiered contract in the current orchestrator context:
 
-- For ordinary non-sensitive chunks, run one focused read-only Codex review against the chunk diff and allow at most one P1/P2 repair/recheck pass. Preserve pending/done todo receipts.
+- For ordinary non-sensitive chunks, run one focused read-only Codex review against the chunk diff and allow at most one P1/P2/P3 repair/recheck pass. Preserve pending/done todo receipts.
 - For sensitive-path chunks, run the full inline `plugins/dm-review/skills/review/SKILL.md` protocol against the chunk worktree, with at most two passes.
 - For the final gate, read `finalReviewMode`. `full` runs the review skill's
   full-mode protocol. `quick` loads and executes the installed
@@ -215,7 +215,7 @@ references.
   a bounded security-sensitive path, escalate to full and receipt the effective
   mode.
 - Use `multi_agent_v1.spawn_agent` for the focused Codex reviewer or for review agents selected by the chosen dm-review protocol when available.
-- Fix P1/P2 findings and retain complete P3 advisory evidence. Verify repairs with affected lanes; repeat the full fan-out only if its coverage was incomplete or a repair changed a security-sensitive boundary.
+- Fix every retained P1/P2/P3 finding and verify repairs with affected lanes; repeat the full fan-out only if its coverage was incomplete or a repair changed a security-sensitive boundary. Reject unsupported preference-only suggestions during consolidation instead of deferring them.
 - Write/read the same `todos/*-pending-*.md` and `todos/*-done-*.md` receipts that dm-review uses.
 
 Do not report "Skill tool unavailable" in Codex when this adapter can run. That message is only valid if the session lacks both nested skill invocation and enough local access to execute the dm-review inline protocol.

--- a/plugins/pipeline/skills/pipeline/SKILL.md
+++ b/plugins/pipeline/skills/pipeline/SKILL.md
@@ -66,7 +66,7 @@ what to do.
   recommended next action, and links or paths to the receipt, requirements
   crosscheck, postmortem, and detailed review when present.
 - A blocked message names the exact blocker, the smallest operator action that
-  can clear it, and where resumable work is preserved. Required P1/P2 findings,
+  can clear it, and where resumable work is preserved. Required P1/P2/P3 findings,
   coverage gaps, blocked browser evidence, cleanup truth, and provenance remain
   in the linked durable evidence.
 - Put `Recommended next action` before any additional option. Show other options
@@ -74,7 +74,7 @@ what to do.
   multiple-choice menu.
 
 The visible summary should normally fit within roughly 250 words. Exceed that
-only to expose actionable P1/P2 findings or a real blocker. Never hide required
+only to expose actionable P1/P2/P3 findings or a real blocker. Never hide required
 action to meet the budget. Do not print `Steps Completed`, provider accounting,
 cleanup inventories, every evaluation receipt, or raw review output in chat by
 default; keep them in `receipt.md`, `run-postmortem.md`, the requirements
@@ -515,7 +515,7 @@ prompt generation may copy them but must never infer replacements.
 `finalReviewMode: full|quick` plus a non-empty `finalReviewRationale`. `full` is
 the default. `quick` requires explicit user/approved-plan intent and is invalid
 when `decisionProfile.consequence` is `high`. It preserves all per-chunk
-sensitive-path review, repository/browser verification, P1/P2 resolution, and
+sensitive-path review, repository/browser verification, P1/P2/P3 resolution, and
 cleanup. If the final diff matches dm-review's bounded security-sensitive path
 set, the quick protocol escalates to full and records the escalation.
 
@@ -532,7 +532,7 @@ Do not turn high uncertainty into debate or a full review per chunk. Decision
 leverage never selects a provider/model/executor, creates a routing override,
 relaxes security, alters `workflowClass`, overrides browser/persona coverage,
 changes cleanup, or changes economics. The existing quick/focused review,
-sensitive-path, final-review, required P1/P2 resolution, run-size, and exact-owned Docker
+sensitive-path, final-review, required P1/P2/P3 resolution, run-size, and exact-owned Docker
 rules remain unchanged.
 
 **Plan self-review (before presenting):** Re-read your own plan and check:

--- a/plugins/pipeline/skills/promptcraft/references/manifest-schema.md
+++ b/plugins/pipeline/skills/promptcraft/references/manifest-schema.md
@@ -155,7 +155,7 @@ uncertain.
 from the approved plan. `branchMode` controls only how Pipeline selects the
 feature branch; it never authorizes a merge or a force-push. `finalReviewMode`
 controls only the terminal dm-review roster; it never weakens sensitive-path
-per-chunk review, required verification, browser evidence, or P1/P2 resolution.
+per-chunk review, required verification, browser evidence, or P1/P2/P3 resolution.
 
 ## Performance Contract
 
@@ -207,7 +207,7 @@ Decision leverage never selects a provider or model, changes an executor,
 creates a routing override, relaxes a security rule, changes `workflowClass`,
 reduces browser/persona coverage, skips review, changes cleanup, or changes run
 economics. It does not authorize open debate or a full review for every chunk.
-All existing sensitive-path, browser recovery, selected final review, required P1/P2 resolution,
+All existing sensitive-path, browser recovery, selected final review, required P1/P2/P3 resolution,
 run-size, and exact-owned Docker cleanup rules remain authoritative.
 
 Bootstrap limitation: a run whose already-approved/current manifest predates

--- a/tools/check-dependencies.sh
+++ b/tools/check-dependencies.sh
@@ -274,8 +274,8 @@ for consumer, expected in consumer_floors.items():
 
 pipeline = manifests.get("pipeline")
 dm_review_floor = None if pipeline is None else pipeline.get("pluginDependencies", {}).get("dm-review")
-if dm_review_floor != ">=1.62.0":
-    errors.append("pipeline must require dm-review >=1.62.0")
+if dm_review_floor != ">=1.63.0":
+    errors.append("pipeline must require dm-review >=1.63.0")
 
 if errors:
     for error in errors:

--- a/tools/validate-dm-review-codex-perspective.sh
+++ b/tools/validate-dm-review-codex-perspective.sh
@@ -308,13 +308,13 @@ require_text "$issue_tracking" 'source_agents:' "todo source_agents metadata rem
 require_text "$consolidator" 'Coverage Gaps' "coverage gaps remain explicit"
 require_text "$graceful_degradation" 'REVIEW INCOMPLETE' "core-lane incomplete behavior remains compatible"
 require_text "$graceful_degradation" 'Degraded: all conditional agents unavailable' "degraded-lane behavior remains compatible"
-require_text "$output_format" 'if any P3 findings:' "P3-only recommendation retains advisory branch"
-require_text "$output_format" 'recommendation = "CLEAN"' "P3-only maps to CLEAN"
-require_text "$output_format" 'source identity, raw reference, evidence, synthesis disposition, counts, and provenance' "P3 report retains complete advisory evidence"
-require_text "$issue_tracking" 'P3 -- Advisory' "P3 is advisory in issue-tracking policy"
-require_text "$issue_tracking" 'No -- retain in report and receipts only' "P3 does not create todo or issue work"
-require_text "$review_loop" 'never enters the fix queue' "P3 does not enter convergence fix queue"
-require_text "$review_loop" 'required_finding_files = todos/*-pending-p1-*.md plus todos/*-pending-p2-*.md' "review loop excludes legacy P3 todos from convergence"
+require_text "$output_format" 'elif any P2 or P3 findings:' "P3-only recommendation requires fixes"
+require_text "$output_format" 'recommendation = "APPROVE WITH FIXES"' "P3-only cannot map to CLEAN"
+require_text "$output_format" 'every retained P3 enters the fix queue' "P3 report preserves evidence and requires repair"
+require_text "$issue_tracking" 'P3 -- Required Fix' "P3 is required in issue-tracking policy"
+require_text "$issue_tracking" '| `p3` | Yes -- always |' "P3 creates tracked work"
+require_text "$review_loop" 'Every retained finding triggers repair and affected-lane verification.' "P3 participates in convergence"
+require_text "$review_loop" 'required_finding_files = todos/*-pending-p1-*.md plus todos/*-pending-p2-*.md plus todos/*-pending-p3-*.md' "review loop includes P3 todos in convergence"
 require_text "$review_loop" 'prior_finding_owner_lanes = union of validated exact source_agents' "review loop preserves repaired finding owners"
 require_text "$review_loop" 'promoted_to_full = true' "review loop records full-review promotion"
 reject_text "$review_skill" 'Phase 5.5: Simplification Pass' "active simplification phase is retired"
@@ -354,20 +354,32 @@ require_text "$pipeline_orchestrator" 'one **focused Codex review**' "Pipeline k
 require_text "$pipeline_orchestrator" 'validated final dm-review mode' "Pipeline runs the approved final review mode"
 require_text "$pipeline_orchestrator" 'Re-run only the affected lanes' "Pipeline verifies repairs with affected lanes"
 require_text "$pipeline_orchestrator" 'whole selected roster only when prior coverage was incomplete' "Pipeline limits repeated final-review fan-out"
-require_text "$pipeline_orchestrator" 'p3_advisories: [N]' "Pipeline evaluation receipt names P3 advisories"
+require_text "$pipeline_orchestrator" 'p3_findings: [N]' "Pipeline evaluation receipt counts P3 findings"
 reject_text "$pipeline_orchestrator" 'findings_remaining: [N] | deferred: [N]' "Pipeline evaluation receipt retires undefined deferred count"
 require_text "$REPO_ROOT/README.md" 'Quick review with two core judgment lanes' "README describes proportional quick roster"
-require_text "$REPO_ROOT/README.md" 'P3 stays advisory' "README describes proportional convergence"
+require_text "$REPO_ROOT/README.md" 'no retained P1/P2/P3 findings remain; no deferrals' "README describes zero-deferral convergence"
 reject_text "$REPO_ROOT/plugins/project-scaffolder/skills/scaffolding/references/claude-md-templates/dm-standard.md" '--allow-defer-p3' "scaffold template retires P3 deferral flag"
-require_text "$review_skill" 'Every P1/P2 must name the affected current user or operator' "P1/P2 requires current affected-user evidence"
-require_text "$review_skill" 'reachable actor/input/path' "P1/P2 requires a reachable path"
+require_text "$review_skill" 'P1/P2 must also name' "P1/P2 requires additional impact evidence"
+require_text "$review_skill" 'affected current user or operator' "P1/P2 requires current affected-user evidence"
+require_text "$review_skill" 'observable current defect, its location' "every severity requires a current defect and location"
 require_text "$review_skill" 'realistic harm or regression' "P1/P2 requires realistic harm"
 require_text "$review_skill" 'smallest adequate repair' "P1/P2 requires the smallest repair"
 require_text "$consolidator" 'Reject scope-expanding repairs' "consolidation rejects unrelated product scope"
-require_text "$REPO_ROOT/plugins/dm-review/.claude-plugin/plugin.json" '"version": "1.62.1"' "canonical dm-review version is 1.62.1"
-require_text "$REPO_ROOT/plugins/dm-review/.codex-plugin/plugin.json" '"version": "1.62.1"' "generated dm-review version is 1.62.1"
-require_text "$REPO_ROOT/plugins/pipeline/.claude-plugin/plugin.json" '"version": "1.52.0"' "canonical Pipeline version is 1.52.0"
-require_text "$REPO_ROOT/plugins/pipeline/.codex-plugin/plugin.json" '"dm-review": ">=1.62.0"' "generated Pipeline dependency floor is current"
+for zero_deferral_surface in \
+  "$review_skill" \
+  "$output_format" \
+  "$issue_tracking" \
+  "$review_loop" \
+  "$pipeline_orchestrator" \
+  "$REPO_ROOT/README.md"; do
+  reject_text "$zero_deferral_surface" 'P3 is advisory' "${zero_deferral_surface#$REPO_ROOT/} rejects advisory P3 policy"
+  reject_text "$zero_deferral_surface" 'P3 advisories' "${zero_deferral_surface#$REPO_ROOT/} rejects deferred P3 evidence"
+  reject_text "$zero_deferral_surface" 'P3 stays advisory' "${zero_deferral_surface#$REPO_ROOT/} rejects clean-with-P3 policy"
+done
+require_text "$REPO_ROOT/plugins/dm-review/.claude-plugin/plugin.json" '"version": "1.63.0"' "canonical dm-review version is 1.63.0"
+require_text "$REPO_ROOT/plugins/dm-review/.codex-plugin/plugin.json" '"version": "1.63.0"' "generated dm-review version is 1.63.0"
+require_text "$REPO_ROOT/plugins/pipeline/.claude-plugin/plugin.json" '"version": "1.53.0"' "canonical Pipeline version is 1.53.0"
+require_text "$REPO_ROOT/plugins/pipeline/.codex-plugin/plugin.json" '"dm-review": ">=1.63.0"' "generated Pipeline dependency floor is current"
 
 printf "Synthesis identity fixtures\n"
 base_id=$(fixture_finding_id \

--- a/tools/validate-workflow-contracts.sh
+++ b/tools/validate-workflow-contracts.sh
@@ -376,7 +376,7 @@ printf "\nBaseplate evidence gates:\n"
 require_text "$promptcraft" "Phase 3m: Fixture SDK Conformance Gate" "promptcraft gates fixture SDK conformance"
 require_text "$promptcraft" "Phase 3n: Production Readiness Preflight Gate" "promptcraft gates production preflight"
 require_text "$arch" "Fixture SDK Conformance Gap" "architecture-reviewer checks reachable fixture conformance gaps"
-require_text "$arch" "Missing Auth Boundary Map Receipt (P3)" "Auth Boundary Map absence is advisory without a reachable defect"
+require_text "$arch" "Its absence is a coverage note, not a product finding" "Auth Boundary Map absence is a coverage note without a reachable defect"
 require_absent "$arch" "Missing Auth Boundary Map Receipt (P2)" "Auth Boundary Map absence is not automatically blocking"
 require_text "$sec" "Public/Private URL Boundary" "security-auditor guards the public/private URL boundary"
 require_text "$sec" "Update / Release Preflight" "security-auditor checks update/release preflight"
@@ -511,8 +511,8 @@ for loop_contract in "$review_loop" "$review_loop_skill"; do
   for receipt_field in selective_rerun lanes_rerun lanes_skipped rerun_reasons selection_fallback_reason; do
     require_text "$loop_contract" "\`$receipt_field\`" "$loop_contract_relative preserves $receipt_field receipt field"
   done
-  require_text "$loop_contract" '**Convergence requires no open P1/P2 findings and complete required coverage for the verification pass.**' "$loop_contract_relative defines proportional convergence"
-  require_text "$loop_contract" 'P3 advisories never trigger another pass.' "$loop_contract_relative excludes P3 from convergence"
+  require_text "$loop_contract" '**Convergence requires no open P1/P2/P3 findings and complete required coverage for the verification pass.**' "$loop_contract_relative defines zero-deferral convergence"
+  require_text "$loop_contract" 'Every retained finding triggers repair and affected-lane verification.' "$loop_contract_relative includes every retained severity in convergence"
   require_text "$loop_contract" 'the touched-file set is the union of `git diff --name-only <prior-review-head>..HEAD` and the paths reported by `git status --porcelain`' "$loop_contract_relative unions committed and uncommitted changed paths"
   require_text "$loop_contract" "An empty computed lane set is never dispatched." "$loop_contract_relative never dispatches an empty selection"
   require_text "$loop_contract" 'selection fails open to a full fan-out with `fallback_reason: empty selection`' "$loop_contract_relative fails open on an empty selection"
@@ -520,14 +520,14 @@ for loop_contract in "$review_loop" "$review_loop_skill"; do
   require_text "$loop_contract" '`max-iterations-verification-receipt.json`' "$loop_contract_relative names the max-iterations receipt artifact"
   require_text "$loop_contract" 'Repeat the whole full fan-out only when the prior full review was incomplete or a repair changed a security-sensitive boundary.' "$loop_contract_relative limits repeated full fan-out"
   require_text "$loop_contract" 'prior_finding_owner_lanes = union of validated exact source_agents' "$loop_contract_relative preserves repaired finding ownership"
-  require_text "$loop_contract" 'required_finding_files = todos/*-pending-p1-*.md plus todos/*-pending-p2-*.md' "$loop_contract_relative excludes P3 artifacts from convergence"
+  require_text "$loop_contract" 'required_finding_files = todos/*-pending-p1-*.md plus todos/*-pending-p2-*.md plus todos/*-pending-p3-*.md' "$loop_contract_relative includes P3 artifacts in convergence"
   require_text "$loop_contract" 'security_boundary_changed: security_boundary_changed' "$loop_contract_relative binds security repair classification"
   require_line "$loop_contract" '          rerun_lanes = lanes_a union lanes_b' "$loop_contract_relative keeps affected-lane assignment inside the non-promotion branch"
   require_line "$loop_contract" '          promoted_to_full = true' "$loop_contract_relative records ordinary full-review promotion"
 done
 require_text "$review_skill" '`review_lane_allowlist`' "review receiver names the selective lane allowlist"
 require_text "$REPO_ROOT/plugins/dm-review/.claude-plugin/plugin.json" '"workflow-kernel": ">=0.14.0"' "dm-review requires the simplified verification kernel release"
-require_text "$REPO_ROOT/plugins/pipeline/.claude-plugin/plugin.json" '"dm-review": ">=1.62.0"' "pipeline requires compact-handoff dm-review release"
+require_text "$REPO_ROOT/plugins/pipeline/.claude-plugin/plugin.json" '"dm-review": ">=1.63.0"' "pipeline requires zero-deferral dm-review release"
 require_text "$REPO_ROOT/plugins/dm-review/.claude-plugin/plugin.json" '"name": "Second Perspective Reviewer"' "dm-review manifest names the provider-neutral perspective lane"
 require_text "$REPO_ROOT/plugins/dm-review/.claude-plugin/plugin.json" 'family-independent second-opinion review' "dm-review manifest describes family-independent perspective resolution"
 require_text "$REPO_ROOT/plugins/dm-review/skills/review/references/agent-registry.md" 'Full mode only.' "migration-validator registry limits the lane to full mode"
@@ -691,13 +691,13 @@ require_text "$plan_adversary" "targeted recheck of only those revised blocker s
 require_text "$sec" "reachable actor, input, and path" "security P1/P2 evidence requires a reachable threat"
 require_text "$sec" "realistic harm or regression" "security P1/P2 evidence requires realistic current harm"
 require_text "$sec" "actual trust boundary crossed" "security P1/P2 evidence names the actual trust boundary"
-require_text "$arch" "not automatic P1/P2 findings" "architecture preferences are heuristic rather than blocking"
+require_text "$arch" "not findings by themselves" "architecture preferences are heuristic rather than blocking"
 require_absent "$arch" "Layer violations are P1 when they create circular dependencies, P2 otherwise" "architecture review rejects automatic layer-violation severity"
-require_text "$arch" "A layer violation is P1 or P2 only when it causes a concrete current failure, reachable harm, or approved-scope regression" "architecture layer findings require current evidence"
+require_text "$arch" "Report a layer violation only when it causes a concrete current failure" "architecture layer findings require current evidence"
 require_text "$arch" "Direct one-use handlers and concrete implementations are valid" "direct clear implementations remain valid"
 require_text "$arch" "Mere direct access in trusted first-party Fixture code is not automatically a finding" "architecture review requires a reachable Fixture boundary defect"
 require_text "$simplicity" "the number alone is not a finding" "numeric simplicity thresholds are not automatically blocking"
-require_text "$review_consolidator" "Discard unrelated hardening and new product scope from the fix queue" "review repairs cannot introduce unrelated hardening or product scope"
+require_text "$review_consolidator" "Discard unrelated hardening, new product scope" "review repairs cannot introduce unrelated hardening or product scope"
 require_text "$review_fix" "Do not add unrelated hardening, architecture layers, compatibility machinery, or product scope" "dm-review-fix keeps repairs inside evidenced approved scope"
 require_text "$security_mapping" "authentication or authorization bypass, credential disclosure, unsafe destructive operations, corruptible state or backups, public untrusted input, release/update integrity failures, and false verification claims remain blocking" "real sensitive boundaries and verification integrity remain blocking"
 require_text "$review_loop" "one repair batch followed by one" "default review convergence uses one repair batch"
@@ -1197,11 +1197,11 @@ require_absent "$voice_check" 'Provide 2-3 rewritten passages' \
 require_before "$review_output" '## Compact Human Handoff' '## Complete Report Template' \
   "dm-review leads with compact handoff before complete evidence"
 require_text "$review_output" 'path:anchor -- problem -- smallest adequate fix' \
-  "dm-review handoff has the compact P1/P2 row shape"
+  "dm-review handoff has the compact P1/P2/P3 row shape"
 require_text "$review_output" 'findings` with the exact remaining count' \
   "dm-review discloses the exact overflow count"
-require_text "$review_output" 'exact count and evidence pointer in this handoff' \
-  "dm-review keeps P3 advisory detail out of the handoff"
+require_text "$review_output" 'Chat keeps P3' \
+  "dm-review keeps P3 compact while preserving its required fix path"
 require_text "$review_output" '### Synthesis Decisions' \
   "dm-review retains the complete synthesis ledger"
 require_text "$review_output" '### Repository Cleanup' \
@@ -1242,8 +1242,8 @@ require_absent "$review_skill" 'Output the full report to the user.' \
   "dm-review rejects the old visible full-report dump"
 for f in "$review_command" "$review_alias"; do
   rel="${f#$REPO_ROOT/}"
-  require_text "$f" 'show only the exact count and evidence pointer in the compact handoff' \
-    "$rel keeps P3 detail in complete evidence"
+  require_text "$f" '**P3 only:** `APPROVE WITH FIXES`. Must fix.' \
+    "$rel rejects a clean result with retained P3 findings"
   require_absent "$f" 'retain every P3 as a visible advisory' \
     "$rel rejects expanded P3 delivery"
 done
@@ -1326,8 +1326,8 @@ require_text "$orchestrator" 'providerSplit: {claude: N, codex: N, openrouter: N
   "Pipeline receipt retains provider provenance"
 require_text "$orchestrator" 'retained/blocked <J>' \
   "Pipeline receipt retains cleanup truth"
-require_text "$orchestrator" 'P1/P2' \
-  "Pipeline still preserves actionable findings"
+require_text "$orchestrator" 'P1/P2/P3' \
+  "Pipeline preserves every actionable finding severity"
 require_text "$orchestrator" 'human_help_required' \
   "Pipeline still preserves blocked browser evidence"
 require_absent "$orchestrator" '# Pipeline Execution Complete' \


### PR DESCRIPTION
## Summary

- make every retained P1, P2, and P3 finding required work before CLEAN or merge
- route P3 todos through dm-review-fix, affected-lane rechecks, Pipeline chunk repair, final review, and fix-pass reporting
- reject speculative hardening, preference-only architecture, future-scale concerns, duplicates, and disproved inputs during consolidation instead of retaining them as debt
- remove the remaining review-finding deferral path and add regression assertions against advisory-P3 policy drift
- release dm-review 1.63.0 and Pipeline 1.53.0 with regenerated Codex manifests and command aliases

## Verification

- ./tools/validate-composition.sh --all
- ./tools/validate-dm-review-codex-perspective.sh
- ./tools/validate-workflow-contracts.sh
- ./tools/check-dependencies.sh
- ./tools/validate-dual-compat.sh
- generated manifest and command-alias checks
- git diff --check

All validators pass at exact head 2c7b8c5.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Design-Machines-Studio/codesmith/depot/pr/71"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789400415&installation_model_id=428410&pr_number=71&repository=Design-Machines-Studio%2Fdepot&return_to=https%3A%2F%2Fgithub.com%2FDesign-Machines-Studio%2Fdepot%2Fpull%2F71&signature=992f9f08c1d015f9a304ee3154ed5e8d7baf56f560eb98a3f305244f1f228f58"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->