### PR TITLE
fix(assembly): remove redundant release approvals

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -139,7 +139,7 @@
     {
       "name": "assembly",
       "source": "./plugins/assembly",
-      "version": "3.11.0",
+      "version": "3.12.0",
       "author": {
         "name": "Design Machines"
       },

--- a/docs/search-index.md
+++ b/docs/search-index.md
@@ -131,7 +131,7 @@ Common questions mapped to the right skill:
 | airlift | /airlift-in | [path] | Resume from an existing .airlift handoff bundle in the current harness. |
 | airlift | /airlift-install | [wire | unwire | status] | Wire, unwire, or check the airlift Tier-3 early-warning monitor in settings.json (statusLine chain + StopFailure hook). Preserves the existing statusLine; ccusage optional. |
 | assembly | /assembly-build | [generate, build, test, full, focused, level, candidate, or post-merge] | Build and test via legacy Docker modes or tiered repository verification |
-| assembly | /assembly-release | [status|plan|publish|resume|promote] [tag] [channel] | Inspect, plan, publish, resume, or promote Assembly Baseplate releases |
+| assembly | /assembly-release | [status|plan|publish|resume|promote] [tag] [channel] [--minimum-version <tag>] | Inspect, plan, publish, resume, or promote Assembly Baseplate releases |
 | chef | /meal-plan | [number of days, any constraints or preferences] | Generate a meal plan following Eve Persak's timing framework |
 | chef | /recipe-check | [paste recipe text, URL, or Mela recipe name] | Analyze a recipe against Eve Persak's dietary framework |
 | chef | /recipe-convert | [recipe name from Mela, URL, or paste recipe text] | Convert a recipe to a healthy, Bali-friendly version and export as .melarecipe |

--- a/plugins/assembly/.claude-plugin/plugin.json
+++ b/plugins/assembly/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "assembly",
   "description": "Assembly governance application development with Go, Templ, and Datastar",
-  "version": "3.11.0",
+  "version": "3.12.0",
   "author": {
     "name": "Design Machines"
   },
@@ -158,7 +158,7 @@
         "id": "assembly-release",
         "name": "Assembly Release",
         "description": "Inspect, plan, publish, resume, or promote Assembly Baseplate releases",
-        "argumentHint": "[status|plan|publish|resume|promote] [tag] [channel]"
+        "argumentHint": "[status|plan|publish|resume|promote] [tag] [channel] [--minimum-version <tag>]"
       }
     ]
   }

--- a/plugins/assembly/.codex-plugin/plugin.json
+++ b/plugins/assembly/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "assembly",
-  "version": "3.11.0",
+  "version": "3.12.0",
   "description": "Assembly governance application development with Go, Templ, and Datastar",
   "author": {
     "name": "Design Machines"
@@ -153,7 +153,7 @@
         "id": "assembly-release",
         "name": "Assembly Release",
         "description": "Inspect, plan, publish, resume, or promote Assembly Baseplate releases",
-        "argumentHint": "[status|plan|publish|resume|promote] [tag] [channel]"
+        "argumentHint": "[status|plan|publish|resume|promote] [tag] [channel] [--minimum-version <tag>]"
       }
     ]
   },

--- a/plugins/assembly/commands/assembly-release.md
+++ b/plugins/assembly/commands/assembly-release.md
@@ -1,7 +1,7 @@
 ---
 name: assembly-release
 description: Assembly Baseplate release operations for current release state, release planning, failed or stopped release resumption, R2 publication failures, existing assets and manifest recovery when pointers never moved, staging acceptance, and beta or stable promotion
-argument-hint: "[status|plan|publish|resume|promote] [tag] [channel]"
+argument-hint: "[status|plan|publish|resume|promote] [tag] [channel] [--minimum-version <tag>]"
 ---
 
 # Assembly Release
@@ -15,17 +15,22 @@ repository's runbooks and workflows.
 Parse `$ARGUMENTS` as:
 
 ```text
-[status|plan|publish|resume|promote] [tag] [channel]
+[status|plan|publish|resume|promote] [tag] [channel] [--minimum-version <tag>]
 ```
 
 - No arguments means `status`.
 - Accept only `status`, `plan`, `publish`, `resume`, and `promote`.
-- Reject extra or speculative modes.
+- Accept only the optional `--minimum-version <canonical tag>` flag. Reject
+  unknown flags, extra arguments, and speculative modes.
 - `status` and `plan` are read-only. They must not create or move a tag, edit or
   publish a GitHub Release, dispatch a workflow, write a manifest, operate a
   provider, change a deployment, or create a credential.
-- `publish`, `resume`, and `promote` require the exact authorization gate below
-  before their first mutation. Read-only inspection before that gate is allowed.
+- `publish`, `resume`, and `promote` require an exact tag and channel in the
+  current invocation. The invocation is the operator authorization. Do not ask
+  for a second confirmation before mutation. Read-only inspection before
+  mutation is allowed and required.
+- If a required argument is absent or invalid, return `BLOCKED` with one exact
+  corrected invocation. Do not replace missing input with an approval screen.
 
 ## Resolve authority first
 
@@ -132,7 +137,7 @@ are:
 | Alpha | staging only |
 | Beta | staging, then beta |
 | RC | staging, then beta |
-| Stable | staging, beta acceptance, explicit approval, stable |
+| Stable | staging, beta acceptance, explicit `promote <tag> stable` invocation, stable |
 
 Reject a tag/channel combination that current policy does not allow. If this
 table and the current repository disagree, stop and report the disagreement.
@@ -168,24 +173,29 @@ Produce one exact read-only plan for the selected candidate, tag, class,
 channel, storage target, deliberate `minimum_version`, and current workflow
 head. Name each transition and its evidence prerequisite, but keep the normal
 response compact. Do not dispatch a dry run: a workflow dispatch is not a
-read-only plan.
+read-only plan. Prefer mechanically derived facts over a checklist for the
+operator to re-verify.
 
 ### `publish`
 
 Use only for a new release plan. Reconstruct state and reject candidate drift,
 tag collision, unsupported class/channel posture, missing authored notes, or
-an incomplete exact plan. Present the authorization envelope once. After exact
-authorization, execute only the named plan and its idempotent checks, respecting
-repository-defined GitHub approval gates. Never move, delete, or recreate a
-pushed tag.
+an incomplete exact plan. Mechanically bind and validate the invocation as
+described below, then execute the repository-defined valid transitions toward
+the requested channel without another confirmation. Verify every transition
+before continuing and respect any live repository-defined GitHub environment
+gate. Never move, delete, or recreate a pushed tag.
 
 ### `resume`
 
 This is the preferred mode for a partial release. Rebuild live state, then
-identify and execute at most the one smallest valid next transition covered by
-the exact authorization. Reuse the exact pushed tag and byte-identical existing
-artifacts. Retry a failed gate without rebuilding or republishing completed
-irreversible work merely to make a cleaner receipt.
+identify and execute every currently valid incomplete transition toward the
+exact requested channel. Reuse the exact pushed tag and byte-identical existing
+artifacts. Verify each completed transition before starting the next. Stop at
+the first failed, conflicting, approval-waiting, or genuinely non-automatable
+gate. Do not artificially limit a resume invocation to one transition. Retry a
+failed gate without rebuilding or republishing completed irreversible work
+merely to make a cleaner receipt.
 
 Required distinctions include:
 
@@ -217,8 +227,9 @@ the source manifest, immutable public bytes, current destination manifest,
 release posture, deliberate support floor, and required staging/beta acceptance
 evidence. Use the current manifest workflow; do not invoke artifact builds or
 publication. Alpha cannot promote, beta/RC cannot promote to stable, and stable
-requires both staging and distinct beta acceptance plus explicit stable
-approval under current policy.
+requires both staging and distinct beta acceptance. The explicit
+`promote <tag> stable` invocation is the stable-promotion approval; do not ask
+for a second confirmation.
 
 ## Credential and configuration semantics
 
@@ -244,12 +255,16 @@ credential pairs from memory or old receipts. For a missing credential, say:
 
 Classify a missing configured name as configuration, not a workflow defect. If
 code repair is actually required, stop and report that as a separate next
-action; release authorization never includes patching Baseplate.
+action; invocation authority never includes patching Baseplate.
 
-## Exact authorization gate
+## Invocation authority and deterministic checks
 
-`publish`, `resume`, and `promote` must pause before mutation and request one
-explicit authorization containing all of:
+`publish`, `resume`, and `promote` mutate only when the current invocation
+contains an exact tag and channel. That invocation is the operator
+authorization. Do not ask "are you sure?", present an authorization envelope,
+or emit a paused-for-approval state.
+
+Before the first mutation, mechanically bind and validate:
 
 ```text
 candidate commit: <40-character SHA>
@@ -262,16 +277,31 @@ transition: <exact workflow dispatch or state change, including dry_run posture>
 workflow head: <40-character SHA>
 ```
 
-Use `PAUSED FOR APPROVAL` until the user explicitly approves that exact
-envelope. A vague "continue" from before the envelope is not authorization.
-Once approved, do not add repeated Depot-owned confirmations for internal reads
-or idempotent checks, but continue to respect repository-defined environment
-approvals.
+Resolve `minimum_version` in this order:
 
-Authorization never expands to repairing code/workflows, moving tags, changing
-the support floor, creating credentials, changing the default update channel,
-or altering DNS, firewall, backups, staging topology, Cloudflare configuration,
-unrelated GitHub Projects, or other releases.
+1. an explicit `--minimum-version` value in the current invocation;
+2. for `resume`, the verified input of the release attempt being resumed;
+3. for `promote`, the verified source manifest floor; or
+4. one unambiguous value required by current executable repository policy.
+
+Reject conflicting sources. Validate the selected floor against current tag
+policy, channel rules, manifest-forward-movement rules, and supported-upgrade
+evidence. An explicit flag supplies a product choice; it never overrides those
+checks. If the floor or another bound value cannot be determined mechanically,
+return `BLOCKED` with the exact missing decision and one corrected invocation.
+Do not turn machine-checkable facts into a human review checklist.
+
+A vague `continue` without an exact tag and channel cannot mutate. An exact
+invocation does not need a second approval. Continue to respect an actual live
+GitHub environment wait or other repository-owned approval that the workflow
+itself enforces, and report that external wait plainly instead of adding a
+Depot-owned gate.
+
+Invocation authority never expands to repairing code/workflows, moving tags,
+changing the support floor beyond an explicit validated `--minimum-version`,
+creating credentials, changing the default update channel, altering DNS,
+firewall, backups, staging topology, Cloudflare configuration, unrelated GitHub
+Projects, or other releases.
 
 ## Receipts
 
@@ -287,7 +317,7 @@ Keep the receipt compact:
 - state before and after;
 - workflow URLs and conclusions;
 - public artifact and manifest hashes;
-- exact authorization received;
+- exact invocation mode, tag, channel, and resolved floor;
 - remaining gaps; and
 - commands actually run.
 
@@ -301,7 +331,6 @@ Every response begins with exactly one of:
 ```text
 READY
 IN PROGRESS
-PAUSED FOR APPROVAL
 BLOCKED
 FAILED
 COMPLETE

--- a/plugins/assembly/skills/assembly-release/SKILL.md
+++ b/plugins/assembly/skills/assembly-release/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: assembly-release
 description: Codex skill alias for /assembly-release. Assembly Baseplate release operations for current release state, release planning, failed or stopped release resumption, R2 publication failures, existing assets and manifest recovery when pointers never moved, staging acceptance, and beta or stable promotion
-argument-hint: "[status|plan|publish|resume|promote] [tag] [channel]"
+argument-hint: "[status|plan|publish|resume|promote] [tag] [channel] [--minimum-version <tag>]"
 ---
 
 # Codex Command Alias: /assembly-release
@@ -30,17 +30,22 @@ repository's runbooks and workflows.
 Parse `$ARGUMENTS` as:
 
 ```text
-[status|plan|publish|resume|promote] [tag] [channel]
+[status|plan|publish|resume|promote] [tag] [channel] [--minimum-version <tag>]
 ```
 
 - No arguments means `status`.
 - Accept only `status`, `plan`, `publish`, `resume`, and `promote`.
-- Reject extra or speculative modes.
+- Accept only the optional `--minimum-version <canonical tag>` flag. Reject
+  unknown flags, extra arguments, and speculative modes.
 - `status` and `plan` are read-only. They must not create or move a tag, edit or
   publish a GitHub Release, dispatch a workflow, write a manifest, operate a
   provider, change a deployment, or create a credential.
-- `publish`, `resume`, and `promote` require the exact authorization gate below
-  before their first mutation. Read-only inspection before that gate is allowed.
+- `publish`, `resume`, and `promote` require an exact tag and channel in the
+  current invocation. The invocation is the operator authorization. Do not ask
+  for a second confirmation before mutation. Read-only inspection before
+  mutation is allowed and required.
+- If a required argument is absent or invalid, return `BLOCKED` with one exact
+  corrected invocation. Do not replace missing input with an approval screen.
 
 ## Resolve authority first
 
@@ -147,7 +152,7 @@ are:
 | Alpha | staging only |
 | Beta | staging, then beta |
 | RC | staging, then beta |
-| Stable | staging, beta acceptance, explicit approval, stable |
+| Stable | staging, beta acceptance, explicit `promote <tag> stable` invocation, stable |
 
 Reject a tag/channel combination that current policy does not allow. If this
 table and the current repository disagree, stop and report the disagreement.
@@ -183,24 +188,29 @@ Produce one exact read-only plan for the selected candidate, tag, class,
 channel, storage target, deliberate `minimum_version`, and current workflow
 head. Name each transition and its evidence prerequisite, but keep the normal
 response compact. Do not dispatch a dry run: a workflow dispatch is not a
-read-only plan.
+read-only plan. Prefer mechanically derived facts over a checklist for the
+operator to re-verify.
 
 ### `publish`
 
 Use only for a new release plan. Reconstruct state and reject candidate drift,
 tag collision, unsupported class/channel posture, missing authored notes, or
-an incomplete exact plan. Present the authorization envelope once. After exact
-authorization, execute only the named plan and its idempotent checks, respecting
-repository-defined GitHub approval gates. Never move, delete, or recreate a
-pushed tag.
+an incomplete exact plan. Mechanically bind and validate the invocation as
+described below, then execute the repository-defined valid transitions toward
+the requested channel without another confirmation. Verify every transition
+before continuing and respect any live repository-defined GitHub environment
+gate. Never move, delete, or recreate a pushed tag.
 
 ### `resume`
 
 This is the preferred mode for a partial release. Rebuild live state, then
-identify and execute at most the one smallest valid next transition covered by
-the exact authorization. Reuse the exact pushed tag and byte-identical existing
-artifacts. Retry a failed gate without rebuilding or republishing completed
-irreversible work merely to make a cleaner receipt.
+identify and execute every currently valid incomplete transition toward the
+exact requested channel. Reuse the exact pushed tag and byte-identical existing
+artifacts. Verify each completed transition before starting the next. Stop at
+the first failed, conflicting, approval-waiting, or genuinely non-automatable
+gate. Do not artificially limit a resume invocation to one transition. Retry a
+failed gate without rebuilding or republishing completed irreversible work
+merely to make a cleaner receipt.
 
 Required distinctions include:
 
@@ -232,8 +242,9 @@ the source manifest, immutable public bytes, current destination manifest,
 release posture, deliberate support floor, and required staging/beta acceptance
 evidence. Use the current manifest workflow; do not invoke artifact builds or
 publication. Alpha cannot promote, beta/RC cannot promote to stable, and stable
-requires both staging and distinct beta acceptance plus explicit stable
-approval under current policy.
+requires both staging and distinct beta acceptance. The explicit
+`promote <tag> stable` invocation is the stable-promotion approval; do not ask
+for a second confirmation.
 
 ## Credential and configuration semantics
 
@@ -259,12 +270,16 @@ credential pairs from memory or old receipts. For a missing credential, say:
 
 Classify a missing configured name as configuration, not a workflow defect. If
 code repair is actually required, stop and report that as a separate next
-action; release authorization never includes patching Baseplate.
+action; invocation authority never includes patching Baseplate.
 
-## Exact authorization gate
+## Invocation authority and deterministic checks
 
-`publish`, `resume`, and `promote` must pause before mutation and request one
-explicit authorization containing all of:
+`publish`, `resume`, and `promote` mutate only when the current invocation
+contains an exact tag and channel. That invocation is the operator
+authorization. Do not ask "are you sure?", present an authorization envelope,
+or emit a paused-for-approval state.
+
+Before the first mutation, mechanically bind and validate:
 
 ```text
 candidate commit: <40-character SHA>
@@ -277,16 +292,31 @@ transition: <exact workflow dispatch or state change, including dry_run posture>
 workflow head: <40-character SHA>
 ```
 
-Use `PAUSED FOR APPROVAL` until the user explicitly approves that exact
-envelope. A vague "continue" from before the envelope is not authorization.
-Once approved, do not add repeated Depot-owned confirmations for internal reads
-or idempotent checks, but continue to respect repository-defined environment
-approvals.
+Resolve `minimum_version` in this order:
 
-Authorization never expands to repairing code/workflows, moving tags, changing
-the support floor, creating credentials, changing the default update channel,
-or altering DNS, firewall, backups, staging topology, Cloudflare configuration,
-unrelated GitHub Projects, or other releases.
+1. an explicit `--minimum-version` value in the current invocation;
+2. for `resume`, the verified input of the release attempt being resumed;
+3. for `promote`, the verified source manifest floor; or
+4. one unambiguous value required by current executable repository policy.
+
+Reject conflicting sources. Validate the selected floor against current tag
+policy, channel rules, manifest-forward-movement rules, and supported-upgrade
+evidence. An explicit flag supplies a product choice; it never overrides those
+checks. If the floor or another bound value cannot be determined mechanically,
+return `BLOCKED` with the exact missing decision and one corrected invocation.
+Do not turn machine-checkable facts into a human review checklist.
+
+A vague `continue` without an exact tag and channel cannot mutate. An exact
+invocation does not need a second approval. Continue to respect an actual live
+GitHub environment wait or other repository-owned approval that the workflow
+itself enforces, and report that external wait plainly instead of adding a
+Depot-owned gate.
+
+Invocation authority never expands to repairing code/workflows, moving tags,
+changing the support floor beyond an explicit validated `--minimum-version`,
+creating credentials, changing the default update channel, altering DNS,
+firewall, backups, staging topology, Cloudflare configuration, unrelated GitHub
+Projects, or other releases.
 
 ## Receipts
 
@@ -302,7 +332,7 @@ Keep the receipt compact:
 - state before and after;
 - workflow URLs and conclusions;
 - public artifact and manifest hashes;
-- exact authorization received;
+- exact invocation mode, tag, channel, and resolved floor;
 - remaining gaps; and
 - commands actually run.
 
@@ -316,7 +346,6 @@ Every response begins with exactly one of:
 ```text
 READY
 IN PROGRESS
-PAUSED FOR APPROVAL
 BLOCKED
 FAILED
 COMPLETE

--- a/tools/validate-workflow-contracts.sh
+++ b/tools/validate-workflow-contracts.sh
@@ -175,6 +175,8 @@ persona_verification_runtime="$REPO_ROOT/plugins/workflow-kernel/skills/workflow
 verification_execution="$REPO_ROOT/plugins/workflow-kernel/skills/workflow-kernel/references/workflow_kernel/verification_execution.py"
 repository_verification="$REPO_ROOT/plugins/workflow-kernel/skills/workflow-kernel/references/repository-verification.md"
 assembly_build="$REPO_ROOT/plugins/assembly/commands/assembly-build.md"
+assembly_release="$REPO_ROOT/plugins/assembly/commands/assembly-release.md"
+assembly_release_skill="$REPO_ROOT/plugins/assembly/skills/assembly-release/SKILL.md"
 assembly_test_runner="$REPO_ROOT/plugins/assembly/agents/workflow/go-test-runner.md"
 assembly_go_tests="$REPO_ROOT/plugins/assembly/agents/workflow/go-test-runner.md"
 assembly_verification_profile="$REPO_ROOT/plugins/assembly/references/repository-verification-profile.example.json"
@@ -381,6 +383,25 @@ require_absent "$arch" "Missing Auth Boundary Map Receipt (P2)" "Auth Boundary M
 require_text "$sec" "Public/Private URL Boundary" "security-auditor guards the public/private URL boundary"
 require_text "$sec" "Update / Release Preflight" "security-auditor checks update/release preflight"
 require_text "$sec" "Responder-side share transport" "security-auditor reviews the federation responder side"
+
+printf "\nAssembly release invocation-authority contract:\n"
+for release_surface in "$assembly_release" "$assembly_release_skill"; do
+  release_rel="${release_surface#$REPO_ROOT/}"
+  require_text "$release_surface" "The invocation is the operator authorization." "$release_rel treats the exact invocation as authorization"
+  require_text "$release_surface" "second confirmation before mutation" "$release_rel removes redundant confirmation prompts"
+  require_text "$release_surface" "exact tag and channel" "$release_rel requires bounded mutating input"
+  require_text "$release_surface" "execute every currently valid incomplete transition" "$release_rel resumes all valid incomplete work"
+  require_text "$release_surface" "Do not artificially limit a resume invocation to one transition." "$release_rel rejects one-step resume churn"
+  require_text "$release_surface" "stable-promotion approval; do not ask" "$release_rel makes stable intent explicit once"
+  require_text "$release_surface" "Before the first mutation, mechanically bind and validate:" "$release_rel keeps deterministic pre-mutation validation"
+  require_text "$release_surface" "Do not turn machine-checkable facts into a human review checklist." "$release_rel prefers code validation"
+  require_text "$release_surface" 'return `BLOCKED` with the exact missing decision and one corrected invocation' "$release_rel blocks only on a concrete unresolved decision"
+  require_text "$release_surface" "GitHub environment wait or other repository-owned approval" "$release_rel preserves repository-owned external gates"
+  require_absent "$release_surface" "## Exact authorization gate" "$release_rel removes the Depot authorization gate"
+  require_absent "$release_surface" "PAUSED FOR APPROVAL" "$release_rel removes the paused-for-approval state"
+  require_absent "$release_surface" "Present the authorization envelope once" "$release_rel removes the authorization envelope"
+  require_absent "$release_surface" "at most the one smallest valid next transition" "$release_rel removes the one-transition resume cap"
+done
 
 # --------------------------------------------------------------------------
 # Group 4: Workflow-kernel integration anchors


### PR DESCRIPTION
## Summary

- treat an exact `publish`, `resume`, or `promote` invocation as the operator authorization
- replace repeated approval envelopes with deterministic tag, artifact, workflow, manifest, and support-floor validation
- let `resume` complete every currently valid transition toward the requested channel instead of stopping after one step
- preserve actual repository-owned GitHub environment waits and fail-closed release conflicts
- add workflow-contract regression checks for the canonical Claude command and generated Codex skill
- bump Assembly from 3.11.0 to 3.12.0 and regenerate manifests, alias, and search index

## Validation

- `./tools/eval-descriptions.sh assembly-assembly-release.json` (16/16, 100%)
- `./tools/generate-codex-command-skills.py --check`
- `./tools/generate-codex-manifests.py --check`
- `./tools/check-dependencies.sh`
- `./tools/validate-dual-compat.sh`
- `./tools/validate-workflow-contracts.sh`
- `./tools/validate-composition.sh --all`
- `git diff --check`

No Assembly Baseplate code, workflows, environment settings, tags, releases, manifests, or deployments were changed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Design-Machines-Studio/codesmith/depot/pr/72"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789422014&installation_model_id=428410&pr_number=72&repository=Design-Machines-Studio%2Fdepot&return_to=https%3A%2F%2Fgithub.com%2FDesign-Machines-Studio%2Fdepot%2Fpull%2F72&signature=b5461a4daa4c6455badf94ea093ed850345e5b2c9775a9779b90943e1f3e8204"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->