### PR TITLE
chore(openrouter): refresh 2026-08-21 model pulse

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -361,7 +361,7 @@
     {
       "name": "pipeline",
       "source": "./plugins/pipeline",
-      "version": "1.56.0",
+      "version": "1.56.1",
       "author": {
         "name": "Design Machines",
         "url": "https://designmachines.studio"

--- a/docs/openrouter-model-matrix-refreshes/2026-08-21.md
+++ b/docs/openrouter-model-matrix-refreshes/2026-08-21.md
@@ -1,0 +1,77 @@
+# OpenRouter model matrix refresh — 2026-08-21
+
+## Catalog receipt
+
+- Exact saved official catalog snapshot: `/home/ned/.local/state/openrouter-model-pulse/catalog/models-2026-08-21T092022+0800.json`
+- Snapshot timestamp: `2026-08-21T09:20:22+08:00`
+- Catalog source recorded by the snapshot: `https://openrouter.ai/api/v1/models`
+- Network catalog fetches: **zero**. This refresh used only the saved snapshot.
+- Price unit: USD per million tokens. “Unavailable” and `null` are catalog
+  values, not estimates. Per-request limits are `null` for every candidate.
+
+| Catalog ID | Canonical identity | Input / output / cache read / cache write | Context / top provider / max output | Moderated | Reasoning requirement | Supported parameters |
+|---|---|---:|---:|---|---|---|
+| `deepseek/deepseek-v4-flash-0731` | `deepseek/deepseek-v4-flash-20260731` | $0.14 / $0.28 / $0.028 / $unavailable | 1310720 / 1048576 / 393216 | false | mandatory=unavailable, default=high | `frequency_penalty`, `include_reasoning`, `logit_bias`, `logprobs`, `max_tokens`, `min_p`, `parallel_tool_calls`, `presence_penalty`, `reasoning`, `reasoning_effort`, `repetition_penalty`, `response_format`, `seed`, `stop`, `structured_outputs`, `temperature`, `tool_choice`, `tools`, `top_a`, `top_k`, `top_logprobs`, `top_p` |
+| `deepseek/deepseek-v4-pro-0813` | `deepseek/deepseek-v4-pro-20260813` | $1.188 / $3.564 / $0.0396 / $unavailable | 1048576 / 1048575 / unavailable | false | mandatory=unavailable, default=high | `frequency_penalty`, `include_reasoning`, `logit_bias`, `logprobs`, `max_tokens`, `min_p`, `presence_penalty`, `reasoning`, `reasoning_effort`, `repetition_penalty`, `response_format`, `seed`, `stop`, `structured_outputs`, `temperature`, `tool_choice`, `tools`, `top_k`, `top_logprobs`, `top_p` |
+| `qwen/qwen3.8-max` | `qwen/qwen3.8-max-20260803` | $2 / $6 / $0.25 / $2.5 | 1000000 / 1000000 / 131072 | false | mandatory=true, default=xhigh | `frequency_penalty`, `include_reasoning`, `logprobs`, `max_tokens`, `presence_penalty`, `reasoning`, `reasoning_effort`, `response_format`, `seed`, `stop`, `structured_outputs`, `temperature`, `tool_choice`, `tools`, `top_k`, `top_logprobs`, `top_p` |
+| `qwen/qwen3.8-2.4t-a95b` | `qwen/qwen3.8-2.4t-a95b-20260812` | $2 / $6 / $0.25 / $unavailable | 1048576 / 1000000 / 262144 | false | mandatory=true, default=xhigh | `frequency_penalty`, `include_reasoning`, `logit_bias`, `logprobs`, `max_tokens`, `min_p`, `presence_penalty`, `reasoning`, `reasoning_effort`, `repetition_penalty`, `response_format`, `seed`, `stop`, `structured_outputs`, `temperature`, `tool_choice`, `tools`, `top_k`, `top_logprobs`, `top_p` |
+| `qwen/qwen3.8-27b` | `qwen/qwen3.8-27b-20260814` | $0.45 / $3.2 / $0.05 / $unavailable | 1000000 / 262144 / 131072 | false | mandatory=unavailable, default=xhigh | `frequency_penalty`, `include_reasoning`, `logit_bias`, `logprobs`, `max_tokens`, `presence_penalty`, `reasoning`, `reasoning_effort`, `repetition_penalty`, `response_format`, `seed`, `stop`, `structured_outputs`, `temperature`, `tool_choice`, `tools`, `top_k`, `top_logprobs`, `top_p` |
+| `qwen/qwen3.7-flash` | `qwen/qwen3.7-flash-20260727` | $0.03 / $0.13 / $0.006 / $0.038 | 1000000 / 1000000 / 65536 | false | mandatory=unavailable, default=unavailable | `include_reasoning`, `logprobs`, `max_tokens`, `presence_penalty`, `reasoning`, `response_format`, `seed`, `temperature`, `tool_choice`, `tools`, `top_logprobs`, `top_p` |
+| `x-ai/grok-4.6` | `x-ai/grok-4.6-20260810` | $2 / $6 / $0.5 / $unavailable | 500000 / 500000 / unavailable | false | mandatory=true, default=high | `include_reasoning`, `logprobs`, `max_tokens`, `reasoning`, `reasoning_effort`, `response_format`, `seed`, `structured_outputs`, `temperature`, `tool_choice`, `tools`, `top_logprobs`, `top_p` |
+| `google/gemini-3.7-flash` | `google/gemini-3.7-flash-20260813` | $0.375 / $1.875 / $0.0375 / $0.020833 | 1048576 / 1048576 / 65536 | false | mandatory=true, default=medium | `include_reasoning`, `max_tokens`, `reasoning`, `reasoning_effort`, `response_format`, `seed`, `stop`, `structured_outputs`, `temperature`, `tool_choice`, `tools`, `top_p` |
+| `meta/muse-spark-1.2` | `meta/muse-spark-1.2-20260805` | $1.25 / $4.25 / $0.15 / $unavailable | 1048576 / 1048576 / unavailable | true | mandatory=true, default=medium | `include_reasoning`, `max_tokens`, `reasoning`, `reasoning_effort`, `repetition_penalty`, `response_format`, `structured_outputs`, `temperature`, `tool_choice`, `tools`, `top_k`, `top_p` |
+| `z-ai/glm-5.2` | `z-ai/glm-5.2-20260616` | $0.966 / $3.036 / $0.1932 / $unavailable | 1048576 / 1048576 / 131072 | false | mandatory=unavailable, default=high | `frequency_penalty`, `include_reasoning`, `logit_bias`, `logprobs`, `max_tokens`, `min_p`, `parallel_tool_calls`, `presence_penalty`, `reasoning`, `reasoning_effort`, `repetition_penalty`, `response_format`, `seed`, `stop`, `structured_outputs`, `temperature`, `tool_choice`, `tools`, `top_k`, `top_logprobs`, `top_p` |
+| `moonshotai/kimi-k3` | `moonshotai/kimi-k3-20260715` | $3 / $15 / $0.3 / $unavailable | 1048576 / 1048576 / unavailable | false | mandatory=unavailable, default=max | `frequency_penalty`, `include_reasoning`, `logit_bias`, `logprobs`, `max_tokens`, `min_p`, `presence_penalty`, `reasoning`, `reasoning_effort`, `repetition_penalty`, `response_format`, `seed`, `stop`, `structured_outputs`, `temperature`, `tool_choice`, `tools`, `top_k`, `top_logprobs`, `top_p` |
+| `openai/gpt-5.6-luna` | `openai/gpt-5.6-luna-20260709` | $0.2 / $1.2 / $0.02 / $0.25 | 1050000 / 1050000 / 128000 | true | mandatory=unavailable, default=medium | `include_reasoning`, `max_completion_tokens`, `max_tokens`, `reasoning`, `reasoning_effort`, `response_format`, `seed`, `structured_outputs`, `tool_choice`, `tools` |
+| `openai/gpt-5.6-terra` | `openai/gpt-5.6-terra-20260709` | $2 / $12 / $0.2 / $2.5 | 1050000 / 1050000 / 128000 | true | mandatory=unavailable, default=medium | `include_reasoning`, `max_completion_tokens`, `max_tokens`, `reasoning`, `reasoning_effort`, `response_format`, `seed`, `structured_outputs`, `tool_choice`, `tools` |
+| `z-ai/glm-5.3` | `z-ai/glm-5.3-20260816` | $1.4 / $4.4 / $0.26 / $unavailable | 1048576 / 1048576 / 131072 | false | mandatory=true, default=max | `include_reasoning`, `max_tokens`, `reasoning`, `reasoning_effort`, `response_format`, `temperature`, `tool_choice`, `tools`, `top_k`, `top_p` |
+
+## Price overrides and explicit absences
+
+The snapshot has no DeepSeek Pro 0813 price override. Its base price is
+$1.188 / $3.564 / $0.0396 cache read, and its top-provider max output is
+unavailable. The retained old time-window override schedule is removed.
+
+| Catalog ID | Threshold | Input / output / cache read / cache write |
+|---|---:|---:|
+| `qwen/qwen3.7-flash` | 32,000 prompt tokens | $0.10 / $0.40 / $0.02 / $0.125 |
+| `qwen/qwen3.7-flash` | 256,000 prompt tokens | $0.20 / $0.80 / $0.04 / $0.25 |
+| `x-ai/grok-4.6` | 200,000 prompt tokens | $4 / $12 / $1 / unavailable |
+| `openai/gpt-5.6-luna` | 272,000 prompt tokens | $0.40 / $1.80 / $0.04 / $0.50 |
+| `openai/gpt-5.6-terra` | 272,000 prompt tokens | $4 / $18 / $0.40 / $5 |
+
+The material catalog deltas include DeepSeek Pro 0813’s increased base and
+cache-read price with its now-unavailable top-provider output limit; GLM 5.2’s
+$0.966/$3.036/$0.1932 pricing; Luna’s $0.20/$1.20 base and $0.02/$0.25 cache
+pricing; and Terra’s $2/$12 base and $0.20/$2.50 cache pricing. The table above
+records every current override, including the >=20% Luna and Terra override
+changes, rather than extrapolating from prior values.
+
+## GLM 5.3
+
+`z-ai/glm-5.3` is catalogued as canonical
+`z-ai/glm-5.3-20260816`, with mandatory reasoning enabled by default at
+`max`. Its catalog-reported benchmark values and vendor claims are
+uncorroborated claims, not routing authority. It is **catalogued-not-routed**:
+there is no default role, no Pipeline rung, and no dm-review route. A future
+successful single call cannot change that status.
+
+## Authorized canary receipt
+
+The approved cap was at most four one-shot, content-safe calls, with
+`OPENROUTER_ALLOW_FALLBACKS=0`, no retries, no model fallback, concise
+output limits, and a US$1 cumulative ceiling. No `OPENROUTER_API_KEY` or
+`OPENROUTER_API_KEY_FILE` was configured in this worktree session, so no
+request was attempted and no transport was opened. This stops before any spend;
+it does not infer model quality or make any routing change.
+
+| Model / intended scope | Attempts | Cost | Latency | Validity / verbosity / usefulness | Transport failure |
+|---|---:|---:|---:|---|---|
+| `deepseek/deepseek-v4-flash-0731` routine review | 0 | $0 | unavailable | not assessed; fixture not transmitted | not attempted: no configured credential |
+| `deepseek/deepseek-v4-pro-0813` long-context/pattern analysis | 0 | $0 | unavailable | not assessed; fixture not transmitted | not attempted: no configured credential |
+| `qwen/qwen3.8-max` control | 0 | $0 | unavailable | not assessed; fixture not transmitted | not attempted: no configured credential |
+| `z-ai/glm-5.3` bounded judgment fixture | 0 | $0 | unavailable | not assessed; fixture not transmitted | not attempted: no configured credential |
+
+Actual cumulative spend: **$0.00**. The receipt deliberately preserves the
+remaining fields as unavailable rather than fabricating a canary outcome.
+

--- a/plugins/openrouter/skills/openrouter-delegate/references/model-matrix.json
+++ b/plugins/openrouter/skills/openrouter-delegate/references/model-matrix.json
@@ -1,8 +1,8 @@
 {
   "_comment": "CANONICAL machine-readable OpenRouter model matrix. This file records current catalog evidence and compatibility quality floors; ordered role lists in routing-policy.json and harness-profile.json are the routing authority. Native Codex identities and native Claude aliases are absent from routing models. native_api_equivalent_cost is observation-only pricing evidence and never routing authority. anthropic/* routing slugs are rejected before provider contact.",
   "schema_version": 1,
-  "snapshot_date": "2026-08-17",
-  "catalog_observed_at": "2026-08-17T00:26:07Z",
+  "snapshot_date": "2026-08-21",
+  "catalog_observed_at": "2026-08-21T09:20:22+08:00",
   "catalog_source": "https://openrouter.ai/api/v1/models",
   "native_api_equivalent_cost": {
     "schema_version": 1,
@@ -21,7 +21,9 @@
         "cache_read_usd_per_m": 0.5,
         "snapshot_date": "2026-08-12",
         "pricing_basis": "API-equivalent planning estimate; never billed subscription spend",
-        "sources": ["https://developers.openai.com/api/docs/models/gpt-5.6-sol"]
+        "sources": [
+          "https://developers.openai.com/api/docs/models/gpt-5.6-sol"
+        ]
       },
       {
         "slug": "openai/gpt-5.6-terra-native-api-equivalent",
@@ -30,7 +32,9 @@
         "cache_read_usd_per_m": 0.2,
         "snapshot_date": "2026-08-12",
         "pricing_basis": "API-equivalent planning estimate; never billed subscription spend",
-        "sources": ["https://developers.openai.com/api/docs/models/gpt-5.6-terra"]
+        "sources": [
+          "https://developers.openai.com/api/docs/models/gpt-5.6-terra"
+        ]
       },
       {
         "slug": "openai/gpt-5.6-luna-native-api-equivalent",
@@ -39,7 +43,9 @@
         "cache_read_usd_per_m": 0.02,
         "snapshot_date": "2026-08-12",
         "pricing_basis": "API-equivalent planning estimate; never billed subscription spend",
-        "sources": ["https://developers.openai.com/api/docs/models/gpt-5.6-luna"]
+        "sources": [
+          "https://developers.openai.com/api/docs/models/gpt-5.6-luna"
+        ]
       }
     ]
   },
@@ -48,8 +54,14 @@
   "refresh_protocol": {
     "cadence": "On demand, and before any paid or policy-changing run.",
     "routing": {
-      "owned_snapshot_paths": ["snapshot_date", "models[*].snapshot_date"],
-      "preserved_snapshot_paths": ["native_api_equivalent_cost.snapshot_date", "native_api_equivalent_cost.models[*].snapshot_date"],
+      "owned_snapshot_paths": [
+        "snapshot_date",
+        "models[*].snapshot_date"
+      ],
+      "preserved_snapshot_paths": [
+        "native_api_equivalent_cost.snapshot_date",
+        "native_api_equivalent_cost.models[*].snapshot_date"
+      ],
       "price_context_availability_source": "OpenRouter live API. Record a receipt whose observedAt and expiresAt are no more than freshness_rule_minutes apart, and use it only before expiry.",
       "quality_source": "A named external evaluation source with its dataset version recorded in benchmark_evidence. Missing comparable benchmark values remain null; quality_rank is only a compatibility floor.",
       "on_refresh": [
@@ -61,8 +73,14 @@
       "documented_in": "model-selection.md -- Refreshing the routing matrix"
     },
     "native_api_equivalent_cost": {
-      "owned_snapshot_paths": ["native_api_equivalent_cost.snapshot_date", "native_api_equivalent_cost.models[*].snapshot_date"],
-      "preserved_snapshot_paths": ["snapshot_date", "models[*].snapshot_date"],
+      "owned_snapshot_paths": [
+        "native_api_equivalent_cost.snapshot_date",
+        "native_api_equivalent_cost.models[*].snapshot_date"
+      ],
+      "preserved_snapshot_paths": [
+        "snapshot_date",
+        "models[*].snapshot_date"
+      ],
       "price_source": "Use only the cited source for each changed price or alias and record the observation date.",
       "on_refresh": [
         "Bump native_api_equivalent_cost.snapshot_date and each changed native-only model entry only when its evidence was independently refreshed.",
@@ -74,8 +92,16 @@
     }
   },
   "receipt_contract": {
-    "required_fields": ["matrix_snapshot_date", "rung_rationale"],
-    "rung_rationale_axes": ["cost", "context", "strength", "availability"],
+    "required_fields": [
+      "matrix_snapshot_date",
+      "rung_rationale"
+    ],
+    "rung_rationale_axes": [
+      "cost",
+      "context",
+      "strength",
+      "availability"
+    ],
     "statement": "Every routing decision recorded in a run receipt must carry matrix_snapshot_date and a one-line rung_rationale naming the deciding axis."
   },
   "models": [
@@ -88,21 +114,77 @@
       "input_usd_per_m": 0.14,
       "output_usd_per_m": 0.28,
       "cache_read_usd_per_m": 0.028,
-      "context_tokens": 1048576,
+      "context_tokens": 1310720,
       "top_provider_context_tokens": 1048576,
       "top_provider_max_completion_tokens": 393216,
       "per_request_limits": null,
-      "input_modalities": ["text"],
+      "input_modalities": [
+        "text"
+      ],
       "supports_tools": true,
       "supports_reasoning": true,
       "supports_reasoning_effort": true,
       "supports_structured_outputs": true,
       "quality_rank": 90,
-      "benchmark_evidence": {"source": "artificial-analysis", "source_version": "v4.1.1", "exact_variant": "DeepSeek V4 Flash 0731 (reasoning, max effort)", "intelligence": 52.0, "observed_on": "2026-08-12", "status": "retained-prior-comparable-evidence"},
+      "benchmark_evidence": {
+        "source": "artificial-analysis",
+        "source_version": "v4.1.1",
+        "exact_variant": "DeepSeek V4 Flash 0731 (reasoning, max effort)",
+        "intelligence": 52.0,
+        "observed_on": "2026-08-12",
+        "status": "retained-prior-comparable-evidence"
+      },
       "local_evidence": "2026-08-17 canary reached OpenRouter once and failed with HTTP 429 before output; this does not disprove the executor contract.",
       "role": "Primary cheap bounded Pipeline executor and primary routine documentation/test review model. Codex remains the supervisor for scope, correctness, UI, integration, live tools, and sensitive work.",
-      "snapshot_date": "2026-08-17",
-      "sources": ["https://openrouter.ai/deepseek/deepseek-v4-flash-0731", "https://api-docs.deepseek.com/news/news260424/", "https://artificialanalysis.ai/models/deepseek-v4-flash"]
+      "snapshot_date": "2026-08-21",
+      "sources": [
+        "https://openrouter.ai/deepseek/deepseek-v4-flash-0731",
+        "https://api-docs.deepseek.com/news/news260424/",
+        "https://artificialanalysis.ai/models/deepseek-v4-flash"
+      ],
+      "canonical_slug": "deepseek/deepseek-v4-flash-20260731",
+      "cache_write_usd_per_m": null,
+      "web_search_usd_per_request": null,
+      "top_provider_is_moderated": false,
+      "pricing_overrides": null,
+      "output_modalities": [
+        "text"
+      ],
+      "supported_parameters": [
+        "frequency_penalty",
+        "include_reasoning",
+        "logit_bias",
+        "logprobs",
+        "max_tokens",
+        "min_p",
+        "parallel_tool_calls",
+        "presence_penalty",
+        "reasoning",
+        "reasoning_effort",
+        "repetition_penalty",
+        "response_format",
+        "seed",
+        "stop",
+        "structured_outputs",
+        "temperature",
+        "tool_choice",
+        "tools",
+        "top_a",
+        "top_k",
+        "top_logprobs",
+        "top_p"
+      ],
+      "reasoning": {
+        "mandatory": false,
+        "default_enabled": true,
+        "supported_efforts": [
+          "max",
+          "high",
+          "low"
+        ],
+        "default_effort": "high"
+      },
+      "default_parameters": {}
     },
     {
       "slug": "deepseek/deepseek-v4-pro-0813",
@@ -110,30 +192,77 @@
       "catalog_name": "DeepSeek: DeepSeek V4 Pro 0813",
       "catalog_status": "available",
       "recommendation_status": "provisional-long-context-pattern-analysis",
-      "input_usd_per_m": 0.66,
-      "output_usd_per_m": 1.98,
-      "cache_read_usd_per_m": 0.022,
+      "input_usd_per_m": 1.188,
+      "output_usd_per_m": 3.564,
+      "cache_read_usd_per_m": 0.0396,
       "context_tokens": 1048576,
-      "top_provider_context_tokens": 1048576,
-      "top_provider_max_completion_tokens": 384000,
+      "top_provider_context_tokens": 1048575,
+      "top_provider_max_completion_tokens": null,
       "per_request_limits": null,
-      "pricing_overrides": [
-        {"utc_start": 1000, "utc_end": 100, "input_usd_per_m": 0.66, "output_usd_per_m": 1.98, "cache_read_usd_per_m": 0.022},
-        {"utc_start": 100, "utc_end": 400, "input_usd_per_m": 1.32, "output_usd_per_m": 3.96, "cache_read_usd_per_m": 0.044},
-        {"utc_start": 400, "utc_end": 600, "input_usd_per_m": 0.66, "output_usd_per_m": 1.98, "cache_read_usd_per_m": 0.022},
-        {"utc_start": 600, "utc_end": 1000, "input_usd_per_m": 1.32, "output_usd_per_m": 3.96, "cache_read_usd_per_m": 0.044}
+      "pricing_overrides": null,
+      "input_modalities": [
+        "text"
       ],
-      "input_modalities": ["text"],
       "supports_tools": true,
       "supports_reasoning": true,
       "supports_reasoning_effort": true,
       "supports_structured_outputs": true,
       "quality_rank": 92,
-      "benchmark_evidence": {"source": "DeepSeek V4 release notes", "source_version": "2026-04-24", "exact_variant": null, "status": "vendor-family-claims-only; no comparable exact-0813 score located"},
+      "benchmark_evidence": {
+        "source": "DeepSeek V4 release notes",
+        "source_version": "2026-04-24",
+        "exact_variant": null,
+        "status": "vendor-family-claims-only; no comparable exact-0813 score located"
+      },
       "local_evidence": "2026-08-17 canary produced a valid seven-line minimal unified diff in 7 seconds; 125 prompt, 709 completion, 661 reasoning tokens; $0.00297264.",
       "role": "Provisional long-context and pattern-analysis primary, plus bulk-analysis fallback after a different-family Qwen primary.",
-      "snapshot_date": "2026-08-17",
-      "sources": ["https://openrouter.ai/deepseek/deepseek-v4-pro-0813", "https://api-docs.deepseek.com/news/news260424/"]
+      "snapshot_date": "2026-08-21",
+      "sources": [
+        "https://openrouter.ai/deepseek/deepseek-v4-pro-0813",
+        "https://api-docs.deepseek.com/news/news260424/"
+      ],
+      "canonical_slug": "deepseek/deepseek-v4-pro-20260813",
+      "cache_write_usd_per_m": null,
+      "web_search_usd_per_request": null,
+      "top_provider_is_moderated": false,
+      "output_modalities": [
+        "text"
+      ],
+      "supported_parameters": [
+        "frequency_penalty",
+        "include_reasoning",
+        "logit_bias",
+        "logprobs",
+        "max_tokens",
+        "min_p",
+        "presence_penalty",
+        "reasoning",
+        "reasoning_effort",
+        "repetition_penalty",
+        "response_format",
+        "seed",
+        "stop",
+        "structured_outputs",
+        "temperature",
+        "tool_choice",
+        "tools",
+        "top_k",
+        "top_logprobs",
+        "top_p"
+      ],
+      "reasoning": {
+        "mandatory": false,
+        "supported_efforts": [
+          "max",
+          "high",
+          "low"
+        ],
+        "default_effort": "high"
+      },
+      "default_parameters": {
+        "temperature": 1,
+        "top_p": 1
+      }
     },
     {
       "slug": "qwen/qwen3.8-max",
@@ -141,25 +270,76 @@
       "catalog_name": "Qwen: Qwen3.8 Max",
       "catalog_status": "available",
       "recommendation_status": "active-independent-bulk-and-complex-review",
-      "input_usd_per_m": 2.0,
-      "output_usd_per_m": 6.0,
+      "input_usd_per_m": 2,
+      "output_usd_per_m": 6,
       "cache_read_usd_per_m": 0.25,
       "cache_write_usd_per_m": 2.5,
       "context_tokens": 1000000,
       "top_provider_context_tokens": 1000000,
       "top_provider_max_completion_tokens": 131072,
       "per_request_limits": null,
-      "input_modalities": ["text", "image", "video"],
+      "input_modalities": [
+        "text",
+        "image",
+        "video"
+      ],
       "supports_tools": true,
       "supports_reasoning": true,
       "supports_reasoning_effort": true,
       "supports_structured_outputs": true,
       "quality_rank": 96,
-      "benchmark_evidence": {"source": "Qwen Code release notes", "source_version": "2026-07-23", "exact_variant": "qwen3.8-max-preview", "status": "availability/adapter evidence only; no comparable benchmark score located"},
+      "benchmark_evidence": {
+        "source": "Qwen Code release notes",
+        "source_version": "2026-07-23",
+        "exact_variant": "qwen3.8-max-preview",
+        "status": "availability/adapter evidence only; no comparable benchmark score located"
+      },
       "local_evidence": "2026-08-17 canary found the seeded arithmetic defect in the required one-line format in 5 seconds; 203 prompt, 174 completion, 138 reasoning tokens; $0.00145.",
       "role": "Primary independent bulk review, code-simplicity review, and OpenRouter second perspective for complex judgment when family independence permits.",
-      "snapshot_date": "2026-08-17",
-      "sources": ["https://openrouter.ai/qwen/qwen3.8-max", "https://qwenlm.github.io/qwen-code-docs/en/blog/updates/weekly-update-2026-07-23/"]
+      "snapshot_date": "2026-08-21",
+      "sources": [
+        "https://openrouter.ai/qwen/qwen3.8-max",
+        "https://qwenlm.github.io/qwen-code-docs/en/blog/updates/weekly-update-2026-07-23/"
+      ],
+      "canonical_slug": "qwen/qwen3.8-max-20260803",
+      "web_search_usd_per_request": null,
+      "top_provider_is_moderated": false,
+      "pricing_overrides": null,
+      "output_modalities": [
+        "text"
+      ],
+      "supported_parameters": [
+        "frequency_penalty",
+        "include_reasoning",
+        "logprobs",
+        "max_tokens",
+        "presence_penalty",
+        "reasoning",
+        "reasoning_effort",
+        "response_format",
+        "seed",
+        "stop",
+        "structured_outputs",
+        "temperature",
+        "tool_choice",
+        "tools",
+        "top_k",
+        "top_logprobs",
+        "top_p"
+      ],
+      "reasoning": {
+        "mandatory": true,
+        "default_enabled": true,
+        "supported_efforts": [
+          "xhigh",
+          "high",
+          "medium",
+          "low",
+          "minimal"
+        ],
+        "default_effort": "xhigh"
+      },
+      "default_parameters": {}
     },
     {
       "slug": "qwen/qwen3.8-2.4t-a95b",
@@ -167,14 +347,16 @@
       "catalog_name": "Qwen: Qwen3.8 2.4T A95B",
       "catalog_status": "available",
       "recommendation_status": "catalogued-not-routed",
-      "input_usd_per_m": 2.0,
-      "output_usd_per_m": 6.0,
+      "input_usd_per_m": 2,
+      "output_usd_per_m": 6,
       "cache_read_usd_per_m": 0.25,
       "context_tokens": 1048576,
       "top_provider_context_tokens": 1000000,
       "top_provider_max_completion_tokens": 262144,
       "per_request_limits": null,
-      "input_modalities": ["text", "image", "video"],
+      "input_modalities": [
+        "text"
+      ],
       "supports_tools": true,
       "supports_reasoning": true,
       "supports_reasoning_effort": true,
@@ -183,8 +365,55 @@
       "benchmark_evidence": null,
       "local_evidence": "No local call authorized for this refresh.",
       "role": "Catalogued candidate only; Qwen3.8 Max owns the active Qwen review seat.",
-      "snapshot_date": "2026-08-17",
-      "sources": ["https://openrouter.ai/qwen/qwen3.8-2.4t-a95b"]
+      "snapshot_date": "2026-08-21",
+      "sources": [
+        "https://openrouter.ai/qwen/qwen3.8-2.4t-a95b"
+      ],
+      "canonical_slug": "qwen/qwen3.8-2.4t-a95b-20260812",
+      "cache_write_usd_per_m": null,
+      "web_search_usd_per_request": null,
+      "top_provider_is_moderated": false,
+      "pricing_overrides": null,
+      "output_modalities": [
+        "text"
+      ],
+      "supported_parameters": [
+        "frequency_penalty",
+        "include_reasoning",
+        "logit_bias",
+        "logprobs",
+        "max_tokens",
+        "min_p",
+        "presence_penalty",
+        "reasoning",
+        "reasoning_effort",
+        "repetition_penalty",
+        "response_format",
+        "seed",
+        "stop",
+        "structured_outputs",
+        "temperature",
+        "tool_choice",
+        "tools",
+        "top_k",
+        "top_logprobs",
+        "top_p"
+      ],
+      "reasoning": {
+        "mandatory": true,
+        "default_enabled": true,
+        "supported_efforts": [
+          "xhigh",
+          "medium",
+          "low"
+        ],
+        "default_effort": "xhigh"
+      },
+      "default_parameters": {
+        "temperature": 1,
+        "top_p": 0.95,
+        "top_k": 20
+      }
     },
     {
       "slug": "qwen/qwen3.8-27b",
@@ -195,11 +424,15 @@
       "input_usd_per_m": 0.45,
       "output_usd_per_m": 3.2,
       "cache_read_usd_per_m": 0.05,
-      "context_tokens": 262144,
+      "context_tokens": 1000000,
       "top_provider_context_tokens": 262144,
       "top_provider_max_completion_tokens": 131072,
       "per_request_limits": null,
-      "input_modalities": ["text", "image", "video"],
+      "input_modalities": [
+        "text",
+        "image",
+        "video"
+      ],
       "supports_tools": true,
       "supports_reasoning": true,
       "supports_reasoning_effort": true,
@@ -208,8 +441,54 @@
       "benchmark_evidence": null,
       "local_evidence": "No local call authorized for this refresh.",
       "role": "Catalogued compact candidate only; its 262K context does not displace the active Qwen3.8 Max seat.",
-      "snapshot_date": "2026-08-17",
-      "sources": ["https://openrouter.ai/qwen/qwen3.8-27b"]
+      "snapshot_date": "2026-08-21",
+      "sources": [
+        "https://openrouter.ai/qwen/qwen3.8-27b"
+      ],
+      "canonical_slug": "qwen/qwen3.8-27b-20260814",
+      "cache_write_usd_per_m": null,
+      "web_search_usd_per_request": null,
+      "top_provider_is_moderated": false,
+      "pricing_overrides": null,
+      "output_modalities": [
+        "text"
+      ],
+      "supported_parameters": [
+        "frequency_penalty",
+        "include_reasoning",
+        "logit_bias",
+        "logprobs",
+        "max_tokens",
+        "presence_penalty",
+        "reasoning",
+        "reasoning_effort",
+        "repetition_penalty",
+        "response_format",
+        "seed",
+        "stop",
+        "structured_outputs",
+        "temperature",
+        "tool_choice",
+        "tools",
+        "top_k",
+        "top_logprobs",
+        "top_p"
+      ],
+      "reasoning": {
+        "mandatory": false,
+        "default_enabled": true,
+        "supported_efforts": [
+          "xhigh",
+          "medium",
+          "low"
+        ],
+        "default_effort": "xhigh"
+      },
+      "default_parameters": {
+        "temperature": 1,
+        "top_p": 0.95,
+        "top_k": 20
+      }
     },
     {
       "slug": "qwen/qwen3.7-flash",
@@ -226,10 +505,26 @@
       "top_provider_max_completion_tokens": 65536,
       "per_request_limits": null,
       "pricing_overrides": [
-        {"min_prompt_tokens": 32000, "input_usd_per_m": 0.1, "output_usd_per_m": 0.4, "cache_read_usd_per_m": 0.02, "cache_write_usd_per_m": 0.125},
-        {"min_prompt_tokens": 256000, "input_usd_per_m": 0.2, "output_usd_per_m": 0.8, "cache_read_usd_per_m": 0.04, "cache_write_usd_per_m": 0.25}
+        {
+          "min_prompt_tokens": 32000,
+          "prompt": 0.1,
+          "completion": 0.4,
+          "input_cache_read": 0.02,
+          "input_cache_write": 0.125
+        },
+        {
+          "min_prompt_tokens": 256000,
+          "prompt": 0.2,
+          "completion": 0.8,
+          "input_cache_read": 0.04,
+          "input_cache_write": 0.25
+        }
       ],
-      "input_modalities": ["text", "image", "video"],
+      "input_modalities": [
+        "text",
+        "image",
+        "video"
+      ],
       "supports_tools": true,
       "supports_reasoning": true,
       "supports_reasoning_effort": false,
@@ -238,8 +533,43 @@
       "benchmark_evidence": null,
       "local_evidence": "No local call authorized for this refresh.",
       "role": "Catalogued economical candidate only; it lacks the active routed models' complete parameter contract.",
-      "snapshot_date": "2026-08-17",
-      "sources": ["https://openrouter.ai/qwen/qwen3.7-flash"]
+      "snapshot_date": "2026-08-21",
+      "sources": [
+        "https://openrouter.ai/qwen/qwen3.7-flash"
+      ],
+      "canonical_slug": "qwen/qwen3.7-flash-20260727",
+      "web_search_usd_per_request": null,
+      "top_provider_is_moderated": false,
+      "output_modalities": [
+        "text"
+      ],
+      "supported_parameters": [
+        "include_reasoning",
+        "logprobs",
+        "max_tokens",
+        "presence_penalty",
+        "reasoning",
+        "response_format",
+        "seed",
+        "temperature",
+        "tool_choice",
+        "tools",
+        "top_logprobs",
+        "top_p"
+      ],
+      "reasoning": {
+        "mandatory": false,
+        "default_enabled": true,
+        "supports_max_tokens": true
+      },
+      "default_parameters": {
+        "temperature": null,
+        "top_p": null,
+        "top_k": null,
+        "frequency_penalty": null,
+        "presence_penalty": null,
+        "repetition_penalty": null
+      }
     },
     {
       "slug": "x-ai/grok-4.6",
@@ -247,8 +577,8 @@
       "catalog_name": "SpaceXAI: Grok 4.6",
       "catalog_status": "available",
       "recommendation_status": "active-demanding-bounded-escalation",
-      "input_usd_per_m": 2.0,
-      "output_usd_per_m": 6.0,
+      "input_usd_per_m": 2,
+      "output_usd_per_m": 6,
       "cache_read_usd_per_m": 0.5,
       "web_search_usd_per_request": 0.005,
       "context_tokens": 500000,
@@ -256,19 +586,68 @@
       "top_provider_max_completion_tokens": null,
       "per_request_limits": null,
       "pricing_overrides": [
-        {"min_prompt_tokens": 200000, "input_usd_per_m": 4.0, "output_usd_per_m": 12.0, "cache_read_usd_per_m": 1.0}
+        {
+          "min_prompt_tokens": 200000,
+          "prompt": 4,
+          "completion": 12,
+          "input_cache_read": 1
+        }
       ],
-      "input_modalities": ["text", "image", "file"],
+      "input_modalities": [
+        "text",
+        "image",
+        "file"
+      ],
       "supports_tools": true,
       "supports_reasoning": true,
       "supports_reasoning_effort": true,
       "supports_structured_outputs": true,
       "quality_rank": 95,
-      "benchmark_evidence": {"source": "SpaceXAI release notes", "source_version": null, "exact_variant": null, "status": "no exact Grok 4.6 release note or comparable score located; catalog evidence only"},
+      "benchmark_evidence": {
+        "source": "SpaceXAI release notes",
+        "source_version": null,
+        "exact_variant": null,
+        "status": "no exact Grok 4.6 release note or comparable score located; catalog evidence only"
+      },
       "local_evidence": "2026-08-17 canary found the seeded arithmetic defect in the exact one-line format in 5 seconds; 352 prompt, 295 completion, 274 reasoning tokens; $0.002282.",
       "role": "Demanding bounded Pipeline execution/review escalation and different-family security fallback after Kimi K3 when family independence permits.",
-      "snapshot_date": "2026-08-17",
-      "sources": ["https://openrouter.ai/x-ai/grok-4.6"]
+      "snapshot_date": "2026-08-21",
+      "sources": [
+        "https://openrouter.ai/x-ai/grok-4.6"
+      ],
+      "canonical_slug": "x-ai/grok-4.6-20260810",
+      "cache_write_usd_per_m": null,
+      "top_provider_is_moderated": false,
+      "output_modalities": [
+        "text"
+      ],
+      "supported_parameters": [
+        "include_reasoning",
+        "logprobs",
+        "max_tokens",
+        "reasoning",
+        "reasoning_effort",
+        "response_format",
+        "seed",
+        "structured_outputs",
+        "temperature",
+        "tool_choice",
+        "tools",
+        "top_logprobs",
+        "top_p"
+      ],
+      "reasoning": {
+        "mandatory": true,
+        "default_enabled": true,
+        "supported_efforts": [
+          "xhigh",
+          "high",
+          "medium",
+          "low"
+        ],
+        "default_effort": "high"
+      },
+      "default_parameters": {}
     },
     {
       "slug": "google/gemini-3.7-flash",
@@ -279,12 +658,18 @@
       "input_usd_per_m": 0.375,
       "output_usd_per_m": 1.875,
       "cache_read_usd_per_m": 0.0375,
-      "cache_write_usd_per_m": 0.0208333333333333,
+      "cache_write_usd_per_m": 0.020833,
       "context_tokens": 1048576,
       "top_provider_context_tokens": 1048576,
       "top_provider_max_completion_tokens": 65536,
       "per_request_limits": null,
-      "input_modalities": ["text", "image", "file", "audio", "video"],
+      "input_modalities": [
+        "text",
+        "image",
+        "video",
+        "file",
+        "audio"
+      ],
       "supports_tools": true,
       "supports_reasoning": true,
       "supports_reasoning_effort": true,
@@ -293,8 +678,42 @@
       "benchmark_evidence": null,
       "local_evidence": "No local call authorized for this refresh.",
       "role": "Catalogued multimodal candidate only; the current wrapper remains text-only and no current consumer requires it.",
-      "snapshot_date": "2026-08-17",
-      "sources": ["https://openrouter.ai/google/gemini-3.7-flash"]
+      "snapshot_date": "2026-08-21",
+      "sources": [
+        "https://openrouter.ai/google/gemini-3.7-flash"
+      ],
+      "canonical_slug": "google/gemini-3.7-flash-20260813",
+      "web_search_usd_per_request": 0.014,
+      "top_provider_is_moderated": false,
+      "pricing_overrides": null,
+      "output_modalities": [
+        "text"
+      ],
+      "supported_parameters": [
+        "include_reasoning",
+        "max_tokens",
+        "reasoning",
+        "reasoning_effort",
+        "response_format",
+        "seed",
+        "stop",
+        "structured_outputs",
+        "temperature",
+        "tool_choice",
+        "tools",
+        "top_p"
+      ],
+      "reasoning": {
+        "mandatory": true,
+        "default_enabled": true,
+        "supported_efforts": [
+          "high",
+          "medium",
+          "low"
+        ],
+        "default_effort": "medium"
+      },
+      "default_parameters": {}
     },
     {
       "slug": "meta/muse-spark-1.2",
@@ -310,7 +729,13 @@
       "top_provider_context_tokens": 1048576,
       "top_provider_max_completion_tokens": null,
       "per_request_limits": null,
-      "input_modalities": ["text", "image", "file", "audio", "video"],
+      "input_modalities": [
+        "text",
+        "image",
+        "video",
+        "file",
+        "audio"
+      ],
       "supports_tools": true,
       "supports_reasoning": true,
       "supports_reasoning_effort": true,
@@ -319,8 +744,43 @@
       "benchmark_evidence": null,
       "local_evidence": "No local call authorized for this refresh.",
       "role": "Catalogued multimodal candidate only; the current wrapper remains text-only and no current consumer requires it.",
-      "snapshot_date": "2026-08-17",
-      "sources": ["https://openrouter.ai/meta/muse-spark-1.2"]
+      "snapshot_date": "2026-08-21",
+      "sources": [
+        "https://openrouter.ai/meta/muse-spark-1.2"
+      ],
+      "canonical_slug": "meta/muse-spark-1.2-20260805",
+      "cache_write_usd_per_m": null,
+      "top_provider_is_moderated": true,
+      "pricing_overrides": null,
+      "output_modalities": [
+        "text"
+      ],
+      "supported_parameters": [
+        "include_reasoning",
+        "max_tokens",
+        "reasoning",
+        "reasoning_effort",
+        "repetition_penalty",
+        "response_format",
+        "structured_outputs",
+        "temperature",
+        "tool_choice",
+        "tools",
+        "top_k",
+        "top_p"
+      ],
+      "reasoning": {
+        "mandatory": true,
+        "supported_efforts": [
+          "xhigh",
+          "high",
+          "medium",
+          "low",
+          "minimal"
+        ],
+        "default_effort": "medium"
+      },
+      "default_parameters": {}
     },
     {
       "slug": "z-ai/glm-5.2",
@@ -328,24 +788,82 @@
       "catalog_name": "Z.ai: GLM 5.2",
       "catalog_status": "available",
       "recommendation_status": "catalogued-not-routed",
-      "input_usd_per_m": 0.76,
-      "output_usd_per_m": 2.42,
-      "cache_read_usd_per_m": 0.14,
+      "input_usd_per_m": 0.966,
+      "output_usd_per_m": 3.036,
+      "cache_read_usd_per_m": 0.1932,
       "context_tokens": 1048576,
-      "top_provider_context_tokens": 262144,
-      "top_provider_max_completion_tokens": 262144,
+      "top_provider_context_tokens": 1048576,
+      "top_provider_max_completion_tokens": 131072,
       "per_request_limits": null,
-      "input_modalities": ["text"],
+      "input_modalities": [
+        "text"
+      ],
       "supports_tools": true,
       "supports_reasoning": true,
       "supports_reasoning_effort": true,
       "supports_structured_outputs": true,
       "quality_rank": 80,
-      "benchmark_evidence": {"source": "Z.ai GLM-5.2 release notes", "source_version": "2026-06-16", "exact_variant": "GLM-5.2", "status": "vendor benchmark claims; not used as routing authority"},
+      "benchmark_evidence": {
+        "source": "Z.ai GLM-5.2 release notes",
+        "source_version": "2026-06-16",
+        "exact_variant": "GLM-5.2",
+        "status": "vendor benchmark claims; not used as routing authority"
+      },
       "local_evidence": "Prior Depot/Assembly operator evidence found repeated handholding; no call was authorized in this refresh.",
       "role": "Catalogued for evidence only and intentionally absent from every active Pipeline and dm-review ladder.",
-      "snapshot_date": "2026-08-17",
-      "sources": ["https://openrouter.ai/z-ai/glm-5.2", "https://z.ai/blog/glm-5.2"]
+      "snapshot_date": "2026-08-21",
+      "sources": [
+        "https://openrouter.ai/z-ai/glm-5.2",
+        "https://z.ai/blog/glm-5.2"
+      ],
+      "canonical_slug": "z-ai/glm-5.2-20260616",
+      "cache_write_usd_per_m": null,
+      "web_search_usd_per_request": null,
+      "top_provider_is_moderated": false,
+      "pricing_overrides": null,
+      "output_modalities": [
+        "text"
+      ],
+      "supported_parameters": [
+        "frequency_penalty",
+        "include_reasoning",
+        "logit_bias",
+        "logprobs",
+        "max_tokens",
+        "min_p",
+        "parallel_tool_calls",
+        "presence_penalty",
+        "reasoning",
+        "reasoning_effort",
+        "repetition_penalty",
+        "response_format",
+        "seed",
+        "stop",
+        "structured_outputs",
+        "temperature",
+        "tool_choice",
+        "tools",
+        "top_k",
+        "top_logprobs",
+        "top_p"
+      ],
+      "reasoning": {
+        "mandatory": false,
+        "default_enabled": true,
+        "supported_efforts": [
+          "xhigh",
+          "high"
+        ],
+        "default_effort": "high"
+      },
+      "default_parameters": {
+        "temperature": 1,
+        "top_p": 0.95,
+        "top_k": null,
+        "frequency_penalty": null,
+        "presence_penalty": null,
+        "repetition_penalty": null
+      }
     },
     {
       "slug": "moonshotai/kimi-k3",
@@ -353,24 +871,86 @@
       "catalog_name": "MoonshotAI: Kimi K3",
       "catalog_status": "available",
       "recommendation_status": "active-focused-security-only",
-      "input_usd_per_m": 3.0,
-      "output_usd_per_m": 15.0,
+      "input_usd_per_m": 3,
+      "output_usd_per_m": 15,
       "cache_read_usd_per_m": 0.3,
       "context_tokens": 1048576,
       "top_provider_context_tokens": 1048576,
       "top_provider_max_completion_tokens": null,
       "per_request_limits": null,
-      "input_modalities": ["text", "image", "video"],
+      "input_modalities": [
+        "text",
+        "image",
+        "video"
+      ],
       "supports_tools": true,
       "supports_reasoning": true,
       "supports_reasoning_effort": true,
       "supports_structured_outputs": true,
       "quality_rank": 97,
-      "benchmark_evidence": {"source": "artificial-analysis", "source_version": "v4.1.1", "exact_variant": "Kimi K3 (max)", "intelligence": 60.0, "observed_on": "2026-08-12", "status": "retained-prior-comparable-evidence"},
+      "benchmark_evidence": {
+        "source": "artificial-analysis",
+        "source_version": "v4.1.1",
+        "exact_variant": "Kimi K3 (max)",
+        "intelligence": 60.0,
+        "observed_on": "2026-08-12",
+        "status": "retained-prior-comparable-evidence"
+      },
       "local_evidence": "Recent Baseplate review: 5 attempts, about $1.334, with useful security evidence but excessive cost for routine review.",
       "role": "Focused applicable security analysis only; never ordinary bulk, second-perspective, documentation, test, pattern, simplicity, or implementation routing.",
-      "snapshot_date": "2026-08-17",
-      "sources": ["https://openrouter.ai/moonshotai/kimi-k3", "https://artificialanalysis.ai/models/kimi-k3"]
+      "snapshot_date": "2026-08-21",
+      "sources": [
+        "https://openrouter.ai/moonshotai/kimi-k3",
+        "https://artificialanalysis.ai/models/kimi-k3"
+      ],
+      "canonical_slug": "moonshotai/kimi-k3-20260715",
+      "cache_write_usd_per_m": null,
+      "web_search_usd_per_request": null,
+      "top_provider_is_moderated": false,
+      "pricing_overrides": null,
+      "output_modalities": [
+        "text"
+      ],
+      "supported_parameters": [
+        "frequency_penalty",
+        "include_reasoning",
+        "logit_bias",
+        "logprobs",
+        "max_tokens",
+        "min_p",
+        "presence_penalty",
+        "reasoning",
+        "reasoning_effort",
+        "repetition_penalty",
+        "response_format",
+        "seed",
+        "stop",
+        "structured_outputs",
+        "temperature",
+        "tool_choice",
+        "tools",
+        "top_k",
+        "top_logprobs",
+        "top_p"
+      ],
+      "reasoning": {
+        "mandatory": false,
+        "default_enabled": true,
+        "supported_efforts": [
+          "max",
+          "high",
+          "low"
+        ],
+        "default_effort": "max"
+      },
+      "default_parameters": {
+        "temperature": null,
+        "top_p": 0.95,
+        "top_k": null,
+        "frequency_penalty": null,
+        "presence_penalty": null,
+        "repetition_penalty": null
+      }
     },
     {
       "slug": "openai/gpt-5.6-luna",
@@ -378,18 +958,28 @@
       "catalog_name": "OpenAI: GPT-5.6 Luna",
       "catalog_status": "available",
       "recommendation_status": "active-economical-mechanical-fallback",
-      "input_usd_per_m": 0.1,
-      "output_usd_per_m": 0.6,
-      "cache_read_usd_per_m": 0.01,
-      "cache_write_usd_per_m": 0.125,
+      "input_usd_per_m": 0.2,
+      "output_usd_per_m": 1.2,
+      "cache_read_usd_per_m": 0.02,
+      "cache_write_usd_per_m": 0.25,
       "context_tokens": 1050000,
       "top_provider_context_tokens": 1050000,
       "top_provider_max_completion_tokens": 128000,
       "per_request_limits": null,
       "pricing_overrides": [
-        {"min_prompt_tokens": 272000, "input_usd_per_m": 0.2, "output_usd_per_m": 0.9, "cache_read_usd_per_m": 0.02, "cache_write_usd_per_m": 0.25}
+        {
+          "min_prompt_tokens": 272000,
+          "prompt": 0.4,
+          "completion": 1.8,
+          "input_cache_read": 0.04,
+          "input_cache_write": 0.5
+        }
       ],
-      "input_modalities": ["text", "image", "file"],
+      "input_modalities": [
+        "file",
+        "image",
+        "text"
+      ],
       "supports_tools": true,
       "supports_reasoning": true,
       "supports_reasoning_effort": true,
@@ -398,8 +988,50 @@
       "benchmark_evidence": null,
       "local_evidence": "Recent Baseplate review: 5 attempts, about $0.019; economical but no longer primary for all routine reviewers.",
       "role": "Economical mechanical fallback for routine documentation and test-coverage review after DeepSeek Flash.",
-      "snapshot_date": "2026-08-17",
-      "sources": ["https://openrouter.ai/openai/gpt-5.6-luna", "https://developers.openai.com/api/docs/models/gpt-5.6-luna"]
+      "snapshot_date": "2026-08-21",
+      "sources": [
+        "https://openrouter.ai/openai/gpt-5.6-luna",
+        "https://developers.openai.com/api/docs/models/gpt-5.6-luna"
+      ],
+      "canonical_slug": "openai/gpt-5.6-luna-20260709",
+      "web_search_usd_per_request": 0.01,
+      "top_provider_is_moderated": true,
+      "output_modalities": [
+        "text"
+      ],
+      "supported_parameters": [
+        "include_reasoning",
+        "max_completion_tokens",
+        "max_tokens",
+        "reasoning",
+        "reasoning_effort",
+        "response_format",
+        "seed",
+        "structured_outputs",
+        "tool_choice",
+        "tools"
+      ],
+      "reasoning": {
+        "mandatory": false,
+        "default_enabled": true,
+        "supported_efforts": [
+          "max",
+          "xhigh",
+          "high",
+          "medium",
+          "low",
+          "none"
+        ],
+        "default_effort": "medium"
+      },
+      "default_parameters": {
+        "temperature": null,
+        "top_p": null,
+        "top_k": null,
+        "frequency_penalty": null,
+        "presence_penalty": null,
+        "repetition_penalty": null
+      }
     },
     {
       "slug": "openai/gpt-5.6-terra",
@@ -407,18 +1039,28 @@
       "catalog_name": "OpenAI: GPT-5.6 Terra",
       "catalog_status": "available",
       "recommendation_status": "catalogued-not-routed",
-      "input_usd_per_m": 1.0,
-      "output_usd_per_m": 6.0,
-      "cache_read_usd_per_m": 0.1,
-      "cache_write_usd_per_m": 1.25,
+      "input_usd_per_m": 2,
+      "output_usd_per_m": 12,
+      "cache_read_usd_per_m": 0.2,
+      "cache_write_usd_per_m": 2.5,
       "context_tokens": 1050000,
       "top_provider_context_tokens": 1050000,
       "top_provider_max_completion_tokens": 128000,
       "per_request_limits": null,
       "pricing_overrides": [
-        {"min_prompt_tokens": 272000, "input_usd_per_m": 2.0, "output_usd_per_m": 9.0, "cache_read_usd_per_m": 0.2, "cache_write_usd_per_m": 2.5}
+        {
+          "min_prompt_tokens": 272000,
+          "prompt": 4,
+          "completion": 18,
+          "input_cache_read": 0.4,
+          "input_cache_write": 5
+        }
       ],
-      "input_modalities": ["text", "image", "file"],
+      "input_modalities": [
+        "file",
+        "image",
+        "text"
+      ],
       "supports_tools": true,
       "supports_reasoning": true,
       "supports_reasoning_effort": true,
@@ -427,11 +1069,125 @@
       "benchmark_evidence": null,
       "local_evidence": "No local call authorized for this refresh.",
       "role": "Catalogued explicit-choice model only; absent from default direct, Pipeline, and dm-review ladders.",
-      "snapshot_date": "2026-08-17",
-      "sources": ["https://openrouter.ai/openai/gpt-5.6-terra", "https://developers.openai.com/api/docs/models/gpt-5.6-terra"]
+      "snapshot_date": "2026-08-21",
+      "sources": [
+        "https://openrouter.ai/openai/gpt-5.6-terra",
+        "https://developers.openai.com/api/docs/models/gpt-5.6-terra"
+      ],
+      "canonical_slug": "openai/gpt-5.6-terra-20260709",
+      "web_search_usd_per_request": 0.01,
+      "top_provider_is_moderated": true,
+      "output_modalities": [
+        "text"
+      ],
+      "supported_parameters": [
+        "include_reasoning",
+        "max_completion_tokens",
+        "max_tokens",
+        "reasoning",
+        "reasoning_effort",
+        "response_format",
+        "seed",
+        "structured_outputs",
+        "tool_choice",
+        "tools"
+      ],
+      "reasoning": {
+        "mandatory": false,
+        "default_enabled": true,
+        "supported_efforts": [
+          "max",
+          "xhigh",
+          "high",
+          "medium",
+          "low",
+          "none"
+        ],
+        "default_effort": "medium"
+      },
+      "default_parameters": {
+        "temperature": null,
+        "top_p": null,
+        "top_k": null,
+        "frequency_penalty": null,
+        "presence_penalty": null,
+        "repetition_penalty": null
+      }
+    },
+    {
+      "slug": "z-ai/glm-5.3",
+      "canonical_slug": "z-ai/glm-5.3-20260816",
+      "name": "GLM 5.3",
+      "catalog_name": "Z.ai: GLM 5.3",
+      "catalog_status": "available",
+      "recommendation_status": "catalogued-not-routed",
+      "input_usd_per_m": 1.4,
+      "output_usd_per_m": 4.4,
+      "cache_read_usd_per_m": 0.26,
+      "cache_write_usd_per_m": null,
+      "web_search_usd_per_request": null,
+      "context_tokens": 1048576,
+      "top_provider_context_tokens": 1048576,
+      "top_provider_max_completion_tokens": 131072,
+      "top_provider_is_moderated": false,
+      "per_request_limits": null,
+      "pricing_overrides": null,
+      "input_modalities": [
+        "text"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "supported_parameters": [
+        "include_reasoning",
+        "max_tokens",
+        "reasoning",
+        "reasoning_effort",
+        "response_format",
+        "temperature",
+        "tool_choice",
+        "tools",
+        "top_k",
+        "top_p"
+      ],
+      "reasoning": {
+        "mandatory": true,
+        "default_enabled": true,
+        "supported_efforts": [
+          "max",
+          "high",
+          "low"
+        ],
+        "default_effort": "max"
+      },
+      "default_parameters": {
+        "temperature": 1,
+        "top_p": 0.95
+      },
+      "supports_tools": true,
+      "supports_reasoning": true,
+      "supports_reasoning_effort": true,
+      "supports_structured_outputs": false,
+      "quality_rank": null,
+      "benchmark_evidence": {
+        "source": "OpenRouter catalog snapshot 2026-08-21T092022+0800",
+        "exact_variant": "z-ai/glm-5.3-20260816",
+        "catalog_reported_values": {
+          "artificial_analysis": {
+            "intelligence_index": 59.5,
+            "coding_index": 74.8,
+            "agentic_index": 59.1
+          }
+        },
+        "status": "catalog-reported benchmark values and vendor claims are uncorroborated; not routing authority"
+      },
+      "local_evidence": "No live canary request was sent because no configured OpenRouter credential was available in this worktree session.",
+      "role": "Catalogued candidate only; mandatory reasoning with default max is recorded, but GLM 5.3 has no default role and is intentionally absent from every active Pipeline and dm-review ladder.",
+      "snapshot_date": "2026-08-21",
+      "sources": [
+        "https://openrouter.ai/api/v1/models"
+      ]
     }
   ],
-  "excluded_catalog_candidates": {
-    "glm-5.3": "No matching OpenRouter catalog slug existed at 2026-08-17T00:26:07Z; no executable slug was added."
-  }
+  "catalog_snapshot": "/home/ned/.local/state/openrouter-model-pulse/catalog/models-2026-08-21T092022+0800.json"
 }

--- a/plugins/openrouter/skills/openrouter-delegate/references/model-selection.md
+++ b/plugins/openrouter/skills/openrouter-delegate/references/model-selection.md
@@ -8,32 +8,33 @@ engine.
 
 ## Available Models
 
-Prices below are a checked-in planning snapshot from 2026-08-17, in USD per
+Prices below are a checked-in planning snapshot from 2026-08-21, in USD per
 million input/output tokens. The compact refresh receipt is
-`docs/openrouter-model-matrix-refreshes/2026-08-17.md`; use a fresh catalog
+`docs/openrouter-model-matrix-refreshes/2026-08-21.md`; use a fresh catalog
 receipt before a later paid or policy-changing run.
 
 | Exact slug | Input / output | Context | Current role |
 |---|---:|---:|---|
-| `deepseek/deepseek-v4-flash-0731` | $0.14 / $0.28 | 1,048,576 | Primary cheap bounded executor; documentation and test review |
-| `deepseek/deepseek-v4-pro-0813` | $0.66 / $1.98 | 1,048,576 | Provisional pattern and long-context analysis |
+| `deepseek/deepseek-v4-flash-0731` | $0.14 / $0.28 | 1,310,720 | Primary cheap bounded executor; documentation and test review |
+| `deepseek/deepseek-v4-pro-0813` | $1.188 / $3.564 | 1,048,576 | Provisional pattern and long-context analysis |
 | `qwen/qwen3.8-max` | $2 / $6 | 1,000,000 | Bulk/independent review and complexity judgment |
 | `qwen/qwen3.8-2.4t-a95b` | $2 / $6 | 1,048,576 | Catalogued; no active consumer |
-| `qwen/qwen3.8-27b` | $0.45 / $3.20 | 262,144 | Catalogued; no active consumer |
+| `qwen/qwen3.8-27b` | $0.45 / $3.20 | 1,000,000 | Catalogued; no active consumer |
 | `qwen/qwen3.7-flash` | $0.03 / $0.13 | 1,000,000 | Catalogued; no active consumer |
 | `x-ai/grok-4.6` | $2 / $6 | 500,000 | Demanding bounded escalation; independent security fallback |
 | `google/gemini-3.7-flash` | $0.375 / $1.875 | 1,048,576 | Catalogued; no text-only active consumer |
 | `meta/muse-spark-1.2` | $1.25 / $4.25 | 1,048,576 | Catalogued; no text-only active consumer |
-| `z-ai/glm-5.2` | $0.76 / $2.42 | 1,048,576 | Evidence only; excluded from every active ladder |
+| `z-ai/glm-5.2` | $0.966 / $3.036 | 1,048,576 | Evidence only; excluded from every active ladder |
+| `z-ai/glm-5.3` | $1.40 / $4.40 | 1,048,576 | Catalogued-not-routed; mandatory reasoning defaults to max |
 | `moonshotai/kimi-k3` | $3 / $15 | 1,048,576 | Focused applicable security analysis only |
-| `openai/gpt-5.6-luna` | $0.10 / $0.60 | 1,050,000 | Economical mechanical fallback |
-| `openai/gpt-5.6-terra` | $1 / $6 | 1,050,000 | Catalogued compatibility evidence; no default role |
+| `openai/gpt-5.6-luna` | $0.20 / $1.20 | 1,050,000 | Economical mechanical fallback |
+| `openai/gpt-5.6-terra` | $2 / $12 | 1,050,000 | Catalogued compatibility evidence; no default role |
 
 Every executable identity is an exact versioned slug. Moving aliases such as
-`latest` are forbidden. GLM 5.3 was absent from the catalog at refresh time and
-has no executable identity. The matrix records cache pricing, top-provider
-limits, feature support, benchmark provenance, and local evidence without
-inventing unavailable values.
+`latest` are forbidden. GLM 5.3 is recorded only as the exact catalog identity
+`z-ai/glm-5.3` / canonical `z-ai/glm-5.3-20260816`; it has no default role.
+The matrix records cache pricing, top-provider limits, feature support,
+benchmark provenance, and missing values without inference.
 
 Native Codex identities and native Claude aliases are not OpenRouter routing
 models. OpenRouter transport is provider provenance, not a model family;
@@ -66,7 +67,7 @@ can be assigned an API-equivalent planning cost.
   contract before native verification.
 - Documentation and test-coverage review use DeepSeek Flash, then Luna.
 - Pattern review uses DeepSeek Pro, then Qwen3.8 Max.
-- Simplicity, ordinary independent review, and bulk analysis use Qwen3.8 Max,
+- Simplicity, ordinary independent review, and dm-review bulk analysis use Qwen3.8 Max,
   with DeepSeek Pro or Grok 4.6 according to the role's ordered list.
 - Focused applicable security analysis alone uses Kimi K3, then Grok 4.6.
   Consequential security completion still requires a full-input reviewer from
@@ -113,21 +114,21 @@ All supported hosts expose the same ordered OpenRouter models:
 | `openrouter_exec` | DeepSeek V4 Flash 0731 -> Grok 4.6 |
 | `frontier_api` | Grok 4.6 -> Qwen3.8 Max -> DeepSeek V4 Pro 0813 |
 | `cheap_api` | DeepSeek V4 Flash 0731 -> Qwen3.8 Max |
-| `bulk_api` | Qwen3.8 Max -> DeepSeek V4 Pro 0813 -> Grok 4.6 |
 
 The `codex` class walks native Codex before these OpenRouter roles; the
 `openrouter` class may try the bounded executor first for eligible config,
-documentation, or mechanical work. Wrapper roles never autonomously implement
-complex logic, served UI, integration, browser-dependent, or live-tool work.
+documentation, or mechanical work. The former Pipeline bulk role was
+unreachable from both class ladders and is deliberately removed; dm-review
+retains its separate Qwen-led `openrouter-bulk-analyst` route. Wrapper roles
+never autonomously implement complex logic, served UI, integration,
+browser-dependent, or live-tool work.
 
 ## Evidence interpretation
 
-The 2026-08-17 canary supports DeepSeek Pro for the current unified-diff
-contract, Qwen3.8 Max for concise independent review, and Grok 4.6 for demanding
-review/escalation. DeepSeek Flash received an HTTP 429 before output; one
-transport rate limit does not show that it cannot satisfy the output contract,
-so it remains the cheap primary with no quality claim from that call. The
-receipt records exact tokens, cost, timing, format, scope, and complexity.
+The 2026-08-21 receipt has no live canary output because this worktree had no
+configured OpenRouter credential; it makes no new performance or routing claim.
+The prior dated evidence remains historical only. GLM 5.3's catalog-reported
+benchmark values and vendor claims are uncorroborated and do not earn a route.
 
 The recent Baseplate operator evidence also matters: Kimi was repeatedly used
 for ordinary review at substantial cost, Luna handled routine lanes cheaply,

--- a/plugins/pipeline/.claude-plugin/plugin.json
+++ b/plugins/pipeline/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "pipeline",
   "description": "Autonomous feature development pipeline with approved-scope intake, minimum-adequate planning, bounded adversarial review, fresh tiered verification, browser recovery, and isolated execution",
-  "version": "1.56.0",
+  "version": "1.56.1",
   "author": {
     "name": "Design Machines",
     "url": "https://designmachines.io"

--- a/plugins/pipeline/.codex-plugin/plugin.json
+++ b/plugins/pipeline/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pipeline",
-  "version": "1.56.0",
+  "version": "1.56.1",
   "description": "Autonomous feature development pipeline with approved-scope intake, minimum-adequate planning, bounded adversarial review, fresh tiered verification, browser recovery, and isolated execution",
   "author": {
     "name": "Design Machines",

--- a/plugins/pipeline/references/harness-profile.json
+++ b/plugins/pipeline/references/harness-profile.json
@@ -11,8 +11,7 @@
         "openrouter_exec":  { "kind": "openrouter_exec", "probe": "openrouter", "models": ["deepseek/deepseek-v4-flash-0731", "x-ai/grok-4.6"] },
         "premium_sub":     { "kind": "codex_companion", "probe": "codex",      "models": ["gpt-5.6-sol"] },
         "frontier_api":    { "kind": "wrapper",         "probe": "openrouter", "models": ["x-ai/grok-4.6", "qwen/qwen3.8-max", "deepseek/deepseek-v4-pro-0813"] },
-        "cheap_api":       { "kind": "wrapper",         "probe": "openrouter", "models": ["deepseek/deepseek-v4-flash-0731", "qwen/qwen3.8-max"] },
-        "bulk_api":        { "kind": "wrapper",         "probe": "openrouter", "models": ["qwen/qwen3.8-max", "deepseek/deepseek-v4-pro-0813", "x-ai/grok-4.6"] }
+        "cheap_api":       { "kind": "wrapper",         "probe": "openrouter", "models": ["deepseek/deepseek-v4-flash-0731", "qwen/qwen3.8-max"] }
       }
     },
 
@@ -22,8 +21,7 @@
         "openrouter_exec":  { "kind": "openrouter_exec", "probe": "openrouter", "models": ["deepseek/deepseek-v4-flash-0731", "x-ai/grok-4.6"] },
         "premium_sub":     { "kind": "native",  "probe": "codex",      "models": ["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.5", "gpt-5.6-luna"] },
         "frontier_api":    { "kind": "wrapper", "probe": "openrouter", "models": ["x-ai/grok-4.6", "qwen/qwen3.8-max", "deepseek/deepseek-v4-pro-0813"] },
-        "cheap_api":       { "kind": "wrapper", "probe": "openrouter", "models": ["deepseek/deepseek-v4-flash-0731", "qwen/qwen3.8-max"] },
-        "bulk_api":        { "kind": "wrapper", "probe": "openrouter", "models": ["qwen/qwen3.8-max", "deepseek/deepseek-v4-pro-0813", "x-ai/grok-4.6"] }
+        "cheap_api":       { "kind": "wrapper", "probe": "openrouter", "models": ["deepseek/deepseek-v4-flash-0731", "qwen/qwen3.8-max"] }
       }
     },
 
@@ -33,8 +31,7 @@
         "openrouter_exec":  { "kind": "openrouter_exec", "probe": "openrouter", "models": ["deepseek/deepseek-v4-flash-0731", "x-ai/grok-4.6"] },
         "premium_sub":     { "kind": "none" },
         "frontier_api":    { "kind": "wrapper", "probe": "openrouter", "models": ["x-ai/grok-4.6", "qwen/qwen3.8-max", "deepseek/deepseek-v4-pro-0813"] },
-        "cheap_api":       { "kind": "wrapper", "probe": "openrouter", "models": ["deepseek/deepseek-v4-flash-0731", "qwen/qwen3.8-max"] },
-        "bulk_api":        { "kind": "wrapper", "probe": "openrouter", "models": ["qwen/qwen3.8-max", "deepseek/deepseek-v4-pro-0813", "x-ai/grok-4.6"] }
+        "cheap_api":       { "kind": "wrapper", "probe": "openrouter", "models": ["deepseek/deepseek-v4-flash-0731", "qwen/qwen3.8-max"] }
       }
     }
   }

--- a/plugins/pipeline/references/model-cascade.json
+++ b/plugins/pipeline/references/model-cascade.json
@@ -7,7 +7,7 @@
     "logic": "codex", "config": "openrouter", "docs": "openrouter", "ui": "codex", "integration": "codex"
   },
 
-  "roles": ["openrouter_exec", "premium_sub", "frontier_api", "cheap_api", "bulk_api"],
+  "roles": ["openrouter_exec", "premium_sub", "frontier_api", "cheap_api"],
 
   "quality_rank": {
     "_comment": "Global model->compatibility score; enforces quality_floor regardless of which role surfaced the model. Ordered role lists remain the routing authority; this is not a ranking engine.",

--- a/tools/validate-dm-review-codex-perspective.sh
+++ b/tools/validate-dm-review-codex-perspective.sh
@@ -395,7 +395,7 @@ for zero_deferral_surface in \
 done
 require_text "$REPO_ROOT/plugins/dm-review/.claude-plugin/plugin.json" '"version": "1.68.0"' "canonical dm-review version is 1.68.0"
 require_text "$REPO_ROOT/plugins/dm-review/.codex-plugin/plugin.json" '"version": "1.68.0"' "generated dm-review version is 1.68.0"
-require_text "$REPO_ROOT/plugins/pipeline/.claude-plugin/plugin.json" '"version": "1.56.0"' "canonical Pipeline version is 1.56.0"
+require_text "$REPO_ROOT/plugins/pipeline/.claude-plugin/plugin.json" '"version": "1.56.1"' "canonical Pipeline version is 1.56.1"
 require_text "$REPO_ROOT/plugins/pipeline/.codex-plugin/plugin.json" '"dm-review": ">=1.64.0"' "generated Pipeline dependency floor is current"
 
 printf "Synthesis identity fixtures\n"

--- a/tools/validate-openrouter-cascade.sh
+++ b/tools/validate-openrouter-cascade.sh
@@ -69,7 +69,7 @@ wrapper="$REPO_ROOT/plugins/openrouter/skills/openrouter-delegate/references/ope
 boundary="$REPO_ROOT/plugins/openrouter/skills/openrouter-delegate/references/delegation-boundary.sh"
 security_policy="$REPO_ROOT/plugins/openrouter/skills/openrouter-delegate/references/delegation-security-policy.json"
 model_selection="$REPO_ROOT/plugins/openrouter/skills/openrouter-delegate/references/model-selection.md"
-matrix_refresh_receipt="$REPO_ROOT/docs/openrouter-model-matrix-refreshes/2026-08-17.md"
+matrix_refresh_receipt="$REPO_ROOT/docs/openrouter-model-matrix-refreshes/2026-08-21.md"
 orchestrator="$REPO_ROOT/plugins/pipeline/agents/workflow/execution-orchestrator.md"
 
 any_failed=0
@@ -1125,24 +1125,28 @@ check_routing_policy_slugs() {
 
 check_active_routing_semantics() {
   local harness="$REPO_ROOT/plugins/pipeline/references/harness-profile.json"
-  local required='["deepseek/deepseek-v4-flash-0731","deepseek/deepseek-v4-pro-0813","qwen/qwen3.8-max","qwen/qwen3.8-2.4t-a95b","qwen/qwen3.8-27b","qwen/qwen3.7-flash","x-ai/grok-4.6","google/gemini-3.7-flash","meta/muse-spark-1.2","z-ai/glm-5.2","moonshotai/kimi-k3","openai/gpt-5.6-luna","openai/gpt-5.6-terra"]'
+  local required='["deepseek/deepseek-v4-flash-0731","deepseek/deepseek-v4-pro-0813","qwen/qwen3.8-max","qwen/qwen3.8-2.4t-a95b","qwen/qwen3.8-27b","qwen/qwen3.7-flash","x-ai/grok-4.6","google/gemini-3.7-flash","meta/muse-spark-1.2","z-ai/glm-5.2","z-ai/glm-5.3","moonshotai/kimi-k3","openai/gpt-5.6-luna","openai/gpt-5.6-terra"]'
 
   if jq -e --argjson required "$required" '
     ([.models[].slug] | sort) == ($required | sort)
     and ([.models[].slug | select(test("^[^/]+/[^/]+$") | not)] | length == 0)
     and ([.models[].slug | select(test("(^|[-_/])latest($|[-_/])"; "i"))] | length == 0)
-    and ([.models[] | select(.slug == "deepseek/deepseek-v4-pro-0813" or .slug == "qwen/qwen3.7-flash" or .slug == "x-ai/grok-4.6" or .slug == "openai/gpt-5.6-luna" or .slug == "openai/gpt-5.6-terra")
-          | (.pricing_overrides | type == "array" and length > 0)] | all)
+    and ([.models[] | (.canonical_slug | type == "string" and test("^[^/]+/[^/]+$") and (test("(^|[-_/])latest($|[-_/])"; "i") | not))] | all)
+    and ([.models[] | (.supported_parameters | type == "array") and (.reasoning | type == "object" or .reasoning == null) and (.top_provider_is_moderated | type == "boolean")] | all)
+    and ([.models[] | select(.slug == "deepseek/deepseek-v4-pro-0813") | .canonical_slug == "deepseek/deepseek-v4-pro-20260813" and .input_usd_per_m == 1.188 and .output_usd_per_m == 3.564 and .cache_read_usd_per_m == 0.0396 and .top_provider_max_completion_tokens == null and .pricing_overrides == null] | all)
+    and ([.models[] | select(.slug == "openai/gpt-5.6-luna") | .input_usd_per_m == 0.2 and .output_usd_per_m == 1.2 and .cache_read_usd_per_m == 0.02 and .cache_write_usd_per_m == 0.25] | all)
+    and ([.models[] | select(.slug == "openai/gpt-5.6-terra") | .input_usd_per_m == 2 and .output_usd_per_m == 12 and .cache_read_usd_per_m == 0.2 and .cache_write_usd_per_m == 2.5] | all)
+    and ([.models[] | select(.slug == "z-ai/glm-5.3") | .canonical_slug == "z-ai/glm-5.3-20260816" and .recommendation_status == "catalogued-not-routed" and .reasoning == {"mandatory":true,"default_enabled":true,"supported_efforts":["max","high","low"],"default_effort":"max"} and .default_parameters == {"temperature":1,"top_p":0.95} and .top_provider_max_completion_tokens == 131072 and .top_provider_is_moderated == false and .cache_write_usd_per_m == null and .pricing_overrides == null] | all)
     and ([.models[].per_request_limits] | all(. == null))
   ' "$model_matrix" >/dev/null; then
-    pass "matrix contains the exact refreshed versioned candidate set and catalog price overrides"
+    pass "matrix contains the exact versioned catalog candidates, identities, limits, pricing, parameters, and explicit missing values"
   else
-    fail "matrix must contain the refreshed versioned candidates, overrides, and per-request limits"
+    fail "matrix must contain the refreshed versioned candidates, catalog fields, and explicit missing values"
     any_failed=1
   fi
 
-  if jq -e '[.models[] | select(.slug == "qwen/qwen3.8-2.4t-a95b") | .input_modalities] == [["text","image","video"]]' "$model_matrix" >/dev/null &&
-     grep -Fq '| `qwen/qwen3.8-2.4t-a95b` | $2 / $6 | $0.25 / — | 1,048,576 / 1,000,000 | 262,144 | text/image/video input; tools, reasoning, effort, structured output |' "$matrix_refresh_receipt"; then
+  if jq -e '[.models[] | select(.slug == "qwen/qwen3.8-2.4t-a95b") | .input_modalities] == [["text"]]' "$model_matrix" >/dev/null &&
+     grep -Fq '| `qwen/qwen3.8-2.4t-a95b` | `qwen/qwen3.8-2.4t-a95b-20260812` | $2 / $6 / $0.25 / $unavailable | 1048576 / 1000000 / 262144 | false |' "$matrix_refresh_receipt"; then
     pass "Qwen 3.8 2.4T matrix modalities match the catalog refresh receipt"
   else
     fail "Qwen 3.8 2.4T matrix modalities must match the catalog refresh receipt"
@@ -1189,10 +1193,11 @@ check_active_routing_semantics() {
   ' "$routing_policy" >/dev/null &&
      jq -e '
        ([.hosts[].roles[] | select(.kind == "wrapper" or .kind == "openrouter_exec") | .models[]]
-        | map(select(. == "z-ai/glm-5.2" or . == "moonshotai/kimi-k3")) | length == 0)
-       and (([.hosts[].roles | {openrouter_exec:.openrouter_exec.models, frontier_api:.frontier_api.models, cheap_api:.cheap_api.models, bulk_api:.bulk_api.models}] | unique) | length == 1)
+        | map(select(. == "z-ai/glm-5.2" or . == "z-ai/glm-5.3" or . == "moonshotai/kimi-k3")) | length == 0)
+       and ([.hosts[].roles | has("bulk_api")] | any | not)
+       and (([.hosts[].roles | {openrouter_exec:.openrouter_exec.models, frontier_api:.frontier_api.models, cheap_api:.cheap_api.models}] | unique) | length == 1)
      ' "$harness" >/dev/null; then
-    pass "dm-review roles and host ladders enforce DeepSeek/Qwen reachability and Kimi/GLM isolation"
+    pass "dm-review roles and reachable host ladders enforce DeepSeek/Qwen reachability and Kimi/GLM isolation"
   else
     fail "active routing violates role reachability, Kimi/GLM isolation, or host parity"
     any_failed=1


### PR DESCRIPTION
## Summary
- Refreshes OpenRouter model evidence from the saved 2026-08-21 official catalog snapshot, including canonical identities, prices, limits, moderation, reasoning, parameters, cache/override data, and explicit missing values.
- Adds GLM-5.3 as catalogued-not-routed with mandatory reasoning/default max; catalog-reported benchmarks and vendor claims remain uncorroborated and do not alter routing.
- Repairs Pipeline reachability by removing the unreachable bulk role from the cascade, all host maps, guidance, and validator semantics while preserving dm-review's Qwen-led bulk analyst, Kimi security-only routing, GLM no-default status, and Codex-first constraints.
- Bumps openrouter to 1.17.0 and pipeline to 1.56.1; regenerated Codex manifests.

## Canary receipt
No configured OpenRouter credential was available in this worktree session, so the four authorized zero-fallback canaries were not attempted. Spend was /bin/bash.00; the dated receipt records unavailable latency/validity/verbosity/usefulness rather than inferring outcomes.

## Validation
- ./tools/generate-codex-manifests.py
- ./tools/generate-codex-manifests.py --check
- ./tools/validate-openrouter-cascade.sh
- ./tools/validate-routing-economics.sh
- ./tools/validate-workflow-contracts.sh
- ./tools/validate-dual-compat.sh
- ./tools/validate-composition.sh --all
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Design-Machines-Studio/codesmith/depot/pr/83"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789888595&installation_model_id=428410&pr_number=83&repository=Design-Machines-Studio%2Fdepot&return_to=https%3A%2F%2Fgithub.com%2FDesign-Machines-Studio%2Fdepot%2Fpull%2F83&signature=ab678f6cf84a7a45728250088b08c2fce39fe8d5e303099a5d5877aeab1b29d4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->