### PR TITLE
Add terminal operator model-and-cost reports

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -69,7 +69,7 @@
     {
       "name": "project-manager",
       "source": "./plugins/project-manager",
-      "version": "1.10.0",
+      "version": "1.11.0",
       "author": {
         "name": "Design Machines"
       },
@@ -283,7 +283,7 @@
     {
       "name": "dm-review",
       "source": "./plugins/dm-review",
-      "version": "1.71.0",
+      "version": "1.72.0",
       "author": {
         "name": "Design Machines",
         "url": "https://designmachines.studio"
@@ -361,7 +361,7 @@
     {
       "name": "pipeline",
       "source": "./plugins/pipeline",
-      "version": "1.58.0",
+      "version": "1.59.0",
       "author": {
         "name": "Design Machines",
         "url": "https://designmachines.studio"
@@ -388,7 +388,7 @@
     {
       "name": "model-router",
       "source": "./plugins/model-router",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "author": {
         "name": "Design Machines",
         "url": "https://designmachines.studio"

--- a/docs/dependency-graph.md
+++ b/docs/dependency-graph.md
@@ -64,7 +64,7 @@ graph LR
 | dm-review | live-wires | required | `>=1.8.0` |
 | dm-review | ghostwriter | required | `>=3.7.0` |
 | dm-review | council | required | `>=1.5.0` |
-| dm-review | model-router | required | `>=0.1.0` |
+| dm-review | model-router | required | `>=0.2.0` |
 | dm-review | workflow-kernel | required | `>=0.17.0` |
 | dm-review | ned | optional | `>=1.4.0` |
 | dm-review | superpowers | optional | `>=1.0.0` |
@@ -74,8 +74,8 @@ graph LR
 | model-router | openrouter | optional | `>=1.19.0` |
 | model-router | workflow-kernel | optional | `>=0.17.0` |
 | ned | superpowers | optional | `>=1.0.0` |
-| pipeline | dm-review | required | `>=1.71.0` |
-| pipeline | model-router | required | `>=0.1.0` |
+| pipeline | dm-review | required | `>=1.72.0` |
+| pipeline | model-router | required | `>=0.2.0` |
 | pipeline | workflow-kernel | required | `>=0.17.0` |
 | pipeline | ned | optional | `>=1.4.0` |
 | pipeline | design-machines | optional | `>=1.3.0` |
@@ -91,7 +91,7 @@ graph LR
 | project-manager | design-machines | required | `>=1.3.0` |
 | project-manager | ghostwriter | required | `>=3.7.0` |
 | project-manager | council | required | `>=1.5.0` |
-| project-manager | model-router | optional | `>=0.1.0` |
+| project-manager | model-router | optional | `>=0.2.0` |
 | project-scaffolder | live-wires | optional | `>=1.0.0` |
 | project-scaffolder | dm-review | optional | `>=1.0.0` |
 | project-scaffolder | pipeline | optional | `>=1.0.0` |

--- a/plugins/dm-review/.claude-plugin/plugin.json
+++ b/plugins/dm-review/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dm-review",
   "description": "Code review orchestrator with evidence-backed severity, minimum-adequate repairs, zero-deferral convergence, full security and browser coverage, and stable finding receipts",
-  "version": "1.71.0",
+  "version": "1.72.0",
   "author": {
     "name": "Design Machines",
     "url": "https://designmachines.io"
@@ -11,7 +11,7 @@
     "live-wires": ">=1.8.0",
     "ghostwriter": ">=3.7.0",
     "council": ">=1.5.0",
-    "model-router": ">=0.1.0",
+    "model-router": ">=0.2.0",
     "workflow-kernel": ">=0.17.0"
   },
   "optionalPluginDependencies": {

--- a/plugins/dm-review/.codex-plugin/plugin.json
+++ b/plugins/dm-review/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dm-review",
-  "version": "1.71.0",
+  "version": "1.72.0",
   "description": "Code review orchestrator with evidence-backed severity, minimum-adequate repairs, zero-deferral convergence, full security and browser coverage, and stable finding receipts",
   "author": {
     "name": "Design Machines",
@@ -316,7 +316,7 @@
     "live-wires": ">=1.8.0",
     "ghostwriter": ">=3.7.0",
     "council": ">=1.5.0",
-    "model-router": ">=0.1.0",
+    "model-router": ">=0.2.0",
     "workflow-kernel": ">=0.17.0"
   },
   "optionalPluginDependencies": {

--- a/plugins/dm-review/commands/dm-review-loop.md
+++ b/plugins/dm-review/commands/dm-review-loop.md
@@ -61,6 +61,7 @@ full_review_baseline_complete = false
 full_fanout_override = true if DM_REVIEW_LOOP_FULL_FANOUT=1 in the environment, else false
 workflowClass = explicit request value, else "feature" with workflow_class_defaulted=true
 shadow_state = trusted runtime state directory, or "shadow unavailable"
+terminalModelReportOwner = "dm-review-loop"
 ```
 
 The canonical loop state and todo files remain authoritative. Pass the exact `workflowClass` and `workflow_class_defaulted` values into every nested `/dm-review-quick` or `/dm-review`, every `/dm-review-fix`, every final re-review, every iteration receipt, and the terminal receipt. Nested commands MUST NOT re-default, infer, or change the class. Resolve `$WORKFLOW_KERNEL` -- the workflow-kernel launcher script -- once per run, following the fail-closed resolution contract in the workflow-kernel plugin's `references/runtime-resolution.md`. Initialize this run under `.workflow-kernel/runs/<run-id>`; the kernel derives and verifies the immutable repository scope from the state directory, and no caller-selected lease root is accepted. Append lifecycle transitions there. Materialize the validated request at `<exact-run-root>/review/request.json`. Before corresponding authoritative actions, produce and seal the independent prediction exactly once:
@@ -76,6 +77,12 @@ Rewrite `<exact-run-root>/review/authoritative-receipts.json` as the complete or
 ```
 
 Shadow prediction never advances the loop, declares convergence, changes a finding, or converts the terminal result. Record every requested, attempted, implemented-by, fallback, and reason field; do not silently drop unavailable lanes.
+
+Create one mode-`0700` `<exact-run-root>/receipts/private/router/` directory and
+its ordered `terminal-receipt-index.json` for the entire loop. Every nested
+review, final verification pass, and routed repair receives that same directory
+and `terminalModelReportOwner: dm-review-loop`; nested invocations suppress
+their own reports. Extend the index in deterministic dispatch-start order.
 
 ### 2. Review-Fix Loop
 
@@ -190,10 +197,12 @@ while iteration < max_iterations:
   prior_review_head = git rev-parse HEAD
   if mode == "quick":
     Run /dm-review-quick {target} with review_lane_allowlist when non-null
-      with workflowClass and workflow_class_defaulted forwarded unchanged
+      with workflowClass and workflow_class_defaulted forwarded unchanged,
+      the loop-private router directory/index, and terminal reporting suppressed
   else:
     Run /dm-review {target} with review_lane_allowlist when non-null
-      with workflowClass and workflow_class_defaulted forwarded unchanged
+      with workflowClass and workflow_class_defaulted forwarded unchanged,
+      the loop-private router directory/index, and terminal reporting suppressed
 
   Consume and validate the nested review's authoritative coverage receipt: one
     row per selected lane with requested, attempted, implemented-by, status,
@@ -271,7 +280,8 @@ while iteration < max_iterations:
     STOP -- needs attention
 
   # Fix every retained finding (P1/P2/P3).
-  Run /dm-review-fix with workflowClass and workflow_class_defaulted forwarded unchanged
+  Run /dm-review-fix with workflowClass and workflow_class_defaulted forwarded unchanged,
+    using the loop-private router directory/index and terminal reporting suppressed
   # dm-review-fix resolves and cleans up todo files
 
   # If this was the last iteration, run one final review to verify.
@@ -313,6 +323,17 @@ rules, the mode-specific trigger sources, the `review_lane_allowlist` handoff,
 and the per-pass receipt fields.
 
 **Convergence requires no open P1/P2/P3 findings and complete required coverage for the verification pass.** Every retained finding triggers repair and affected-lane verification. A selective affected-lane pass may establish convergence when every required selected lane completes; missing required coverage reports `REVIEW INCOMPLETE`. Repeat the whole full fan-out only when the prior full review was incomplete or a repair changed a security-sensitive boundary.
+
+### 2.5 Terminal Model Report
+
+Every `STOP` in the loop exits model-dependent work into this terminal sequence;
+it does not bypass reporting or cleanup. After the final clean, findings-
+remaining, stalled, failed, blocked, or stopped disposition is settled, load
+model-router's `terminal-report-contract.md` and render exactly once from the
+loop-private ordered index to `<exact-run-root>/review/model-cost-report.json`
+and `.md`. Do not render per iteration. No model dispatch, review, repair, or
+convergence decision may follow generation. A renderer failure preserves the
+loop result and records only the one closed unavailable line.
 
 ### 3. Repository Cleanup
 
@@ -366,6 +387,10 @@ Repository cleanup: registered worktrees N->M, branches deleted J, missing K, bl
 Remaining: <ref> -- <reason> -- follow-up: <command>
 git status --porcelain: clean | <residue>
 ```
+
+After the inventory, append the already-generated terminal model/cost Markdown
+or its one closed unavailable line. The JSON and Markdown remain beside
+`run-cost-summary.json`; private receipts are removed during exact cleanup.
 
 ## Integration
 

--- a/plugins/dm-review/commands/dm-review-quick.md
+++ b/plugins/dm-review/commands/dm-review-quick.md
@@ -46,7 +46,9 @@ as optional P3 debt.
 
 ## Process
 
-1. Load the review skill from `plugins/dm-review/skills/review/SKILL.md`
+1. Load the review skill from `plugins/dm-review/skills/review/SKILL.md` with
+   `terminalModelReportOwner: dm-review` unless an enclosing Pipeline or
+   dm-review-loop invocation explicitly supplies its own owner
 2. Check security-sensitive paths first; escalate to Full mode if any match
 3. Compute the file-type trigger set from the diff (Go, Twig/PHP, UI)
 4. Execute in **Quick** mode with the provided argument:
@@ -55,7 +57,8 @@ as optional P3 debt.
    - Branch name: review that branch vs main
    - File path: review that specific file or directory
 5. Dispatch the two core lanes plus applicable existing UI/build/domain verification lanes
-6. Output the unified review report with the standard merge recommendation
+6. Output the unified review report with the standard merge recommendation,
+   followed by this invocation's one terminal operator report
 
 Every pre-execution abort and terminal outcome uses the review skill's
 exact-owned cleanup sequence; quick mode does not get a weaker cleanup path.

--- a/plugins/dm-review/commands/dm-review.md
+++ b/plugins/dm-review/commands/dm-review.md
@@ -12,7 +12,14 @@ Every retained P1, P2, and P3 finding is mandatory work: `/dm-review` tracks it,
 
 ## Process
 
-Load `plugins/dm-review/skills/review/SKILL.md` and execute in **Full** mode on the argument: none -- uncommitted changes or current branch vs main; PR number or URL -- that pull request; branch name -- that branch vs main; file path -- that file or directory. Output the unified review report with that merge recommendation.
+Load `plugins/dm-review/skills/review/SKILL.md` and execute in **Full** mode with
+`terminalModelReportOwner: dm-review` unless an enclosing Pipeline or
+dm-review-loop invocation explicitly supplies its own owner. On the argument:
+none -- uncommitted
+changes or current branch vs main; PR number or URL -- that pull request; branch
+name -- that branch vs main; file path -- that file or directory. Output the
+unified review report with that merge recommendation, followed by the one
+terminal operator report owned by this invocation.
 
 ## Synthesis and Contribution Contract
 

--- a/plugins/dm-review/skills/dm-review-loop/SKILL.md
+++ b/plugins/dm-review/skills/dm-review-loop/SKILL.md
@@ -76,6 +76,7 @@ full_review_baseline_complete = false
 full_fanout_override = true if DM_REVIEW_LOOP_FULL_FANOUT=1 in the environment, else false
 workflowClass = explicit request value, else "feature" with workflow_class_defaulted=true
 shadow_state = trusted runtime state directory, or "shadow unavailable"
+terminalModelReportOwner = "dm-review-loop"
 ```
 
 The canonical loop state and todo files remain authoritative. Pass the exact `workflowClass` and `workflow_class_defaulted` values into every nested `/dm-review-quick` or `/dm-review`, every `/dm-review-fix`, every final re-review, every iteration receipt, and the terminal receipt. Nested commands MUST NOT re-default, infer, or change the class. Resolve `$WORKFLOW_KERNEL` -- the workflow-kernel launcher script -- once per run, following the fail-closed resolution contract in the workflow-kernel plugin's `references/runtime-resolution.md`. Initialize this run under `.workflow-kernel/runs/<run-id>`; the kernel derives and verifies the immutable repository scope from the state directory, and no caller-selected lease root is accepted. Append lifecycle transitions there. Materialize the validated request at `<exact-run-root>/review/request.json`. Before corresponding authoritative actions, produce and seal the independent prediction exactly once:
@@ -91,6 +92,12 @@ Rewrite `<exact-run-root>/review/authoritative-receipts.json` as the complete or
 ```
 
 Shadow prediction never advances the loop, declares convergence, changes a finding, or converts the terminal result. Record every requested, attempted, implemented-by, fallback, and reason field; do not silently drop unavailable lanes.
+
+Create one mode-`0700` `<exact-run-root>/receipts/private/router/` directory and
+its ordered `terminal-receipt-index.json` for the entire loop. Every nested
+review, final verification pass, and routed repair receives that same directory
+and `terminalModelReportOwner: dm-review-loop`; nested invocations suppress
+their own reports. Extend the index in deterministic dispatch-start order.
 
 ### 2. Review-Fix Loop
 
@@ -205,10 +212,12 @@ while iteration < max_iterations:
   prior_review_head = git rev-parse HEAD
   if mode == "quick":
     Run /dm-review-quick {target} with review_lane_allowlist when non-null
-      with workflowClass and workflow_class_defaulted forwarded unchanged
+      with workflowClass and workflow_class_defaulted forwarded unchanged,
+      the loop-private router directory/index, and terminal reporting suppressed
   else:
     Run /dm-review {target} with review_lane_allowlist when non-null
-      with workflowClass and workflow_class_defaulted forwarded unchanged
+      with workflowClass and workflow_class_defaulted forwarded unchanged,
+      the loop-private router directory/index, and terminal reporting suppressed
 
   Consume and validate the nested review's authoritative coverage receipt: one
     row per selected lane with requested, attempted, implemented-by, status,
@@ -286,7 +295,8 @@ while iteration < max_iterations:
     STOP -- needs attention
 
   # Fix every retained finding (P1/P2/P3).
-  Run /dm-review-fix with workflowClass and workflow_class_defaulted forwarded unchanged
+  Run /dm-review-fix with workflowClass and workflow_class_defaulted forwarded unchanged,
+    using the loop-private router directory/index and terminal reporting suppressed
   # dm-review-fix resolves and cleans up todo files
 
   # If this was the last iteration, run one final review to verify.
@@ -328,6 +338,17 @@ rules, the mode-specific trigger sources, the `review_lane_allowlist` handoff,
 and the per-pass receipt fields.
 
 **Convergence requires no open P1/P2/P3 findings and complete required coverage for the verification pass.** Every retained finding triggers repair and affected-lane verification. A selective affected-lane pass may establish convergence when every required selected lane completes; missing required coverage reports `REVIEW INCOMPLETE`. Repeat the whole full fan-out only when the prior full review was incomplete or a repair changed a security-sensitive boundary.
+
+### 2.5 Terminal Model Report
+
+Every `STOP` in the loop exits model-dependent work into this terminal sequence;
+it does not bypass reporting or cleanup. After the final clean, findings-
+remaining, stalled, failed, blocked, or stopped disposition is settled, load
+model-router's `terminal-report-contract.md` and render exactly once from the
+loop-private ordered index to `<exact-run-root>/review/model-cost-report.json`
+and `.md`. Do not render per iteration. No model dispatch, review, repair, or
+convergence decision may follow generation. A renderer failure preserves the
+loop result and records only the one closed unavailable line.
 
 ### 3. Repository Cleanup
 
@@ -381,6 +402,10 @@ Repository cleanup: registered worktrees N->M, branches deleted J, missing K, bl
 Remaining: <ref> -- <reason> -- follow-up: <command>
 git status --porcelain: clean | <residue>
 ```
+
+After the inventory, append the already-generated terminal model/cost Markdown
+or its one closed unavailable line. The JSON and Markdown remain beside
+`run-cost-summary.json`; private receipts are removed during exact cleanup.
 
 ## Integration
 

--- a/plugins/dm-review/skills/dm-review-quick/SKILL.md
+++ b/plugins/dm-review/skills/dm-review-quick/SKILL.md
@@ -61,7 +61,9 @@ as optional P3 debt.
 
 ## Process
 
-1. Load the review skill from `plugins/dm-review/skills/review/SKILL.md`
+1. Load the review skill from `plugins/dm-review/skills/review/SKILL.md` with
+   `terminalModelReportOwner: dm-review` unless an enclosing Pipeline or
+   dm-review-loop invocation explicitly supplies its own owner
 2. Check security-sensitive paths first; escalate to Full mode if any match
 3. Compute the file-type trigger set from the diff (Go, Twig/PHP, UI)
 4. Execute in **Quick** mode with the provided argument:
@@ -70,7 +72,8 @@ as optional P3 debt.
    - Branch name: review that branch vs main
    - File path: review that specific file or directory
 5. Dispatch the two core lanes plus applicable existing UI/build/domain verification lanes
-6. Output the unified review report with the standard merge recommendation
+6. Output the unified review report with the standard merge recommendation,
+   followed by this invocation's one terminal operator report
 
 Every pre-execution abort and terminal outcome uses the review skill's
 exact-owned cleanup sequence; quick mode does not get a weaker cleanup path.

--- a/plugins/dm-review/skills/dm-review/SKILL.md
+++ b/plugins/dm-review/skills/dm-review/SKILL.md
@@ -27,7 +27,14 @@ Every retained P1, P2, and P3 finding is mandatory work: `/dm-review` tracks it,
 
 ## Process
 
-Load `plugins/dm-review/skills/review/SKILL.md` and execute in **Full** mode on the argument: none -- uncommitted changes or current branch vs main; PR number or URL -- that pull request; branch name -- that branch vs main; file path -- that file or directory. Output the unified review report with that merge recommendation.
+Load `plugins/dm-review/skills/review/SKILL.md` and execute in **Full** mode with
+`terminalModelReportOwner: dm-review` unless an enclosing Pipeline or
+dm-review-loop invocation explicitly supplies its own owner. On the argument:
+none -- uncommitted
+changes or current branch vs main; PR number or URL -- that pull request; branch
+name -- that branch vs main; file path -- that file or directory. Output the
+unified review report with that merge recommendation, followed by the one
+terminal operator report owned by this invocation.
 
 ## Synthesis and Contribution Contract
 

--- a/plugins/dm-review/skills/review/SKILL.md
+++ b/plugins/dm-review/skills/review/SKILL.md
@@ -40,6 +40,12 @@ failures, and false verification claims.
 - `/dm-review` -- Full review: all applicable agents + optional memory enrichment when callable
 - `/dm-review quick` -- Quick review: 2 core judgment lanes, plus applicable existing UI/build/domain verification lanes
 
+The caller supplies `terminalModelReportOwner` as `dm-review` for a standalone
+full or quick invocation, or as `pipeline|pipeline-run|dm-review-loop` when an
+enclosing workflow owns the terminal report. A nested invocation always uses
+the enclosing workflow's exact private router directory and ordered index and
+suppresses its own report.
+
 ## Review Tiers
 
 Default to the cheapest tier that fits.
@@ -515,6 +521,21 @@ Tracking may change location, but it never waives the finding or permits a clean
 
 Skip in Quick mode. Determine ai-memory availability from the callable-tool inventory or tool search, never by invoking a memory tool as a probe. When callable, preserve the existing RAG lookup and ai-memory write behavior. Load `${CLAUDE_SKILL_DIR}/references/review-optional-enrichment.md` only when those tools are callable. If absent, omit Phase 7 and 7b silently. Callable-tool failures append `Memory capture: failed -- <safe reason>` without blocking.
 
+### Phase 7c: Terminal Model Report Boundary
+
+All lane execution, consolidation, tracking, optional repair verification, and
+final disposition must be settled before this phase. When
+`terminalModelReportOwner` is `dm-review`, load model-router's
+`terminal-report-contract.md` and render exactly once from this invocation's
+ordered private index to `<exact-run-root>/review/model-cost-report.json` and
+`.md`. Do so before Phase 8 can remove private receipts. No model dispatch may
+follow generation.
+
+When the owner is `pipeline`, `pipeline-run`, or `dm-review-loop`, do not
+render. Preserve the exact private directory and index for that owner and keep
+all identity private. Reporting failure records only the contract's one closed
+unavailable line and never changes the review disposition or cleanup sequence.
+
 ### Phase 8: Repository Cleanup
 
 Runs in **every mode** (quick and full), on every exit path -- including `REVIEW INCOMPLETE`, `BLOCKS MERGE`, and a stalled convergence loop. Read `${CLAUDE_SKILL_DIR}/references/repo-cleanup-contract.md`; it is authoritative.
@@ -539,6 +560,11 @@ dirty worktree. Install this same Phase 8 sequence on every exit path.
 
 Never delete the feature branch under review. There is no condition under which a code review deletes the branch it was asked to review.
 
+For a standalone owner, preserve the already-generated JSON and Markdown beside
+`run-cost-summary.json` while cleaning its private receipts. For an enclosing
+owner, defer only that owner's exact private router directory and index; the
+enclosing workflow removes them after its one terminal render.
+
 ---
 
 ### Finalize Report and Deliver Handoff
@@ -546,6 +572,11 @@ Never delete the feature branch under review. There is no condition under which 
 Only after Phase 8 has completed, add its authoritative repository and Docker cleanup results to the provisional unified report. Then write the complete report to `.claude/ux-review/report.md` -- the existing dm-review artifact flow, not a new report subsystem.
 
 Deliver the compact human handoff after that write, following `references/output-format.md`. Preserve the complete unified report and all machine-readable companions in the established evidence flow. The compact handoff links `.claude/ux-review/report.md` and names any blocked cleanup requiring operator action. Do not dump the expanded report, provider tables, agent transcripts, synthesis ledger, cleanup inventory, or raw reports into visible chat by default.
+
+When `terminalModelReportOwner` is `dm-review`, append the already-generated
+compact model/cost Markdown, or its one closed unavailable line, after this
+handoff. An enclosing owner receives no identity-bearing report from this
+invocation.
 
 ---
 

--- a/plugins/dm-review/skills/review/references/full-lane-dispatch.md
+++ b/plugins/dm-review/skills/review/references/full-lane-dispatch.md
@@ -26,7 +26,9 @@ Quick mode keeps its existing smaller roster but uses the same role mapping.
 
 Resolve one coherent model-router bundle with Workflow Kernel and require
 `skills/model-router/references/role-dispatch.sh`, the request schema, and role
-policy. For each selected lane:
+policy at minimum version `0.2.0`. When this invocation owns terminal reporting,
+require `skills/model-router/references/render-terminal-report.sh` from that
+same bundle. For each selected lane:
 
 1. Build the common reviewer prompt from `reviewer-prompt-template.md`.
    Inline `reviewer-output-contract.md` exactly once. Resolve every trusted
@@ -50,6 +52,14 @@ policy. For each selected lane:
    repair provenance is unavailable, the independent lane remains unavailable.
    The two origin forms are mutually exclusive.
 6. Launch selected lanes in parallel when the host supports it.
+
+The terminal report owner supplies this exact private directory and its
+`terminal-receipt-index.json`. After a parallel fan-out joins, extend the index
+with settled receipt basenames in deterministic selected-lane order, never
+completion order. Standalone dm-review owns the index; Pipeline and
+dm-review-loop pass their enclosing index and suppress this invocation's report.
+Load model-router's `terminal-report-contract.md` only at the terminal boundary,
+never while constructing or dispatching lanes.
 
 Outside an explicit repository test harness, accept `disposition: completed`
 only when the companion also reports `evidenceSource: live` and

--- a/plugins/model-router/.claude-plugin/plugin.json
+++ b/plugins/model-router/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "model-router",
   "description": "Internal deterministic role resolver and one-shot dispatcher for provider-neutral model work",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "author": {
     "name": "Design Machines",
     "url": "https://designmachines.studio"

--- a/plugins/model-router/.codex-plugin/plugin.json
+++ b/plugins/model-router/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "model-router",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Internal deterministic role resolver and one-shot dispatcher for provider-neutral model work",
   "author": {
     "name": "Design Machines",

--- a/plugins/model-router/skills/model-router/SKILL.md
+++ b/plugins/model-router/skills/model-router/SKILL.md
@@ -58,3 +58,9 @@ preference schema is
 `${CLAUDE_SKILL_DIR}/references/operator-profile-schema.json`; an actual
 preference belongs in ignored `.dm/model-router.local.json` in the common
 checkout and must never contain operator identity.
+
+When a Pipeline, dm-review, or Assembly opinion invocation has reached a closed
+terminal state and no later model dispatch is possible, load
+`${CLAUDE_SKILL_DIR}/references/terminal-report-contract.md`. Its shared
+renderer is the sole operator-facing identity projection. Never load or run it
+during routing, implementation, review, repair, synthesis, or merge decisions.

--- a/plugins/model-router/skills/model-router/references/receipt-contract.md
+++ b/plugins/model-router/skills/model-router/references/receipt-contract.md
@@ -10,3 +10,10 @@ The ordinary caller sees only role, normalized capabilities, requested and
 effective effort, anonymous participant ID, disposition, fallback state, and
 output destination. Concrete receipt fields must never be copied into peer
 prompts or ordinary orchestration summaries.
+
+After every model-dependent decision has settled, the terminal workflow may
+load `terminal-report-contract.md` and pass one exact run-private ordered index
+to `render-terminal-report.sh`. That renderer projects only its closed field
+allowlist into operator JSON and Markdown. It never exposes prompts, outputs,
+provider bodies, arbitrary errors, credentials, endpoints, environments, or
+family-independence internals. No model dispatch may follow the projection.

--- a/plugins/model-router/skills/model-router/references/render-terminal-report.sh
+++ b/plugins/model-router/skills/model-router/references/render-terminal-report.sh
@@ -1,0 +1,274 @@
+#!/usr/bin/env bash
+# render-terminal-report.sh -- terminal-only operator model and cost report.
+#
+# Usage:
+#   render-terminal-report.sh --receipt-index INDEX --status STATUS \
+#     --json-output PATH --markdown-output PATH
+#
+# INDEX is a schema-versioned JSON file in the exact private receipt directory.
+# Its receiptFiles array contains safe basenames in deterministic dispatch order.
+
+set -euo pipefail
+PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
+export PATH
+
+RECEIPT_INDEX=""
+STATUS=""
+JSON_OUTPUT=""
+MARKDOWN_OUTPUT=""
+
+fail() {
+  printf 'terminal-model-report: %s\n' "$1" >&2
+  exit "${2:-1}"
+}
+
+usage() {
+  fail "invalid-invocation" 2
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --receipt-index) [ "$#" -ge 2 ] || usage; RECEIPT_INDEX="$2"; shift 2 ;;
+    --status) [ "$#" -ge 2 ] || usage; STATUS="$2"; shift 2 ;;
+    --json-output) [ "$#" -ge 2 ] || usage; JSON_OUTPUT="$2"; shift 2 ;;
+    --markdown-output) [ "$#" -ge 2 ] || usage; MARKDOWN_OUTPUT="$2"; shift 2 ;;
+    *) usage ;;
+  esac
+done
+
+[ -n "$RECEIPT_INDEX" ] && [ -n "$STATUS" ] && [ -n "$JSON_OUTPUT" ] && [ -n "$MARKDOWN_OUTPUT" ] || usage
+case "$STATUS" in complete|failed|blocked|stopped) ;; *) fail "non-terminal-status" 2 ;; esac
+command -v jq >/dev/null 2>&1 || fail "jq-unavailable"
+
+[ -f "$RECEIPT_INDEX" ] && [ ! -L "$RECEIPT_INDEX" ] || fail "receipt-index-unavailable"
+INDEX_PARENT="$(cd "$(dirname "$RECEIPT_INDEX")" 2>/dev/null && pwd -P)" || fail "receipt-index-unavailable"
+INDEX_NAME="$(basename "$RECEIPT_INDEX")"
+RECEIPT_INDEX="$INDEX_PARENT/$INDEX_NAME"
+
+jq -e '
+  type == "object" and
+  .schemaVersion == 1 and
+  (.receiptFiles | type) == "array" and
+  all(.receiptFiles[];
+    type == "string" and
+    test("^[A-Za-z0-9][A-Za-z0-9._-]{0,126}\\.json$") and
+    . != "terminal-receipt-index.json")
+' "$RECEIPT_INDEX" >/dev/null 2>&1 || fail "receipt-index-invalid"
+
+validate_output() {
+  local output="$1" parent name
+  case "$output" in *$'\n'*|*$'\r'*|*$'\t'*|*'`'*) fail "output-destination-invalid" 2 ;; esac
+  parent="$(dirname "$output")"
+  name="$(basename "$output")"
+  [ -n "$name" ] && [ "$name" != . ] && [ "$name" != .. ] || fail "output-destination-invalid" 2
+  [ -d "$parent" ] && [ ! -L "$parent" ] || fail "output-destination-unavailable"
+  parent="$(cd "$parent" 2>/dev/null && pwd -P)" || fail "output-destination-unavailable"
+  if [ -e "$parent/$name" ] && [ -L "$parent/$name" ]; then
+    fail "output-destination-unavailable"
+  fi
+  printf '%s/%s\n' "$parent" "$name"
+}
+
+JSON_OUTPUT="$(validate_output "$JSON_OUTPUT")"
+MARKDOWN_OUTPUT="$(validate_output "$MARKDOWN_OUTPUT")"
+[ "$JSON_OUTPUT" != "$MARKDOWN_OUTPUT" ] || fail "output-destinations-conflict" 2
+
+TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/terminal-model-report.XXXXXX")" || fail "temporary-storage-unavailable"
+cleanup() { rm -rf "$TMP_ROOT"; }
+trap cleanup EXIT
+VALID_RECEIPTS="$TMP_ROOT/valid-receipts.ndjson"
+: > "$VALID_RECEIPTS"
+
+INDEX_COUNT=0
+VALID_COUNT=0
+while IFS= read -r receipt_name; do
+  INDEX_COUNT=$((INDEX_COUNT + 1))
+  receipt_path="$INDEX_PARENT/$receipt_name"
+  [ -f "$receipt_path" ] && [ ! -L "$receipt_path" ] || continue
+  if jq -e '
+    type == "object" and
+    .schemaVersion == 1 and
+    (.receiptId | type) == "string" and
+    (.receiptId | test("^dispatch-[a-f0-9]{24}$")) and
+    (.requested | type) == "object" and
+    (.attempts | type) == "array" and
+    all(.attempts[]; type == "object") and
+    ((.served == null) or ((.served | type) == "object")) and
+    ((.fallback | type) == "boolean")
+  ' "$receipt_path" >/dev/null 2>&1; then
+    jq -c '.' "$receipt_path" >> "$VALID_RECEIPTS"
+    VALID_COUNT=$((VALID_COUNT + 1))
+  fi
+done < <(jq -r '.receiptFiles[]' "$RECEIPT_INDEX")
+
+JSON_PARENT="$(dirname "$JSON_OUTPUT")"
+JSON_NAME="$(basename "$JSON_OUTPUT")"
+MARKDOWN_PARENT="$(dirname "$MARKDOWN_OUTPUT")"
+MARKDOWN_NAME="$(basename "$MARKDOWN_OUTPUT")"
+JSON_TMP="$(mktemp "$JSON_PARENT/.${JSON_NAME}.XXXXXX")" || fail "output-destination-unavailable"
+MARKDOWN_TMP="$(mktemp "$MARKDOWN_PARENT/.${MARKDOWN_NAME}.XXXXXX")" || { rm -f "$JSON_TMP"; fail "output-destination-unavailable"; }
+
+if ! jq -S -s \
+  --arg status "$STATUS" \
+  --arg full_report "$JSON_OUTPUT" \
+  --argjson input_count "$INDEX_COUNT" \
+  --argjson valid_count "$VALID_COUNT" '
+  def safe_slug:
+    if type == "string" and length > 0 and length <= 128 and test("^[A-Za-z0-9][A-Za-z0-9._:/+-]*$")
+    then . else "unavailable" end;
+  def safe_role:
+    . as $value
+    | if type == "string" and (["architect","builder-deep","builder-fast","editorial","plan-critic","research-fast","review-deep","review-fast","security-review"] | index($value) != null)
+      then . else "unavailable" end;
+  def safe_effort:
+    . as $value
+    | if type == "string" and (["low","medium","high","max"] | index($value) != null)
+      then . else "unavailable" end;
+  def safe_transport:
+    . as $value
+    | if type == "string" and (["codex-cli","claude-cli","openrouter"] | index($value) != null)
+      then . else "unavailable" end;
+  def safe_billing:
+    . as $value
+    | if type == "string" and (["api","included-subscription","subscription-headroom-unknown","paid-credits","unavailable"] | index($value) != null)
+      then . else "unavailable" end;
+  def safe_outcome:
+    . as $value
+    | if type == "string" and (["served","failed","skipped"] | index($value) != null)
+      then . else "unavailable" end;
+  def nonnegative_number: if type == "number" and . >= 0 then . else null end;
+  def nonnegative_integer: if type == "number" and . >= 0 and floor == . then . else null end;
+  def unique_first:
+    reduce .[] as $item ({seen:{}, values:[]};
+      if .seen[$item] then . else .seen[$item] = true | .values += [$item] end) | .values;
+  def dedupe_receipts:
+    reduce .[] as $receipt ({seen:{}, values:[]};
+      if .seen[$receipt.receiptId] then .
+      else .seen[$receipt.receiptId] = true | .values += [$receipt]
+      end) | .values;
+  def tokens($served):
+    (($served.tokens.input_tokens // $served.tokens.prompt_tokens // null) | nonnegative_integer) as $input
+    | (($served.tokens.output_tokens // $served.tokens.completion_tokens // null) | nonnegative_integer) as $output
+    | (($served.tokens.total_tokens // null) | nonnegative_integer) as $total
+    | {input:$input, output:$output, total:$total,
+       status:(if $total == null then "unavailable" else "provider-reported" end),
+       provenance:(if $total == null then "unavailable" else
+         (if $served.tokenProvenance == "provider-receipt" then "provider-receipt" else "unavailable" end) end)};
+  def duration($value):
+    ($value | nonnegative_integer) as $seconds
+    | {seconds:$seconds, status:(if $seconds == null then "unavailable" else "measured" end)};
+  def billed_cost($served):
+    ($served.billedCostUsd | nonnegative_number) as $usd
+    | (if $served.costProvenance == "provider-receipt" and $usd != null then
+         {usd:$usd, status:"measured", provenance:"provider-receipt"}
+       else {usd:null, status:"unavailable", provenance:"unavailable"} end);
+  def normalize_receipt:
+    . as $receipt
+    | ($receipt.served // {}) as $served
+    | {
+        receiptId:$receipt.receiptId,
+        role:($receipt.requested.role | safe_role),
+        requestedEffort:($receipt.requested.effort | safe_effort),
+        effectiveEffort:($receipt.effectiveEffort | safe_effort),
+        matrixSnapshot:($receipt.matrixSnapshot | safe_slug),
+        fallback:$receipt.fallback,
+        billingMode:($served.billingMode | safe_billing),
+        attempts:[
+          $receipt.attempts | to_entries[]
+          | . as $entry
+          | ($entry.value.outcome | safe_outcome) as $outcome
+          | ($outcome == "served") as $was_served
+          | {
+              sequence:($entry.key + 1),
+              model:($entry.value.model | safe_slug),
+              provider:($entry.value.provider | safe_slug),
+              transport:($entry.value.transport | safe_transport),
+              billingMode:((if $was_served then $served.billingMode else $entry.value.billingMode end) | safe_billing),
+              duration:(if $was_served then duration($served.durationSeconds) else duration($entry.value.durationSeconds) end),
+              tokens:(if $was_served then tokens($served) else {input:null,output:null,total:null,status:"unavailable",provenance:"unavailable"} end),
+              billedCost:(if $was_served then billed_cost($served) else {usd:null,status:"unavailable",provenance:"unavailable"} end),
+              result:$outcome,
+              served:$was_served
+            }
+        ]
+      };
+  dedupe_receipts as $deduped
+  | ($deduped | map(normalize_receipt)) as $calls
+  | ($calls | map(.matrixSnapshot) | map(select(. != "unavailable")) | unique_first) as $matrices
+  | ($calls | map(.attempts[] | select(.billedCost.status == "measured") | .billedCost.usd) | add // 0) as $paid_total
+  | ($calls | map(select(.billingMode == "included-subscription" or .billingMode == "subscription-headroom-unknown")) | length) as $subscription_calls
+  | ($calls | map(select(.billingMode == "paid-credits")) | length) as $paid_credit_calls
+  | ($calls | map(select(.fallback)) | length) as $fallbacks
+  | ($calls | map(select(([.attempts[] | select(.served)][0].tokens.status // "unavailable") == "unavailable")) | length) as $unavailable_tokens
+  | ($calls | map(select(([.attempts[] | select(.served)][0].billedCost.status // "unavailable") == "unavailable")) | length) as $unavailable_cost
+  | ($calls | map(select(
+      (([.attempts[] | select(.served)][0].tokens.status // "unavailable") == "unavailable") or
+      (([.attempts[] | select(.served)][0].billedCost.status // "unavailable") == "unavailable")
+    )) | length) as $unmeasured
+  | {
+      schemaVersion:1,
+      runStatus:$status,
+      matrixSnapshots:$matrices,
+      calls:$calls,
+      summary:{
+        measuredPaidCostUsd:$paid_total,
+        subscriptionCalls:$subscription_calls,
+        paidCreditCalls:$paid_credit_calls,
+        fallbacks:$fallbacks,
+        unavailableTokenCalls:$unavailable_tokens,
+        unavailableCostCalls:$unavailable_cost,
+        unmeasuredUsageOrCostCalls:$unmeasured,
+        inputReceiptReferences:$input_count,
+        validReceiptObjects:$valid_count,
+        deduplicatedReceipts:($calls | length),
+        ignoredReceiptReferences:($input_count - $valid_count),
+        duplicateReceiptObjects:($valid_count - ($calls | length))
+      },
+      fullReport:$full_report
+    }
+' "$VALID_RECEIPTS" > "$JSON_TMP"; then
+  rm -f "$JSON_TMP" "$MARKDOWN_TMP"
+  fail "json-render-failed"
+fi
+
+if ! jq -r '
+  def display_money: "$" + tostring + " measured";
+  def display_duration: if .status == "measured" then (.seconds|tostring) + "s" else "unavailable" end;
+  def display_tokens: if .status == "provider-reported" then (.total|tostring) else "unavailable" end;
+  def display_cost($billing):
+    if .status == "measured" then (.usd | display_money)
+    elif $billing == "included-subscription" or $billing == "subscription-headroom-unknown" then "subscription allowance"
+    elif $billing == "paid-credits" then "paid-credit usage"
+    else "unavailable" end;
+  def matrix_line: if length == 0 then "unavailable" else join(", ") end;
+  def attempt_rows:
+    .calls[] as $call
+    | $call.attempts[]
+    | . as $attempt
+    | "| \($call.role) | \($attempt.model) \(if $attempt.served then "(served)" else "(attempted)" end) | \($attempt.provider) / \($attempt.transport) | \($call.requestedEffort) / \($call.effectiveEffort) | \($attempt.duration | display_duration) | \($attempt.tokens | display_tokens) | \($attempt.billedCost | display_cost($attempt.billingMode)) | \($attempt.result)\(if $attempt.served and $call.fallback then " (fallback)" else "" end) |";
+  [
+    "### Model & Cost Report",
+    "",
+    "Run: " + (.runStatus | ascii_upcase),
+    "Matrix: " + (.matrixSnapshots | matrix_line),
+    "",
+    "| Role | Attempted / served model | Rail | Effort requested / effective | Duration | Tokens | Billed cost | Result |",
+    "|---|---|---|---|---:|---:|---:|---|",
+    (attempt_rows),
+    "",
+    "Paid total: `" + (.summary.measuredPaidCostUsd | display_money) + "`",
+    "Subscription usage: `" + (.summary.subscriptionCalls|tostring) + " calls`",
+    "Paid-credit usage: `" + (.summary.paidCreditCalls|tostring) + " calls`",
+    "Fallbacks: `" + (.summary.fallbacks|tostring) + "`",
+    "Unmeasured usage/cost: `" + (.summary.unmeasuredUsageOrCostCalls|tostring) + " calls`",
+    "Full report: `" + .fullReport + "`"
+  ] | .[]
+' "$JSON_TMP" > "$MARKDOWN_TMP"; then
+  rm -f "$JSON_TMP" "$MARKDOWN_TMP"
+  fail "markdown-render-failed"
+fi
+
+mv "$JSON_TMP" "$JSON_OUTPUT" || { rm -f "$JSON_TMP" "$MARKDOWN_TMP"; fail "json-publication-failed"; }
+mv "$MARKDOWN_TMP" "$MARKDOWN_OUTPUT" || { rm -f "$MARKDOWN_TMP"; fail "markdown-publication-failed"; }
+
+printf '%s\n' "$MARKDOWN_OUTPUT"

--- a/plugins/model-router/skills/model-router/references/render-terminal-report.sh
+++ b/plugins/model-router/skills/model-router/references/render-terminal-report.sh
@@ -39,6 +39,9 @@ done
 [ -n "$RECEIPT_INDEX" ] && [ -n "$STATUS" ] && [ -n "$JSON_OUTPUT" ] && [ -n "$MARKDOWN_OUTPUT" ] || usage
 case "$STATUS" in complete|failed|blocked|stopped) ;; *) fail "non-terminal-status" 2 ;; esac
 command -v jq >/dev/null 2>&1 || fail "jq-unavailable"
+if [ -n "${MODEL_ROUTER_TEST_FAIL_MARKDOWN_PUBLICATION:-}" ] && [ "${MODEL_ROUTER_TEST_MODE:-0}" != 1 ]; then
+  fail "test-hook-requires-test-mode" 2
+fi
 
 [ -f "$RECEIPT_INDEX" ] && [ ! -L "$RECEIPT_INDEX" ] || fail "receipt-index-unavailable"
 INDEX_PARENT="$(cd "$(dirname "$RECEIPT_INDEX")" 2>/dev/null && pwd -P)" || fail "receipt-index-unavailable"
@@ -63,8 +66,8 @@ validate_output() {
   [ -n "$name" ] && [ "$name" != . ] && [ "$name" != .. ] || fail "output-destination-invalid" 2
   [ -d "$parent" ] && [ ! -L "$parent" ] || fail "output-destination-unavailable"
   parent="$(cd "$parent" 2>/dev/null && pwd -P)" || fail "output-destination-unavailable"
-  if [ -e "$parent/$name" ] && [ -L "$parent/$name" ]; then
-    fail "output-destination-unavailable"
+  if [ -e "$parent/$name" ]; then
+    [ ! -L "$parent/$name" ] && [ -f "$parent/$name" ] || fail "output-destination-unavailable"
   fi
   printf '%s/%s\n' "$parent" "$name"
 }
@@ -147,13 +150,15 @@ if ! jq -S -s \
       else .seen[$receipt.receiptId] = true | .values += [$receipt]
       end) | .values;
   def tokens($served):
-    (($served.tokens.input_tokens // $served.tokens.prompt_tokens // null) | nonnegative_integer) as $input
-    | (($served.tokens.output_tokens // $served.tokens.completion_tokens // null) | nonnegative_integer) as $output
-    | (($served.tokens.total_tokens // null) | nonnegative_integer) as $total
-    | {input:$input, output:$output, total:$total,
-       status:(if $total == null then "unavailable" else "provider-reported" end),
-       provenance:(if $total == null then "unavailable" else
-         (if $served.tokenProvenance == "provider-receipt" then "provider-receipt" else "unavailable" end) end)};
+    (if ($served.tokens | type) == "object" then $served.tokens else {} end) as $usage
+    | (($usage.input_tokens // $usage.prompt_tokens // null) | nonnegative_integer) as $input
+    | (($usage.output_tokens // $usage.completion_tokens // null) | nonnegative_integer) as $output
+    | (($usage.total_tokens // null) | nonnegative_integer) as $total
+    | if $served.tokenProvenance == "provider-receipt" and $total != null then
+        {input:$input, output:$output, total:$total, status:"provider-reported", provenance:"provider-receipt"}
+      else
+        {input:null, output:null, total:null, status:"unavailable", provenance:"unavailable"}
+      end;
   def duration($value):
     ($value | nonnegative_integer) as $seconds
     | {seconds:$seconds, status:(if $seconds == null then "unavailable" else "measured" end)};
@@ -165,6 +170,12 @@ if ! jq -S -s \
   def normalize_receipt:
     . as $receipt
     | ($receipt.served // {}) as $served
+    | ($receipt.attempts | to_entries | map(select(.value.outcome == "served"))) as $served_entries
+    | (if ($receipt.served | type) == "object" and ($served_entries | length) == 1 and
+          $served_entries[0].value.model == $served.model and
+          $served_entries[0].value.provider == $served.provider and
+          $served_entries[0].value.transport == $served.transport
+       then $served_entries[0].key else null end) as $served_index
     | {
         receiptId:$receipt.receiptId,
         role:($receipt.requested.role | safe_role),
@@ -172,12 +183,13 @@ if ! jq -S -s \
         effectiveEffort:($receipt.effectiveEffort | safe_effort),
         matrixSnapshot:($receipt.matrixSnapshot | safe_slug),
         fallback:$receipt.fallback,
-        billingMode:($served.billingMode | safe_billing),
+        billingMode:((if $served_index == null then "unavailable" else $served.billingMode end) | safe_billing),
         attempts:[
           $receipt.attempts | to_entries[]
           | . as $entry
-          | ($entry.value.outcome | safe_outcome) as $outcome
-          | ($outcome == "served") as $was_served
+          | (($entry.value.outcome | safe_outcome)) as $raw_outcome
+          | ($served_index != null and $entry.key == $served_index) as $was_served
+          | (if $raw_outcome == "served" and ($was_served | not) then "unavailable" else $raw_outcome end) as $outcome
           | {
               sequence:($entry.key + 1),
               model:($entry.value.model | safe_slug),
@@ -269,6 +281,14 @@ if ! jq -r '
 fi
 
 mv "$JSON_TMP" "$JSON_OUTPUT" || { rm -f "$JSON_TMP" "$MARKDOWN_TMP"; fail "json-publication-failed"; }
-mv "$MARKDOWN_TMP" "$MARKDOWN_OUTPUT" || { rm -f "$MARKDOWN_TMP"; fail "markdown-publication-failed"; }
+if [ -n "${MODEL_ROUTER_TEST_FAIL_MARKDOWN_PUBLICATION:-}" ]; then
+  markdown_publication_rc=1
+else
+  mv "$MARKDOWN_TMP" "$MARKDOWN_OUTPUT" || markdown_publication_rc=$?
+fi
+if [ "${markdown_publication_rc:-0}" -ne 0 ]; then
+  rm -f "$MARKDOWN_TMP" "$JSON_OUTPUT" "$MARKDOWN_OUTPUT"
+  fail "markdown-publication-failed"
+fi
 
 printf '%s\n' "$MARKDOWN_OUTPUT"

--- a/plugins/model-router/skills/model-router/references/terminal-report-contract.md
+++ b/plugins/model-router/skills/model-router/references/terminal-report-contract.md
@@ -1,0 +1,91 @@
+# Terminal operator model and cost report
+
+This contract is the only point where concrete router identity may leave a
+private receipt. It runs for the human operator only, after the invocation has
+a closed terminal status and every model-dependent decision has settled.
+
+## Terminal ownership
+
+Exactly one workflow owns reporting for an invocation:
+
+| Invocation | Terminal report owner | Nested behavior |
+|---|---|---|
+| `/pipeline` | the Pipeline caller after its final disposition gate | execution-orchestrator and nested dm-review suppress reporting |
+| `/pipeline-run` | execution-orchestrator | nested dm-review suppresses reporting |
+| `/dm-review` or `/dm-review-quick` | the standalone review invocation | no nested owner |
+| `/dm-review-loop` | the loop after its last verification pass | every internal dm-review pass suppresses reporting |
+| Assembly opinion comparison | the coordinator after synthesis | no report when no routed opinion ran |
+
+Suppression means identity remains private and the exact receipt directory and
+index remain available to the terminal owner. It never means delete the
+receipts before the owner has rendered or closed reporting as unavailable.
+
+## Ordered private index
+
+Every terminal owner uses one mode-`0700` run-private router directory. The
+file `terminal-receipt-index.json` in that directory has exactly:
+
+```json
+{
+  "schemaVersion": 1,
+  "receiptFiles": ["dispatch-a.json", "dispatch-b.json"]
+}
+```
+
+Entries are safe basenames for files in that same directory. Record them in
+dispatch-start order. For a parallel fan-out, precompute the deterministic
+selected-lane order and write the settled receipt basenames in that order after
+the fan-out joins; completion order never reorders the index. Nested workflows
+receive the owner's directory and extend this same index instead of creating a
+second report scope. Duplicate references are permitted; the renderer keeps
+the first valid object for each receipt ID.
+
+The index is a bounded input list, not a public receipt or event stream. Never
+copy its contents or any private receipt into a prompt, planning artifact,
+review output, synthesis input, merge decision, public disposition, or
+run-cost summary.
+
+## Closed generation boundary
+
+Resolve one coherent model-router bundle at minimum version `0.2.0` and require
+`skills/model-router/references/render-terminal-report.sh`. Generate only when:
+
+1. implementation, reviews, repairs, synthesis, requirements checks, and merge
+   or recommendation decisions are final;
+2. no later model dispatch can occur in this invocation; and
+3. terminal status is one of `complete`, `failed`, `blocked`, or `stopped`.
+
+Invoke exactly once:
+
+```bash
+"$MODEL_ROUTER_ROOT/skills/model-router/references/render-terminal-report.sh" \
+  --receipt-index <exact-private-router-dir>/terminal-receipt-index.json \
+  --status <complete|failed|blocked|stopped> \
+  --json-output <durable-run-dir>/model-cost-report.json \
+  --markdown-output <durable-run-dir>/model-cost-report.md
+```
+
+The JSON and Markdown paths sit beside the workflow's existing run-cost
+artifacts. Generate them before private receipts or their exact-owned directory
+are cleaned. Then complete cleanup and terminal receipts, and append the
+already-generated Markdown to the human handoff. The report is never read by a
+model and no dispatch, review, repair, synthesis, routing, or merge decision may
+follow generation or display.
+
+Failed and blocked invocations still render incurred attempts once dispatch has
+stopped. An Assembly coordinator invocation that made no routed opinion call
+does not create an empty index or report.
+
+## Failure closure
+
+Reporting is observation-only. Do not retry it. If the renderer fails, accept
+only its closed stderr shape `terminal-model-report: <lowercase-hyphen-reason>`;
+otherwise use `renderer-failed`. Preserve the workflow result, continue exact
+cleanup, and append exactly one line to the terminal handoff:
+
+```text
+Model & Cost Report unavailable: <closed reason>
+```
+
+Failure never reopens review, triggers another model, blocks cleanup, requests
+approval, changes the workflow result, or retries provider work.

--- a/plugins/model-router/skills/model-router/tests/terminal-report/01-openrouter-measured.json
+++ b/plugins/model-router/skills/model-router/tests/terminal-report/01-openrouter-measured.json
@@ -1,0 +1,22 @@
+{
+  "schemaVersion": 1,
+  "receiptId": "dispatch-000000000000000000000001",
+  "requested": {"role": "builder-fast", "effort": "high"},
+  "attempts": [
+    {"model": "fictional/lattice-flash", "provider": "openrouter", "transport": "openrouter", "billingMode": "api", "outcome": "served", "durationSeconds": 12}
+  ],
+  "served": {
+    "model": "fictional/lattice-flash",
+    "provider": "openrouter",
+    "transport": "openrouter",
+    "billingMode": "api",
+    "durationSeconds": 12,
+    "tokens": {"prompt_tokens": 40000, "completion_tokens": 2810, "total_tokens": 42810},
+    "tokenProvenance": "provider-receipt",
+    "billedCostUsd": 0.019,
+    "costProvenance": "provider-receipt"
+  },
+  "effectiveEffort": "high",
+  "fallback": false,
+  "matrixSnapshot": "openrouter:2026-08-25"
+}

--- a/plugins/model-router/skills/model-router/tests/terminal-report/02-native-subscription.json
+++ b/plugins/model-router/skills/model-router/tests/terminal-report/02-native-subscription.json
@@ -1,0 +1,22 @@
+{
+  "schemaVersion": 1,
+  "receiptId": "dispatch-000000000000000000000002",
+  "requested": {"role": "architect", "effort": "high"},
+  "attempts": [
+    {"model": "fictional-native-architect", "provider": "fictional-native", "transport": "claude-cli", "billingMode": "included-subscription", "outcome": "served", "durationSeconds": 31}
+  ],
+  "served": {
+    "model": "fictional-native-architect",
+    "provider": "fictional-native",
+    "transport": "claude-cli",
+    "billingMode": "included-subscription",
+    "durationSeconds": 31,
+    "tokens": null,
+    "tokenProvenance": "unavailable",
+    "billedCostUsd": null,
+    "costProvenance": "unavailable"
+  },
+  "effectiveEffort": "high",
+  "fallback": false,
+  "matrixSnapshot": "openrouter:2026-08-25"
+}

--- a/plugins/model-router/skills/model-router/tests/terminal-report/03-paid-credit.json
+++ b/plugins/model-router/skills/model-router/tests/terminal-report/03-paid-credit.json
@@ -1,0 +1,22 @@
+{
+  "schemaVersion": 1,
+  "receiptId": "dispatch-000000000000000000000003",
+  "requested": {"role": "research-fast", "effort": "medium"},
+  "attempts": [
+    {"model": "fictional-credit-researcher", "provider": "fictional-native", "transport": "claude-cli", "billingMode": "paid-credits", "outcome": "served", "durationSeconds": 8}
+  ],
+  "served": {
+    "model": "fictional-credit-researcher",
+    "provider": "fictional-native",
+    "transport": "claude-cli",
+    "billingMode": "paid-credits",
+    "durationSeconds": 8,
+    "tokens": {"input_tokens": 400, "output_tokens": 100, "total_tokens": 500},
+    "tokenProvenance": "provider-receipt",
+    "billedCostUsd": 0.011,
+    "costProvenance": "provider-receipt"
+  },
+  "effectiveEffort": "medium",
+  "fallback": false,
+  "matrixSnapshot": "openrouter:2026-08-25"
+}

--- a/plugins/model-router/skills/model-router/tests/terminal-report/04-fallback-duplicate-id.json
+++ b/plugins/model-router/skills/model-router/tests/terminal-report/04-fallback-duplicate-id.json
@@ -1,0 +1,12 @@
+{
+  "schemaVersion": 1,
+  "receiptId": "dispatch-000000000000000000000004",
+  "requested": {"role": "review-deep", "effort": "high"},
+  "attempts": [
+    {"model": "fictional/duplicate-must-not-replace-first", "provider": "openrouter", "transport": "openrouter", "billingMode": "api", "outcome": "served", "durationSeconds": 99}
+  ],
+  "served": {"model": "fictional/duplicate-must-not-replace-first", "provider": "openrouter", "transport": "openrouter", "billingMode": "api", "durationSeconds": 99, "tokens": null, "tokenProvenance": "unavailable", "billedCostUsd": 9.99, "costProvenance": "provider-receipt"},
+  "effectiveEffort": "high",
+  "fallback": false,
+  "matrixSnapshot": "openrouter:2026-08-25"
+}

--- a/plugins/model-router/skills/model-router/tests/terminal-report/04-fallback.json
+++ b/plugins/model-router/skills/model-router/tests/terminal-report/04-fallback.json
@@ -1,0 +1,24 @@
+{
+  "schemaVersion": 1,
+  "receiptId": "dispatch-000000000000000000000004",
+  "requested": {"role": "review-deep", "effort": "high"},
+  "attempts": [
+    {"model": "fictional/first-reviewer", "provider": "openrouter", "transport": "openrouter", "billingMode": "api", "outcome": "failed", "reason": "ARBITRARY_PROVIDER_FAILURE_TEXT_MUST_NOT_RENDER", "durationSeconds": 4},
+    {"model": "fictional/second-reviewer", "provider": "openrouter", "transport": "openrouter", "billingMode": "api", "outcome": "served", "durationSeconds": 19}
+  ],
+  "served": {
+    "model": "fictional/second-reviewer",
+    "provider": "openrouter",
+    "transport": "openrouter",
+    "billingMode": "api",
+    "durationSeconds": 19,
+    "tokens": {"prompt_tokens": 15000, "completion_tokens": 3204, "total_tokens": 18204},
+    "tokenProvenance": "provider-receipt",
+    "billedCostUsd": 0.073,
+    "costProvenance": "provider-receipt"
+  },
+  "effectiveEffort": "high",
+  "fallback": true,
+  "fallbackReason": "transport-unavailable",
+  "matrixSnapshot": "openrouter:2026-08-25"
+}

--- a/plugins/model-router/skills/model-router/tests/terminal-report/05-terminal-unavailable.json
+++ b/plugins/model-router/skills/model-router/tests/terminal-report/05-terminal-unavailable.json
@@ -1,0 +1,14 @@
+{
+  "schemaVersion": 1,
+  "receiptId": "dispatch-000000000000000000000005",
+  "requested": {"role": "security-review", "effort": "high"},
+  "attempts": [
+    {"model": "fictional/security-one", "provider": "openrouter", "transport": "openrouter", "billingMode": "api", "outcome": "failed", "durationSeconds": 6},
+    {"model": "fictional-security-native", "provider": "fictional-native", "transport": "codex-cli", "outcome": "skipped"}
+  ],
+  "served": null,
+  "effectiveEffort": "high",
+  "fallback": true,
+  "fallbackReason": "transport-unavailable",
+  "matrixSnapshot": "openrouter:2026-08-25"
+}

--- a/plugins/model-router/skills/model-router/tests/terminal-report/06-missing-measurement.json
+++ b/plugins/model-router/skills/model-router/tests/terminal-report/06-missing-measurement.json
@@ -1,0 +1,22 @@
+{
+  "schemaVersion": 1,
+  "receiptId": "dispatch-000000000000000000000006",
+  "requested": {"role": "plan-critic", "effort": "max"},
+  "attempts": [
+    {"model": "fictional/critic", "provider": "openrouter", "transport": "openrouter", "billingMode": "api", "outcome": "served"}
+  ],
+  "served": {
+    "model": "fictional/critic",
+    "provider": "openrouter",
+    "transport": "openrouter",
+    "billingMode": "api",
+    "durationSeconds": null,
+    "tokens": {"prompt_tokens": null, "completion_tokens": null},
+    "tokenProvenance": "unavailable",
+    "billedCostUsd": null,
+    "costProvenance": "unavailable"
+  },
+  "effectiveEffort": "high",
+  "fallback": false,
+  "matrixSnapshot": "fictional:2026-08-26"
+}

--- a/plugins/model-router/skills/model-router/tests/terminal-report/07-untrusted-fields.json
+++ b/plugins/model-router/skills/model-router/tests/terminal-report/07-untrusted-fields.json
@@ -1,0 +1,25 @@
+{
+  "schemaVersion": 1,
+  "receiptId": "dispatch-000000000000000000000007",
+  "requested": {"role": "editorial", "effort": "low", "prompt": "REFLECTED_INPUT_MUST_NOT_RENDER"},
+  "attempts": [
+    {"model": "REFLECTED INPUT MUST NOT RENDER", "provider": "fictional-provider", "transport": "openrouter", "billingMode": "api", "outcome": "served", "durationSeconds": -7, "providerError": "ARBITRARY_PROVIDER_BODY_MUST_NOT_RENDER"}
+  ],
+  "served": {
+    "model": "REFLECTED INPUT MUST NOT RENDER",
+    "provider": "fictional-provider",
+    "transport": "openrouter",
+    "billingMode": "api",
+    "durationSeconds": -7,
+    "tokens": {"total_tokens": "not-a-number"},
+    "tokenProvenance": "provider-receipt",
+    "billedCostUsd": 999,
+    "costProvenance": "untrusted-text",
+    "providerResponseBody": "ARBITRARY_PROVIDER_BODY_MUST_NOT_RENDER"
+  },
+  "effectiveEffort": "low",
+  "fallback": false,
+  "matrixSnapshot": "REFLECTED MATRIX TEXT MUST NOT RENDER",
+  "output": "MODEL_OUTPUT_MUST_NOT_RENDER",
+  "credentials": "CREDENTIAL_MUST_NOT_RENDER"
+}

--- a/plugins/model-router/skills/model-router/tests/terminal-report/08-nonobject-tokens.json
+++ b/plugins/model-router/skills/model-router/tests/terminal-report/08-nonobject-tokens.json
@@ -1,0 +1,12 @@
+{
+  "schemaVersion": 1,
+  "receiptId": "dispatch-000000000000000000000008",
+  "requested": {"role": "review-fast", "effort": "medium"},
+  "attempts": [
+    {"model": "fictional/nonobject-usage", "provider": "openrouter", "transport": "openrouter", "billingMode": "api", "outcome": "served", "durationSeconds": 2}
+  ],
+  "served": {"model": "fictional/nonobject-usage", "provider": "openrouter", "transport": "openrouter", "billingMode": "api", "durationSeconds": 2, "tokens": "provider text", "tokenProvenance": "provider-receipt", "billedCostUsd": null, "costProvenance": "unavailable"},
+  "effectiveEffort": "medium",
+  "fallback": false,
+  "matrixSnapshot": "openrouter:2026-08-25"
+}

--- a/plugins/model-router/skills/model-router/tests/terminal-report/09-untrusted-token-provenance.json
+++ b/plugins/model-router/skills/model-router/tests/terminal-report/09-untrusted-token-provenance.json
@@ -1,0 +1,12 @@
+{
+  "schemaVersion": 1,
+  "receiptId": "dispatch-000000000000000000000009",
+  "requested": {"role": "review-fast", "effort": "medium"},
+  "attempts": [
+    {"model": "fictional/untrusted-usage", "provider": "openrouter", "transport": "openrouter", "billingMode": "api", "outcome": "served", "durationSeconds": 3}
+  ],
+  "served": {"model": "fictional/untrusted-usage", "provider": "openrouter", "transport": "openrouter", "billingMode": "api", "durationSeconds": 3, "tokens": {"total_tokens": 777}, "tokenProvenance": "reflected-input", "billedCostUsd": 0.005, "costProvenance": "provider-receipt"},
+  "effectiveEffort": "medium",
+  "fallback": false,
+  "matrixSnapshot": "openrouter:2026-08-25"
+}

--- a/plugins/model-router/skills/model-router/tests/terminal-report/10-multiple-served-attempts.json
+++ b/plugins/model-router/skills/model-router/tests/terminal-report/10-multiple-served-attempts.json
@@ -1,0 +1,13 @@
+{
+  "schemaVersion": 1,
+  "receiptId": "dispatch-000000000000000000000010",
+  "requested": {"role": "review-deep", "effort": "high"},
+  "attempts": [
+    {"model": "fictional/served-one", "provider": "openrouter", "transport": "openrouter", "billingMode": "api", "outcome": "served", "durationSeconds": 4},
+    {"model": "fictional/served-two", "provider": "openrouter", "transport": "openrouter", "billingMode": "api", "outcome": "served", "durationSeconds": 5}
+  ],
+  "served": {"model": "fictional/served-two", "provider": "openrouter", "transport": "openrouter", "billingMode": "api", "durationSeconds": 5, "tokens": {"total_tokens": 999}, "tokenProvenance": "provider-receipt", "billedCostUsd": 0.5, "costProvenance": "provider-receipt"},
+  "effectiveEffort": "high",
+  "fallback": true,
+  "matrixSnapshot": "openrouter:2026-08-25"
+}

--- a/plugins/model-router/skills/model-router/tests/terminal-report/edge-receipt-index.json
+++ b/plugins/model-router/skills/model-router/tests/terminal-report/edge-receipt-index.json
@@ -1,0 +1,8 @@
+{
+  "schemaVersion": 1,
+  "receiptFiles": [
+    "08-nonobject-tokens.json",
+    "09-untrusted-token-provenance.json",
+    "10-multiple-served-attempts.json"
+  ]
+}

--- a/plugins/model-router/skills/model-router/tests/terminal-report/malformed.json
+++ b/plugins/model-router/skills/model-router/tests/terminal-report/malformed.json
@@ -1,0 +1,1 @@
+{"schemaVersion":1,"receiptId":

--- a/plugins/model-router/skills/model-router/tests/terminal-report/terminal-receipt-index.json
+++ b/plugins/model-router/skills/model-router/tests/terminal-report/terminal-receipt-index.json
@@ -1,0 +1,16 @@
+{
+  "schemaVersion": 1,
+  "receiptFiles": [
+    "01-openrouter-measured.json",
+    "02-native-subscription.json",
+    "03-paid-credit.json",
+    "04-fallback.json",
+    "04-fallback.json",
+    "04-fallback-duplicate-id.json",
+    "05-terminal-unavailable.json",
+    "06-missing-measurement.json",
+    "07-untrusted-fields.json",
+    "malformed.json",
+    "unrelated.json"
+  ]
+}

--- a/plugins/model-router/skills/model-router/tests/terminal-report/unrelated.json
+++ b/plugins/model-router/skills/model-router/tests/terminal-report/unrelated.json
@@ -1,0 +1,5 @@
+{
+  "schemaVersion": 1,
+  "event": "unrelated-workflow-receipt",
+  "prompt": "UNRELATED_TEXT_MUST_NOT_RENDER"
+}

--- a/plugins/pipeline/.claude-plugin/plugin.json
+++ b/plugins/pipeline/.claude-plugin/plugin.json
@@ -1,14 +1,14 @@
 {
   "name": "pipeline",
   "description": "Autonomous feature development pipeline with approved-scope intake, minimum-adequate planning, bounded adversarial review, fresh tiered verification, browser recovery, and isolated execution",
-  "version": "1.58.0",
+  "version": "1.59.0",
   "author": {
     "name": "Design Machines",
     "url": "https://designmachines.io"
   },
   "pluginDependencies": {
-    "dm-review": ">=1.71.0",
-    "model-router": ">=0.1.0",
+    "dm-review": ">=1.72.0",
+    "model-router": ">=0.2.0",
     "workflow-kernel": ">=0.17.0"
   },
   "optionalPluginDependencies": {

--- a/plugins/pipeline/.codex-plugin/plugin.json
+++ b/plugins/pipeline/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pipeline",
-  "version": "1.58.0",
+  "version": "1.59.0",
   "description": "Autonomous feature development pipeline with approved-scope intake, minimum-adequate planning, bounded adversarial review, fresh tiered verification, browser recovery, and isolated execution",
   "author": {
     "name": "Design Machines",
@@ -163,8 +163,8 @@
     ]
   },
   "pluginDependencies": {
-    "dm-review": ">=1.71.0",
-    "model-router": ">=0.1.0",
+    "dm-review": ">=1.72.0",
+    "model-router": ">=0.2.0",
     "workflow-kernel": ">=0.17.0"
   },
   "optionalPluginDependencies": {

--- a/plugins/pipeline/agents/workflow/execution-orchestrator.md
+++ b/plugins/pipeline/agents/workflow/execution-orchestrator.md
@@ -137,7 +137,7 @@ Create with TodoWrite immediately. Every chunk carries `executionMode`: `full_cl
 
 - Before any chunk: `0e` ref registry; `0f` decision profile validated and contract bound after `run.started`.
 - Per chunk: classify, create worktree, input guardrails, dispatch, validate (completion+commit+build), anti-pattern scan, evaluation gate, Playwright when `renderedSurface: required`, merge, clean up. Record `review_tier`, `review_tier_why`, `forced_full_review`.
-- After all chunks: FINAL 1 approved final dm-review; FINAL 2 `final-requirements-crosscheck.md`; FINAL 3 merge policy; FINAL 4 optional session observation; FINAL 5 Run Post-Mortem; FINAL 5b cleanup; FINAL 5c campaign; FINAL 6 summary. Do not skip steps.
+- After all chunks: FINAL 1 approved final dm-review; FINAL 2 `final-requirements-crosscheck.md`; FINAL 3 merge policy; FINAL 4 optional session observation; FINAL 5 Run Post-Mortem; FINAL 5a.1 terminal report or owner handoff; FINAL 5b cleanup; FINAL 5c campaign; FINAL 6 summary. Do not skip steps.
 
 ### Wait Measurement
 
@@ -270,7 +270,7 @@ CLEANUP_ACTIVE_HOST_ARGS=()
 if ! CONTRACT=$("$WORKFLOW_KERNEL" resolve-plugin-asset \
   --plugin dm-review \
   --asset skills/review/references/repo-cleanup-contract.md \
-  --minimum-version 1.71.0 \
+  --minimum-version 1.72.0 \
   "${CLEANUP_ACTIVE_HOST_ARGS[@]}"); then
   echo "ERROR: required dm-review cleanup contract unavailable" >&2
   exit 1
@@ -475,8 +475,9 @@ model-router bundle:
 ```bash
 : "${WORKFLOW_KERNEL:?resolve workflow-kernel-launcher.sh first}"
 MODEL_ROUTER_BUNDLE_JSON=$("$WORKFLOW_KERNEL" resolve-plugin-bundle \
-  --plugin model-router --minimum-version 0.1.0 \
+  --plugin model-router --minimum-version 0.2.0 \
   --required-executable skills/model-router/references/role-dispatch.sh \
+  --required-executable skills/model-router/references/render-terminal-report.sh \
   --required-asset skills/model-router/references/role-request-schema.json \
   --required-asset skills/model-router/references/role-policy.json)
 MODEL_ROUTER_BUNDLE_REF=$(printf '%s' "$MODEL_ROUTER_BUNDLE_JSON" | jq -r '.selected_root // empty')
@@ -495,6 +496,14 @@ named by opaque receipt ID. Phase 6 passes this directory and every contributing
 implementation/repair receipt ID to independent review lanes. A model repair
 invalidates any earlier `--human-authored` origin claim; missing repair
 provenance keeps the independent lane unavailable.
+
+Create `terminal-receipt-index.json` in that directory using
+model-router's `terminal-report-contract.md`. Add every implementation, repair,
+and nested review receipt basename in deterministic dispatch-start order. For a
+parallel fan-out, join results and write basenames in selected-lane order, not
+completion order. The approved final dm-review receives this same private
+directory and index with terminal reporting suppressed; it must not create or
+display an internal report before Pipeline's merge decision.
 
 **Step 3d.1 -- Dispatch the role.** Materialize the worker prompt, a fresh output
 path, and a private receipt path within the run-private router registry. Build
@@ -838,6 +847,26 @@ kernel reliability, and ranked recommendations labeled `AWAITING APPROVAL`.
 NEVER auto-edit plugin sources. Append one ledger line to
 `docs/pipeline-metrics/ledger.md`. Mark `FINAL 5. Run Post-Mortem` complete.
 
+## Step 5a.1: Terminal Model Report Ownership
+
+The caller passes `terminalModelReportOwner: pipeline|pipeline-run`. Reject any
+other value before execution. Load model-router's
+`terminal-report-contract.md` only now, after the approved final review,
+requirements cross-check, repairs, and Step 4c merge policy are settled.
+
+- For owner `pipeline-run`, render once from this run's exact
+  `terminal-receipt-index.json` to
+  `plans/<feature-slug>/model-cost-report.json` and `.md` before Step 5b removes
+  private receipts. Preserve renderer success or its one closed failure line
+  for Step 6. No model dispatch may follow this point.
+- For owner `pipeline`, do not render. Return only the exact private index and
+  durable output paths as `Terminal model report handoff:` for the Pipeline
+  caller. Preserve the private directory through Step 5b so the caller can
+  render only after its final disposition gate. The handoff contains no
+  identity, cost, or expanded receipt data.
+
+Mark `FINAL 5a.1. Terminal model report or owner handoff` complete.
+
 ## Step 5b: Artifact and Repository Cleanup
 
 Reconcile authoritative Docker ownership first, then clean artifacts and Git refs, then write the final authoritative cleanup/terminal receipt, and only then run shadow observation/comparison/metrics. This order is mandatory.
@@ -916,6 +945,12 @@ delete `plans/<feature-slug>` children by a broad path list: those paths may
 predate this invocation or belong to a concurrent run. On failure, project the
 compact reason and cleanup outcomes, then remove raw Tier 1 and Tier 2 inputs;
 retain at most one bounded diagnostic root under `exact-owned-cleanup.md`.
+When `terminalModelReportOwner` is `pipeline`, the exact private router
+directory and its index are an explicitly deferred caller-owned cleanup record,
+not an abandoned diagnostic root. Retain only that bounded directory until the
+Pipeline caller renders or closes reporting unavailable, then remove it through
+the same exact-owned cleanup authority. For `pipeline-run`, reporting already
+settled in Step 5a.1 and no such deferral exists.
 
 ### 3. Repository cleanup
 
@@ -1012,6 +1047,11 @@ Present this compact report. Populate every evidence path that exists; omit a no
 After the compact report, return the optional internal line prepared in Step 5.1:
 
 `Memory observation handoff: <observation>`
+
+For `pipeline-run`, append the already-generated compact
+`model-cost-report.md`, or its one closed unavailable line, after the visible
+summary. For `pipeline`, return the identity-free `Terminal model report
+handoff:` line internally for the caller and do not display a model report yet.
 
 Omit `Attempt result` when no provider attempt failed. Keep the visible summary roughly 250 words unless there are P1/P2/P3 findings or a blocker.
 

--- a/plugins/pipeline/agents/workflow/execution-orchestrator.md
+++ b/plugins/pipeline/agents/workflow/execution-orchestrator.md
@@ -489,16 +489,19 @@ ROLE_DISPATCH="$MODEL_ROUTER_ROOT/skills/model-router/references/role-dispatch.s
 ```
 
 Persist only bundle version/cache class/reason and the private receipt reference;
-never persist the absolute root. Create
-`<exact-run-root>/receipts/private/router/` with mode `0700`; every successful
+never persist the absolute root. For `terminalModelReportOwner: pipeline-run`,
+create `<exact-run-root>/receipts/private/router/` with mode `0700` and a fresh
+ordered index. For owner `pipeline`, require the caller-supplied mode-`0700`
+private directory and existing ordered index, then extend rather than replace
+them so feedback iterations retain earlier attempts. Every successful
 live implementation or repair stores its content-free router receipt there,
 named by opaque receipt ID. Phase 6 passes this directory and every contributing
 implementation/repair receipt ID to independent review lanes. A model repair
 invalidates any earlier `--human-authored` origin claim; missing repair
 provenance keeps the independent lane unavailable.
 
-Create `terminal-receipt-index.json` in that directory using
-model-router's `terminal-report-contract.md`. Add every implementation, repair,
+Maintain `terminal-receipt-index.json` in that directory using model-router's
+`terminal-report-contract.md`. Add every implementation, repair,
 and nested review receipt basename in deterministic dispatch-start order. For a
 parallel fan-out, join results and write basenames in selected-lane order, not
 completion order. The approved final dm-review receives this same private

--- a/plugins/pipeline/commands/pipeline-run.md
+++ b/plugins/pipeline/commands/pipeline-run.md
@@ -170,7 +170,8 @@ Once the pre-flight checks pass and the shadow-kernel preflight is initialized:
 1. Read the manifest.
 2. If running in Codex with `multi_agent_v1.spawn_agent`, run the **Codex Native Execution Adapter** above.
 3. Otherwise, launch the execution-orchestrator agent from `plugins/pipeline/agents/workflow/execution-orchestrator.md`.
-4. Pass the manifest path, prompts directory, and feature branch name.
+4. Pass the manifest path, prompts directory, feature branch name, and
+   `terminalModelReportOwner: pipeline-run`.
 5. The orchestrator handles everything autonomously:
    - Branch creation or exact-head existing-branch reuse
    - Exact registered worktree creation per chunk under the unique run ID
@@ -214,6 +215,14 @@ Present the compact summary from the orchestrator. If an operator decision is
 still needed, ask for it after `Recommended next action`; mention additional
 choices only when they are genuinely live. Do not emit a standing five-option
 menu.
+
+The execution-orchestrator owns this invocation's terminal model report. It
+loads model-router's `terminal-report-contract.md` only after final review,
+repairs, requirements checks, and merge policy have settled; renders
+`model-cost-report.json` and `.md` beside `run-cost-summary.json` before private
+receipt cleanup; completes cleanup; and appends the compact Markdown or one
+closed unavailable line after the human summary. Do not render it again and do
+not dispatch any model after it is generated or displayed.
 
 Any retained diagnostic report must name the one exact root, why it was kept,
 what compact evidence it contains, and the exact safe cleanup command. Raw

--- a/plugins/pipeline/commands/pipeline.md
+++ b/plugins/pipeline/commands/pipeline.md
@@ -320,6 +320,14 @@ Execution MUST NOT begin without explicit approval of this final package. Correc
 
 Enter only after the final planning gate returned explicit execution approval; approval of assessment, research, or a draft plan is insufficient.
 
+Before the first implementation dispatch, create one mode-`0700`
+invocation-private router directory and ordered `terminal-receipt-index.json`
+owned by this Pipeline caller. Reuse and extend that same index across every
+approved feedback iteration in this invocation; never reset it between
+execution passes. It therefore contains all implementation, repair, planning-
+review, and final-review dispatches that can contribute cost to the eventual
+terminal result.
+
 **Budget nudge (before pre-flight):** if the Progress Ledger shows more than 10 completed items AND the session has run over 90 minutes wall-clock, pause with AskUserQuestion: "Pipeline has been running a while. Continue with full scope, or break remaining work into a follow-up fix-pass run?" Soft nudge, not a hard gate; the default answer is "continue."
 
 **Pre-flight check:**
@@ -341,14 +349,15 @@ Enter only after the final planning gate returned explicit execution approval; a
 Pass `workflowClass` and the exact approved/defaulted `decisionProfile` provenance unchanged into Phase 6. Ordinary receipts name role, requested/effective effort, anonymous participant, fallback, and reason; exact identity stays in private router receipts. Missing lanes remain explicit evidence, and fallback never changes required validation, review, browser, requirements, or cleanup gates. For high consequence the stronger independent verification seam must complete without degraded lane coverage or stop `human_help_required` (no full review on every ordinary chunk); high uncertainty was consumed by the single planning opinion and bounded synthesis and adds no execution debate.
 
 Launch the execution-orchestrator from `plugins/pipeline/agents/workflow/execution-orchestrator.md` with the manifest path (`plans/<feature-slug>/manifest.json`), prompts directory (`plans/<feature-slug>/prompts/`), and feature branch name from the manifest.
-Pass `terminalModelReportOwner: pipeline`. The orchestrator and every nested
-dm-review suppress terminal identity reporting and return only the exact
-identity-free receipt-index handoff for this caller.
+Pass `terminalModelReportOwner: pipeline` plus the caller-owned exact private
+directory and index. The orchestrator and every nested dm-review suppress
+terminal identity reporting and return only the exact identity-free receipt-
+index handoff for this caller.
 
 **Lean mode:** execute the final-gate-approved plan as one bounded implementation pass: inline the approved Key Requirements, compact project goal, relevant non-goals, and ownership boundary into the worker context; run the plan's focused verification and exactly one final dm-review; do not invent a manifest, prompt directory, chunk receipts, or per-chunk ceremony.
-Create one exact run-private router directory and ordered
-`terminal-receipt-index.json` for the implementation and final-review receipts;
-pass that directory to the nested review with terminal reporting suppressed.
+Use the same caller-owned directory and index for the implementation and final-
+review receipts; pass them to the nested review with terminal reporting
+suppressed.
 
 Wait for execution to complete. Mark ledger item 10 complete.
 
@@ -398,7 +407,7 @@ Before this gate, confirm the orchestrator's Step 5b ran repository cleanup (ful
 
 **If the user chooses PR:** create the PR. The feature branch is kept (no merge proof yet -- expected; the inventory says so). Tier 3 cleanup waits for the user's return.
 
-**If the user gives feedback:** append it to `original-prompt.md` (`## Iteration N Feedback`), extract new requirements, re-enter the earliest affected planning phase, and return to the same final planning gate before any new execution -- feedback accumulates rather than replacing context.
+**If the user gives feedback:** append it to `original-prompt.md` (`## Iteration N Feedback`), extract new requirements, re-enter the earliest affected planning phase, and return to the same final planning gate before any new execution -- feedback accumulates rather than replacing context. Keep the caller-owned private directory and index bounded and unexpanded, extend it with later dispatch receipts, and do not render or clean it while another iteration can still run.
 
 **Terminal model report:** A feedback answer is non-terminal and emits no
 report. For `Create PR`, `done`, or a closed failed/blocked/stopped invocation,
@@ -406,7 +415,8 @@ first settle the requested PR/disposition and every model-dependent decision.
 Then load model-router's `terminal-report-contract.md`, consume the full-mode
 orchestrator's exact private index handoff or the lean caller's exact index, and render once to
 `plans/<feature-slug>/model-cost-report.json` and `.md` before cleaning that
-private directory. Complete exact-owned cleanup and terminal receipts, then
+private directory. The index must include every retained feedback iteration in
+this invocation. Complete exact-owned cleanup and terminal receipts, then
 append the already-generated Markdown (or the one closed unavailable line) to
 the final human handoff. No model dispatch, review, repair, synthesis, or merge
 decision may follow report generation.

--- a/plugins/pipeline/commands/pipeline.md
+++ b/plugins/pipeline/commands/pipeline.md
@@ -341,8 +341,14 @@ Enter only after the final planning gate returned explicit execution approval; a
 Pass `workflowClass` and the exact approved/defaulted `decisionProfile` provenance unchanged into Phase 6. Ordinary receipts name role, requested/effective effort, anonymous participant, fallback, and reason; exact identity stays in private router receipts. Missing lanes remain explicit evidence, and fallback never changes required validation, review, browser, requirements, or cleanup gates. For high consequence the stronger independent verification seam must complete without degraded lane coverage or stop `human_help_required` (no full review on every ordinary chunk); high uncertainty was consumed by the single planning opinion and bounded synthesis and adds no execution debate.
 
 Launch the execution-orchestrator from `plugins/pipeline/agents/workflow/execution-orchestrator.md` with the manifest path (`plans/<feature-slug>/manifest.json`), prompts directory (`plans/<feature-slug>/prompts/`), and feature branch name from the manifest.
+Pass `terminalModelReportOwner: pipeline`. The orchestrator and every nested
+dm-review suppress terminal identity reporting and return only the exact
+identity-free receipt-index handoff for this caller.
 
 **Lean mode:** execute the final-gate-approved plan as one bounded implementation pass: inline the approved Key Requirements, compact project goal, relevant non-goals, and ownership boundary into the worker context; run the plan's focused verification and exactly one final dm-review; do not invent a manifest, prompt directory, chunk receipts, or per-chunk ceremony.
+Create one exact run-private router directory and ordered
+`terminal-receipt-index.json` for the implementation and final-review receipts;
+pass that directory to the nested review with terminal reporting suppressed.
 
 Wait for execution to complete. Mark ledger item 10 complete.
 
@@ -393,6 +399,17 @@ Before this gate, confirm the orchestrator's Step 5b ran repository cleanup (ful
 **If the user chooses PR:** create the PR. The feature branch is kept (no merge proof yet -- expected; the inventory says so). Tier 3 cleanup waits for the user's return.
 
 **If the user gives feedback:** append it to `original-prompt.md` (`## Iteration N Feedback`), extract new requirements, re-enter the earliest affected planning phase, and return to the same final planning gate before any new execution -- feedback accumulates rather than replacing context.
+
+**Terminal model report:** A feedback answer is non-terminal and emits no
+report. For `Create PR`, `done`, or a closed failed/blocked/stopped invocation,
+first settle the requested PR/disposition and every model-dependent decision.
+Then load model-router's `terminal-report-contract.md`, consume the full-mode
+orchestrator's exact private index handoff or the lean caller's exact index, and render once to
+`plans/<feature-slug>/model-cost-report.json` and `.md` before cleaning that
+private directory. Complete exact-owned cleanup and terminal receipts, then
+append the already-generated Markdown (or the one closed unavailable line) to
+the final human handoff. No model dispatch, review, repair, synthesis, or merge
+decision may follow report generation.
 
 **If the user says done:** run full cleanup per the artifact lifecycle policy:
 

--- a/plugins/pipeline/skills/pipeline-run/SKILL.md
+++ b/plugins/pipeline/skills/pipeline-run/SKILL.md
@@ -185,7 +185,8 @@ Once the pre-flight checks pass and the shadow-kernel preflight is initialized:
 1. Read the manifest.
 2. If running in Codex with `multi_agent_v1.spawn_agent`, run the **Codex Native Execution Adapter** above.
 3. Otherwise, launch the execution-orchestrator agent from `plugins/pipeline/agents/workflow/execution-orchestrator.md`.
-4. Pass the manifest path, prompts directory, and feature branch name.
+4. Pass the manifest path, prompts directory, feature branch name, and
+   `terminalModelReportOwner: pipeline-run`.
 5. The orchestrator handles everything autonomously:
    - Branch creation or exact-head existing-branch reuse
    - Exact registered worktree creation per chunk under the unique run ID
@@ -229,6 +230,14 @@ Present the compact summary from the orchestrator. If an operator decision is
 still needed, ask for it after `Recommended next action`; mention additional
 choices only when they are genuinely live. Do not emit a standing five-option
 menu.
+
+The execution-orchestrator owns this invocation's terminal model report. It
+loads model-router's `terminal-report-contract.md` only after final review,
+repairs, requirements checks, and merge policy have settled; renders
+`model-cost-report.json` and `.md` beside `run-cost-summary.json` before private
+receipt cleanup; completes cleanup; and appends the compact Markdown or one
+closed unavailable line after the human summary. Do not render it again and do
+not dispatch any model after it is generated or displayed.
 
 Any retained diagnostic report must name the one exact root, why it was kept,
 what compact evidence it contains, and the exact safe cleanup command. Raw

--- a/plugins/pipeline/skills/pipeline/SKILL.md
+++ b/plugins/pipeline/skills/pipeline/SKILL.md
@@ -356,8 +356,14 @@ Enter only after the final planning gate returned explicit execution approval; a
 Pass `workflowClass` and the exact approved/defaulted `decisionProfile` provenance unchanged into Phase 6. Ordinary receipts name role, requested/effective effort, anonymous participant, fallback, and reason; exact identity stays in private router receipts. Missing lanes remain explicit evidence, and fallback never changes required validation, review, browser, requirements, or cleanup gates. For high consequence the stronger independent verification seam must complete without degraded lane coverage or stop `human_help_required` (no full review on every ordinary chunk); high uncertainty was consumed by the single planning opinion and bounded synthesis and adds no execution debate.
 
 Launch the execution-orchestrator from `plugins/pipeline/agents/workflow/execution-orchestrator.md` with the manifest path (`plans/<feature-slug>/manifest.json`), prompts directory (`plans/<feature-slug>/prompts/`), and feature branch name from the manifest.
+Pass `terminalModelReportOwner: pipeline`. The orchestrator and every nested
+dm-review suppress terminal identity reporting and return only the exact
+identity-free receipt-index handoff for this caller.
 
 **Lean mode:** execute the final-gate-approved plan as one bounded implementation pass: inline the approved Key Requirements, compact project goal, relevant non-goals, and ownership boundary into the worker context; run the plan's focused verification and exactly one final dm-review; do not invent a manifest, prompt directory, chunk receipts, or per-chunk ceremony.
+Create one exact run-private router directory and ordered
+`terminal-receipt-index.json` for the implementation and final-review receipts;
+pass that directory to the nested review with terminal reporting suppressed.
 
 Wait for execution to complete. Mark ledger item 10 complete.
 
@@ -408,6 +414,17 @@ Before this gate, confirm the orchestrator's Step 5b ran repository cleanup (ful
 **If the user chooses PR:** create the PR. The feature branch is kept (no merge proof yet -- expected; the inventory says so). Tier 3 cleanup waits for the user's return.
 
 **If the user gives feedback:** append it to `original-prompt.md` (`## Iteration N Feedback`), extract new requirements, re-enter the earliest affected planning phase, and return to the same final planning gate before any new execution -- feedback accumulates rather than replacing context.
+
+**Terminal model report:** A feedback answer is non-terminal and emits no
+report. For `Create PR`, `done`, or a closed failed/blocked/stopped invocation,
+first settle the requested PR/disposition and every model-dependent decision.
+Then load model-router's `terminal-report-contract.md`, consume the full-mode
+orchestrator's exact private index handoff or the lean caller's exact index, and render once to
+`plans/<feature-slug>/model-cost-report.json` and `.md` before cleaning that
+private directory. Complete exact-owned cleanup and terminal receipts, then
+append the already-generated Markdown (or the one closed unavailable line) to
+the final human handoff. No model dispatch, review, repair, synthesis, or merge
+decision may follow report generation.
 
 **If the user says done:** run full cleanup per the artifact lifecycle policy:
 

--- a/plugins/pipeline/skills/pipeline/SKILL.md
+++ b/plugins/pipeline/skills/pipeline/SKILL.md
@@ -335,6 +335,14 @@ Execution MUST NOT begin without explicit approval of this final package. Correc
 
 Enter only after the final planning gate returned explicit execution approval; approval of assessment, research, or a draft plan is insufficient.
 
+Before the first implementation dispatch, create one mode-`0700`
+invocation-private router directory and ordered `terminal-receipt-index.json`
+owned by this Pipeline caller. Reuse and extend that same index across every
+approved feedback iteration in this invocation; never reset it between
+execution passes. It therefore contains all implementation, repair, planning-
+review, and final-review dispatches that can contribute cost to the eventual
+terminal result.
+
 **Budget nudge (before pre-flight):** if the Progress Ledger shows more than 10 completed items AND the session has run over 90 minutes wall-clock, pause with AskUserQuestion: "Pipeline has been running a while. Continue with full scope, or break remaining work into a follow-up fix-pass run?" Soft nudge, not a hard gate; the default answer is "continue."
 
 **Pre-flight check:**
@@ -356,14 +364,15 @@ Enter only after the final planning gate returned explicit execution approval; a
 Pass `workflowClass` and the exact approved/defaulted `decisionProfile` provenance unchanged into Phase 6. Ordinary receipts name role, requested/effective effort, anonymous participant, fallback, and reason; exact identity stays in private router receipts. Missing lanes remain explicit evidence, and fallback never changes required validation, review, browser, requirements, or cleanup gates. For high consequence the stronger independent verification seam must complete without degraded lane coverage or stop `human_help_required` (no full review on every ordinary chunk); high uncertainty was consumed by the single planning opinion and bounded synthesis and adds no execution debate.
 
 Launch the execution-orchestrator from `plugins/pipeline/agents/workflow/execution-orchestrator.md` with the manifest path (`plans/<feature-slug>/manifest.json`), prompts directory (`plans/<feature-slug>/prompts/`), and feature branch name from the manifest.
-Pass `terminalModelReportOwner: pipeline`. The orchestrator and every nested
-dm-review suppress terminal identity reporting and return only the exact
-identity-free receipt-index handoff for this caller.
+Pass `terminalModelReportOwner: pipeline` plus the caller-owned exact private
+directory and index. The orchestrator and every nested dm-review suppress
+terminal identity reporting and return only the exact identity-free receipt-
+index handoff for this caller.
 
 **Lean mode:** execute the final-gate-approved plan as one bounded implementation pass: inline the approved Key Requirements, compact project goal, relevant non-goals, and ownership boundary into the worker context; run the plan's focused verification and exactly one final dm-review; do not invent a manifest, prompt directory, chunk receipts, or per-chunk ceremony.
-Create one exact run-private router directory and ordered
-`terminal-receipt-index.json` for the implementation and final-review receipts;
-pass that directory to the nested review with terminal reporting suppressed.
+Use the same caller-owned directory and index for the implementation and final-
+review receipts; pass them to the nested review with terminal reporting
+suppressed.
 
 Wait for execution to complete. Mark ledger item 10 complete.
 
@@ -413,7 +422,7 @@ Before this gate, confirm the orchestrator's Step 5b ran repository cleanup (ful
 
 **If the user chooses PR:** create the PR. The feature branch is kept (no merge proof yet -- expected; the inventory says so). Tier 3 cleanup waits for the user's return.
 
-**If the user gives feedback:** append it to `original-prompt.md` (`## Iteration N Feedback`), extract new requirements, re-enter the earliest affected planning phase, and return to the same final planning gate before any new execution -- feedback accumulates rather than replacing context.
+**If the user gives feedback:** append it to `original-prompt.md` (`## Iteration N Feedback`), extract new requirements, re-enter the earliest affected planning phase, and return to the same final planning gate before any new execution -- feedback accumulates rather than replacing context. Keep the caller-owned private directory and index bounded and unexpanded, extend it with later dispatch receipts, and do not render or clean it while another iteration can still run.
 
 **Terminal model report:** A feedback answer is non-terminal and emits no
 report. For `Create PR`, `done`, or a closed failed/blocked/stopped invocation,
@@ -421,7 +430,8 @@ first settle the requested PR/disposition and every model-dependent decision.
 Then load model-router's `terminal-report-contract.md`, consume the full-mode
 orchestrator's exact private index handoff or the lean caller's exact index, and render once to
 `plans/<feature-slug>/model-cost-report.json` and `.md` before cleaning that
-private directory. Complete exact-owned cleanup and terminal receipts, then
+private directory. The index must include every retained feedback iteration in
+this invocation. Complete exact-owned cleanup and terminal receipts, then
 append the already-generated Markdown (or the one closed unavailable line) to
 the final human handoff. No model dispatch, review, repair, synthesis, or merge
 decision may follow report generation.

--- a/plugins/project-manager/.claude-plugin/plugin.json
+++ b/plugins/project-manager/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-manager",
   "description": "Project management: LT10 methodology, Notion-integrated sprint planning, and GitHub-native cross-repository Assembly coordination",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "author": {
     "name": "Design Machines"
   },
@@ -12,7 +12,7 @@
     "council": ">=1.5.0"
   },
   "optionalPluginDependencies": {
-    "model-router": ">=0.1.0"
+    "model-router": ">=0.2.0"
   },
   "capabilities": {
     "skills": [

--- a/plugins/project-manager/.codex-plugin/plugin.json
+++ b/plugins/project-manager/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "project-manager",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "description": "Project management: LT10 methodology, Notion-integrated sprint planning, and GitHub-native cross-repository Assembly coordination",
   "author": {
     "name": "Design Machines"
@@ -105,7 +105,7 @@
     "council": ">=1.5.0"
   },
   "optionalPluginDependencies": {
-    "model-router": ">=0.1.0"
+    "model-router": ">=0.2.0"
   },
   "interface": {
     "displayName": "Project Manager",

--- a/plugins/project-manager/skills/assembly-coordinator/SKILL.md
+++ b/plugins/project-manager/skills/assembly-coordinator/SKILL.md
@@ -154,5 +154,8 @@ Return a compact, outcome-first report containing:
    one bounded synthesis;
 10. one complete copy-paste execution prompt when requested, with role,
     capabilities, and effort.
+11. only when the opinion path actually dispatched a role, the already-
+    generated terminal model/cost Markdown after the recommendation and
+    execution prompt; routine sessions emit no empty report.
 
 Do not bury the recommendation beneath process narration.

--- a/plugins/project-manager/skills/assembly-coordinator/references/planning-opinions.md
+++ b/plugins/project-manager/skills/assembly-coordinator/references/planning-opinions.md
@@ -26,10 +26,13 @@ output. Do not run debate, rebuttal, convergence, or a third opinion.
 ## Dispatch mechanics
 
 Resolve one coherent installed model-router bundle through Workflow Kernel and
-bind its `role-dispatch.sh`, request schema, and policy. Materialize Plan A and
-Plan B prompts separately, use the same immutable evidence packet as each
-request's `--repository-evidence-file`, and allocate fresh private output and
-receipt paths in one run-private directory.
+bind its `role-dispatch.sh`, request schema, policy, and terminal renderer at
+minimum model-router version `0.2.0`. Materialize Plan A and Plan B prompts
+separately, use the same immutable evidence packet as each request's
+`--repository-evidence-file`, and allocate fresh private output and receipt
+paths in one mode-`0700` run-private directory. Create
+`terminal-receipt-index.json` there and record Plan A then Plan B when each was
+actually requested.
 
 Dispatch Plan A with `--role architect`, the three capabilities above, and
 `--effort high`. Dispatch Plan B with `--role plan-critic`, the four
@@ -50,3 +53,17 @@ verification seam; it does not add another opinion.
 If the architect is unavailable, synthesize from current evidence and the
 remaining valid opinion. If an explicit comparison cannot obtain Plan B, state
 that limitation plainly. Routine planning never blocks on model-router.
+
+## Terminal operator report
+
+Finish Plan A, Plan B when requested, and the coordinator's own synthesis and
+recommendation before loading model-router's `terminal-report-contract.md`.
+Render once from this comparison's exact ordered index, then clean private
+receipts and append the compact Markdown after the recommendation and execution
+prompt. No model dispatch or synthesis revision may follow generation. A
+failed, blocked, or stopped comparison still reports incurred attempts after
+dispatch has ceased. Reporting failure contributes only the contract's one
+closed unavailable line and never changes the recommendation.
+
+When no routed planning opinion was requested, do not create an index and do
+not emit a model report.

--- a/tools/check-dependencies.sh
+++ b/tools/check-dependencies.sh
@@ -275,8 +275,8 @@ for consumer, expected in consumer_floors.items():
 
 pipeline = manifests.get("pipeline")
 dm_review_floor = None if pipeline is None else pipeline.get("pluginDependencies", {}).get("dm-review")
-if dm_review_floor != ">=1.71.0":
-    errors.append("pipeline must require dm-review >=1.71.0")
+if dm_review_floor != ">=1.72.0":
+    errors.append("pipeline must require dm-review >=1.72.0")
 
 if errors:
     for error in errors:

--- a/tools/test-terminal-model-report.sh
+++ b/tools/test-terminal-model-report.sh
@@ -55,4 +55,34 @@ assert test ! -e "$TMP/in-progress.md"
 assert jq -e '.runStatus == "blocked" and (.calls | length) == 7' "$TMP/blocked.json"
 assert grep -Fxq 'Run: BLOCKED' "$TMP/blocked.md"
 
+"$RENDERER" --receipt-index "$FIXTURES/edge-receipt-index.json" \
+  --status complete --json-output "$TMP/edge.json" --markdown-output "$TMP/edge.md" >/dev/null
+assert jq -e '.calls[0].attempts[0].tokens.status == "unavailable"' "$TMP/edge.json"
+assert jq -e '.calls[1].attempts[0].tokens.status == "unavailable" and .calls[1].attempts[0].tokens.total == null' "$TMP/edge.json"
+assert jq -e '.calls[2].billingMode == "unavailable" and ([.calls[2].attempts[].served] | all(. == false)) and ([.calls[2].attempts[].result] | all(. == "unavailable"))' "$TMP/edge.json"
+assert jq -e '.summary.measuredPaidCostUsd == 0.005' "$TMP/edge.json"
+
+mkdir "$TMP/existing-json-directory"
+set +e
+"$RENDERER" --receipt-index "$FIXTURES/terminal-receipt-index.json" \
+  --status complete --json-output "$TMP/existing-json-directory" --markdown-output "$TMP/directory-failure.md" \
+  >"$TMP/directory-failure.stdout" 2>"$TMP/directory-failure.stderr"
+directory_failure_rc=$?
+set -e
+assert test "$directory_failure_rc" -ne 0
+assert grep -Fxq 'terminal-model-report: output-destination-unavailable' "$TMP/directory-failure.stderr"
+assert test ! -e "$TMP/directory-failure.md"
+
+set +e
+MODEL_ROUTER_TEST_MODE=1 MODEL_ROUTER_TEST_FAIL_MARKDOWN_PUBLICATION=1 \
+  "$RENDERER" --receipt-index "$FIXTURES/terminal-receipt-index.json" \
+  --status complete --json-output "$TMP/rollback.json" --markdown-output "$TMP/rollback.md" \
+  >"$TMP/rollback.stdout" 2>"$TMP/rollback.stderr"
+rollback_rc=$?
+set -e
+assert test "$rollback_rc" -ne 0
+assert grep -Fxq 'terminal-model-report: markdown-publication-failed' "$TMP/rollback.stderr"
+assert test ! -e "$TMP/rollback.json"
+assert test ! -e "$TMP/rollback.md"
+
 printf 'terminal-model-report: %d assertions passed\n' "$pass"

--- a/tools/test-terminal-model-report.sh
+++ b/tools/test-terminal-model-report.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
+export PATH
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+RENDERER="$ROOT/plugins/model-router/skills/model-router/references/render-terminal-report.sh"
+FIXTURES="$ROOT/plugins/model-router/skills/model-router/tests/terminal-report"
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/terminal-model-report-tests.XXXXXX")"
+trap 'rm -rf "$TMP"' EXIT
+
+pass=0
+assert() { "$@" >/dev/null || { printf 'FAIL: %s\n' "$*" >&2; exit 1; }; pass=$((pass + 1)); }
+
+"$RENDERER" --receipt-index "$FIXTURES/terminal-receipt-index.json" \
+  --status complete --json-output "$TMP/report.json" --markdown-output "$TMP/report.md" >/dev/null
+
+assert jq -e '.schemaVersion == 1 and .runStatus == "complete"' "$TMP/report.json"
+assert jq -e '.summary.measuredPaidCostUsd == 0.103' "$TMP/report.json"
+assert jq -e '.summary.subscriptionCalls == 1 and .summary.paidCreditCalls == 1' "$TMP/report.json"
+assert jq -e '.summary.fallbacks == 2 and .summary.unmeasuredUsageOrCostCalls == 4' "$TMP/report.json"
+assert jq -e '.summary.inputReceiptReferences == 11 and .summary.validReceiptObjects == 9 and .summary.deduplicatedReceipts == 7 and .summary.ignoredReceiptReferences == 2 and .summary.duplicateReceiptObjects == 2' "$TMP/report.json"
+assert jq -e '.matrixSnapshots == ["openrouter:2026-08-25", "fictional:2026-08-26"]' "$TMP/report.json"
+assert jq -e '[.calls[].receiptId] == ["dispatch-000000000000000000000001","dispatch-000000000000000000000002","dispatch-000000000000000000000003","dispatch-000000000000000000000004","dispatch-000000000000000000000005","dispatch-000000000000000000000006","dispatch-000000000000000000000007"]' "$TMP/report.json"
+assert jq -e '.calls[3].attempts[0].result == "failed" and .calls[3].attempts[1].served == true and .calls[3].attempts[1].model == "fictional/second-reviewer"' "$TMP/report.json"
+assert jq -e '.calls[4].attempts[0].served == false and .calls[4].billingMode == "unavailable"' "$TMP/report.json"
+assert jq -e '.calls[6].attempts[0].model == "unavailable" and .calls[6].attempts[0].duration.status == "unavailable" and .calls[6].attempts[0].billedCost.status == "unavailable"' "$TMP/report.json"
+assert grep -Fq 'fictional/first-reviewer (attempted)' "$TMP/report.md"
+assert grep -Fq 'fictional/second-reviewer (served)' "$TMP/report.md"
+assert grep -Fq 'subscription allowance' "$TMP/report.md"
+assert grep -Fq 'Paid total: `$0.103 measured`' "$TMP/report.md"
+assert sh -c "! grep -Eq 'ARBITRARY_PROVIDER|REFLECTED_INPUT|REFLECTED MATRIX|MODEL_OUTPUT|CREDENTIAL|UNRELATED_TEXT|duplicate-must-not-replace-first' '$TMP/report.json' '$TMP/report.md'"
+
+cp "$TMP/report.json" "$TMP/report-first.json"
+cp "$TMP/report.md" "$TMP/report-first.md"
+"$RENDERER" --receipt-index "$FIXTURES/terminal-receipt-index.json" \
+  --status complete --json-output "$TMP/report.json" --markdown-output "$TMP/report.md" >/dev/null
+assert cmp -s "$TMP/report-first.json" "$TMP/report.json"
+assert cmp -s "$TMP/report-first.md" "$TMP/report.md"
+
+set +e
+"$RENDERER" --receipt-index "$FIXTURES/terminal-receipt-index.json" \
+  --status in-progress --json-output "$TMP/in-progress.json" --markdown-output "$TMP/in-progress.md" \
+  >"$TMP/in-progress.stdout" 2>"$TMP/in-progress.stderr"
+in_progress_rc=$?
+set -e
+assert test "$in_progress_rc" -eq 2
+assert grep -Fxq 'terminal-model-report: non-terminal-status' "$TMP/in-progress.stderr"
+assert test ! -e "$TMP/in-progress.json"
+assert test ! -e "$TMP/in-progress.md"
+
+"$RENDERER" --receipt-index "$FIXTURES/terminal-receipt-index.json" \
+  --status blocked --json-output "$TMP/blocked.json" --markdown-output "$TMP/blocked.md" >/dev/null
+assert jq -e '.runStatus == "blocked" and (.calls | length) == 7' "$TMP/blocked.json"
+assert grep -Fxq 'Run: BLOCKED' "$TMP/blocked.md"
+
+printf 'terminal-model-report: %d assertions passed\n' "$pass"

--- a/tools/validate-composition.sh
+++ b/tools/validate-composition.sh
@@ -651,6 +651,11 @@ run_composition_checks() {
     any_failed=1
   fi
 
+  printf "\n${BOLD}Terminal model and cost report:${RESET}\n"
+  if ! "$SCRIPT_DIR/test-terminal-model-report.sh"; then
+    any_failed=1
+  fi
+
   printf "\n${BOLD}OpenRouter coherent bundle resolution:${RESET}\n"
   if ! "$SCRIPT_DIR/validate-openrouter-resolution.sh" --all; then
     any_failed=1

--- a/tools/validate-dm-review-codex-perspective.sh
+++ b/tools/validate-dm-review-codex-perspective.sh
@@ -393,10 +393,10 @@ for zero_deferral_surface in \
   reject_text "$zero_deferral_surface" 'P3 advisories' "${zero_deferral_surface#$REPO_ROOT/} rejects deferred P3 evidence"
   reject_text "$zero_deferral_surface" 'P3 stays advisory' "${zero_deferral_surface#$REPO_ROOT/} rejects clean-with-P3 policy"
 done
-require_text "$REPO_ROOT/plugins/dm-review/.claude-plugin/plugin.json" '"version": "1.71.0"' "canonical dm-review version is 1.71.0"
-require_text "$REPO_ROOT/plugins/dm-review/.codex-plugin/plugin.json" '"version": "1.71.0"' "generated dm-review version is 1.71.0"
-require_text "$REPO_ROOT/plugins/pipeline/.claude-plugin/plugin.json" '"version": "1.58.0"' "canonical Pipeline version is 1.58.0"
-require_text "$REPO_ROOT/plugins/pipeline/.codex-plugin/plugin.json" '"dm-review": ">=1.71.0"' "generated Pipeline dependency floor is current"
+require_text "$REPO_ROOT/plugins/dm-review/.claude-plugin/plugin.json" '"version": "1.72.0"' "canonical dm-review version is 1.72.0"
+require_text "$REPO_ROOT/plugins/dm-review/.codex-plugin/plugin.json" '"version": "1.72.0"' "generated dm-review version is 1.72.0"
+require_text "$REPO_ROOT/plugins/pipeline/.claude-plugin/plugin.json" '"version": "1.59.0"' "canonical Pipeline version is 1.59.0"
+require_text "$REPO_ROOT/plugins/pipeline/.codex-plugin/plugin.json" '"dm-review": ">=1.72.0"' "generated Pipeline dependency floor is current"
 
 printf "Synthesis identity fixtures\n"
 base_id=$(fixture_finding_id \

--- a/tools/validate-openrouter-resolution.sh
+++ b/tools/validate-openrouter-resolution.sh
@@ -155,7 +155,7 @@ validate_active_cache_consumers() {
   grep -Fq 'resolve-plugin-asset \' "$pipeline_file" &&
   grep -Fq -- '--plugin dm-review' "$pipeline_file" &&
   grep -Fq -- '--asset skills/review/references/repo-cleanup-contract.md' "$pipeline_file" &&
-  grep -Fq -- '--minimum-version 1.71.0' "$pipeline_file" &&
+  grep -Fq -- '--minimum-version 1.72.0' "$pipeline_file" &&
   grep -Fq 'CLEANUP_ACTIVE_HOST_ARGS=(--active-host "$CLEANUP_ACTIVE_HOST")' "$pipeline_file" || consumer_failures=1
 
   if grep -Fq 'CONTRACT=$(ls -t "$CACHE"/dm-review/*/skills/review/references/repo-cleanup-contract.md' "$pipeline_file" ||

--- a/tools/validate-workflow-contracts.sh
+++ b/tools/validate-workflow-contracts.sh
@@ -1095,6 +1095,8 @@ require_before "$orchestrator" '## Step 5a.1: Terminal Model Report Ownership' '
   "Pipeline report precedes private-receipt cleanup"
 require_text "$pipeline_cmd" 'terminalModelReportOwner: pipeline' \
   "/pipeline retains terminal report ownership"
+require_text "$pipeline_cmd" 'Reuse and extend that same index across every' \
+  "/pipeline carries all feedback-iteration receipts to one terminal report"
 require_text "$pipeline_run" 'terminalModelReportOwner: pipeline-run' \
   "/pipeline-run assigns one terminal report owner"
 require_before "$review_skill" '### Phase 7c: Terminal Model Report Boundary' '### Phase 8: Repository Cleanup' \
@@ -1107,6 +1109,8 @@ require_before "$review_loop" '### 2.5 Terminal Model Report' '### 3. Repository
   "dm-review-loop renders once after its last iteration and before cleanup"
 require_text "$review_loop" 'Do not render per iteration.' \
   "dm-review-loop suppresses per-iteration reports"
+require_text "$review_loop" 'using the loop-private router directory/index and terminal reporting suppressed' \
+  "dm-review-loop routed repairs extend the owner index without early reporting"
 require_before "$planning_opinions" '## One synthesis' '## Terminal operator report' \
   "Assembly synthesis settles before identity projection"
 require_text "$coordinator_skill" 'routine sessions emit no empty report' \

--- a/tools/validate-workflow-contracts.sh
+++ b/tools/validate-workflow-contracts.sh
@@ -123,6 +123,22 @@ require_before() {
   fi
 }
 
+require_absent_after() {
+  local file="$1"
+  local marker="$2"
+  local pattern="$3"
+  local label="$4"
+  local marker_line
+
+  marker_line="$(grep -nF -m1 -- "$marker" "$file" 2>/dev/null | cut -d: -f1 || true)"
+  if [ -n "$marker_line" ] && ! tail -n "+$marker_line" "$file" | grep -Fq -- "$pattern"; then
+    printf "  OK    %s\n" "$label"
+  else
+    printf "  FAIL  %s\n" "$label"
+    failures=1
+  fi
+}
+
 require_count() {
   local file="$1"
   local pattern="$2"
@@ -576,7 +592,7 @@ require_text "$review_skill" "references/selective-lane-allowlist.md" "review re
 require_text "$selective_allowlist" "never relax this equality check to a subset check" "allowlist contract requires exact selected_full_set equality"
 require_text "$selective_allowlist" "Any validation failure discards the entire selective input and dispatches the unfiltered recomputed selected full set. Never drop invalid members and honor the remainder." "allowlist contract fails open without partially honoring invalid input"
 require_text "$REPO_ROOT/plugins/dm-review/.claude-plugin/plugin.json" '"workflow-kernel": ">=0.17.0"' "dm-review requires the exact-owned cleanup kernel release"
-require_text "$REPO_ROOT/plugins/pipeline/.claude-plugin/plugin.json" '"dm-review": ">=1.71.0"' "pipeline requires the exact-owned dm-review release"
+require_text "$REPO_ROOT/plugins/pipeline/.claude-plugin/plugin.json" '"dm-review": ">=1.72.0"' "pipeline requires the exact-owned dm-review release"
 require_text "$REPO_ROOT/plugins/dm-review/.claude-plugin/plugin.json" '"name": "Second Perspective Reviewer"' "dm-review manifest names the provider-neutral perspective lane"
 require_text "$REPO_ROOT/plugins/dm-review/.claude-plugin/plugin.json" 'family-independent second-opinion review' "dm-review manifest describes family-independent perspective resolution"
 require_text "$REPO_ROOT/plugins/dm-review/skills/review/references/agent-registry.md" 'Full mode only.' "migration-validator registry limits the lane to full mode"
@@ -1053,6 +1069,54 @@ else
   printf "  FAIL  security sign-off route is implementer-aware and family-independent\n"
   failures=1
 fi
+
+# --------------------------------------------------------------------------
+# Group 8b: terminal operator model and cost reporting
+# --------------------------------------------------------------------------
+
+printf "\nterminal operator model and cost report:\n"
+
+terminal_report_contract="$REPO_ROOT/plugins/model-router/skills/model-router/references/terminal-report-contract.md"
+terminal_report_renderer="$REPO_ROOT/plugins/model-router/skills/model-router/references/render-terminal-report.sh"
+planning_opinions="$REPO_ROOT/plugins/project-manager/skills/assembly-coordinator/references/planning-opinions.md"
+coordinator_skill="$REPO_ROOT/plugins/project-manager/skills/assembly-coordinator/SKILL.md"
+
+require_text "$terminal_report_contract" 'no later model dispatch can occur' \
+  "shared renderer requires a closed no-further-dispatch boundary"
+require_text "$terminal_report_contract" 'Model & Cost Report unavailable: <closed reason>' \
+  "report failure has one closed nonblocking message"
+require_text "$terminal_report_renderer" 'complete|failed|blocked|stopped' \
+  "renderer accepts only closed terminal states"
+require_text "$terminal_report_renderer" 'costProvenance == "provider-receipt"' \
+  "renderer sums only provider-reported billed cost"
+require_before "$orchestrator" '## Step 4c: Merge Policy Check' '## Step 5a.1: Terminal Model Report Ownership' \
+  "Pipeline merge policy settles before terminal identity projection"
+require_before "$orchestrator" '## Step 5a.1: Terminal Model Report Ownership' '## Step 5b: Artifact and Repository Cleanup' \
+  "Pipeline report precedes private-receipt cleanup"
+require_text "$pipeline_cmd" 'terminalModelReportOwner: pipeline' \
+  "/pipeline retains terminal report ownership"
+require_text "$pipeline_run" 'terminalModelReportOwner: pipeline-run' \
+  "/pipeline-run assigns one terminal report owner"
+require_before "$review_skill" '### Phase 7c: Terminal Model Report Boundary' '### Phase 8: Repository Cleanup' \
+  "dm-review renders once before cleanup"
+require_text "$review_cmd" 'terminalModelReportOwner: dm-review' \
+  "/dm-review owns its standalone terminal report"
+require_text "$REPO_ROOT/plugins/dm-review/commands/dm-review-quick.md" 'terminalModelReportOwner: dm-review' \
+  "/dm-review-quick owns its standalone terminal report"
+require_before "$review_loop" '### 2.5 Terminal Model Report' '### 3. Repository Cleanup' \
+  "dm-review-loop renders once after its last iteration and before cleanup"
+require_text "$review_loop" 'Do not render per iteration.' \
+  "dm-review-loop suppresses per-iteration reports"
+require_before "$planning_opinions" '## One synthesis' '## Terminal operator report' \
+  "Assembly synthesis settles before identity projection"
+require_text "$coordinator_skill" 'routine sessions emit no empty report' \
+  "Assembly coordinator reports only when opinions dispatched"
+require_absent_after "$orchestrator" '## Step 5a.1: Terminal Model Report Ownership' 'ROLE_DISPATCH' \
+  "Pipeline schedules no role-dispatch invocation after reporting"
+require_absent_after "$review_skill" '### Phase 7c: Terminal Model Report Boundary' 'role-dispatch.sh' \
+  "dm-review schedules no role-dispatch invocation after reporting"
+require_absent_after "$review_loop" '### 2.5 Terminal Model Report' 'Run /dm-review' \
+  "dm-review-loop schedules no review dispatch after reporting"
 
 # ---------------------------------------------------------------------------
 # Group 9: configured-key OpenRouter contract


### PR DESCRIPTION
Closes #91

## Summary

- add the shared deterministic terminal report renderer to model-router
- preserve concrete model/provider blindness until every model-dependent decision is settled
- integrate one terminal report into Pipeline, dm-review, and routed Assembly coordinator opinion sessions
- add fictional fixtures and workflow-contract checks for ordering, sanitization, accounting, fallback, and failure behavior
- move model-router to 0.2.0, pipeline to 1.59.0, dm-review to 1.72.0, and project-manager to 1.11.0

## Verification

- `./tools/test-terminal-model-report.sh` (34 assertions)
- `./tools/test-model-router.sh` (66 assertions)
- `./tools/validate-provider-neutral-routing.sh`
- `./tools/validate-routing-economics.sh`
- `./tools/validate-workflow-contracts.sh`
- `./tools/validate-openrouter-resolution.sh --all`
- `./tools/validate-dm-review-codex-perspective.sh`
- `./tools/generate-codex-manifests.py --check`
- `./tools/generate-codex-command-skills.py --check`
- `./tools/check-dependencies.sh`
- `./tools/validate-dual-compat.sh`
- `./tools/validate-composition.sh --all`
- `git diff --check`

## Review

A provider-neutral `review-deep` pass found six confirmed in-scope hardening issues. All six were repaired and covered before publication.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Design-Machines-Studio/codesmith/depot/pr/92"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790293282&installation_model_id=428410&pr_number=92&repository=Design-Machines-Studio%2Fdepot&return_to=https%3A%2F%2Fgithub.com%2FDesign-Machines-Studio%2Fdepot%2Fpull%2F92&signature=a43fa3ab88ef801900a79ecbf6ae1e7ee24385f2b691a079ea89ae7c7f444183"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->