### PR TITLE
Add scheduled model intelligence and native benchmark parity

### DIFF
--- a/docs/model-intelligence.md
+++ b/docs/model-intelligence.md
@@ -1,0 +1,112 @@
+# Depot model intelligence
+
+Depot model intelligence combines three evidence classes without pretending
+they are interchangeable:
+
+1. OpenRouter catalog facts: exact identity, availability, capabilities,
+   context limits, provider limits, and pricing.
+2. Controlled `depot-role-v1` results: deterministic quality score, duration,
+   token/cost receipt fields, transport, and repeated-attempt reliability.
+3. Production evidence: Workflow Kernel `metrics.json` and
+   `run-cost-summary.json` artifacts from actual Pipeline and dm-review runs.
+
+Public benchmarks and OpenRouter rankings nominate candidates. They do not
+promote models. Native subscription runs retain their marginal-cost advantage,
+while API-equivalent pricing makes their opportunity cost visible.
+
+## Commands
+
+Capture the live catalog outside the repository, then compare it with the
+checked-in matrix:
+
+```sh
+STATE_ROOT=/home/ned/.local/state/openrouter-model-pulse
+OBSERVED_AT="$(date --iso-8601=seconds)"
+CATALOG="$STATE_ROOT/catalog/models-$(date +%Y%m%dT%H%M%S%z).json"
+
+mkdir -p "$STATE_ROOT/catalog" "$STATE_ROOT/receipts"
+curl -fsS https://openrouter.ai/api/v1/models -o "$CATALOG"
+jq -e '.data | type == "array" and length > 0' "$CATALOG" >/dev/null
+
+./tools/model-intelligence.py catalog-refresh \
+  --catalog "$CATALOG" \
+  --observed-at "$OBSERVED_AT" \
+  --output "$STATE_ROOT/receipts/catalog-$(date +%F).json"
+```
+
+Add `--write` only in a clean automation worktree. It refreshes existing exact
+matrix entries when material catalog facts changed. It never adds a new model
+or edits `role-policy.json`; `new_candidates[]` is a nomination list.
+
+Aggregate local production artifacts and retained benchmark results:
+
+```sh
+./tools/model-intelligence.py report \
+  --run-root /home/ned/ai/depot/plans \
+  --run-root /home/ned/ai/depot/.workflow-kernel/runs \
+  --benchmark-root /home/ned/benchmark-results/depot-role-v1 \
+  --json-output docs/model-intelligence/latest.json \
+  --markdown-output docs/model-intelligence/latest.md
+```
+
+The source checkout paths are explicit because Git-ignored run evidence is not
+copied into an isolated scheduled-task worktree. Reports aggregate content-free
+economic and quality signals; they do not publish private prompt/output content
+or private receipt identity fields.
+
+Run an exact OpenRouter model through the existing benchmark:
+
+```sh
+BENCH=./plugins/openrouter/skills/openrouter-delegate/references/depot-role-benchmark.sh
+"$BENCH" --run \
+  --case review-zero-deferral \
+  --model deepseek/deepseek-v4-flash-0731 \
+  --result-dir /home/ned/benchmark-results/depot-role-v1/manual/openrouter/deepseek-v4-flash/review-zero-deferral/run-1
+```
+
+Run one admitted native subscription model or policy alias through the same
+prompt and scorer. The receipt retains the actual served identity when the CLI
+reports it:
+
+```sh
+./tools/run-native-depot-role-benchmark.sh \
+  --case review-zero-deferral \
+  --transport codex-cli \
+  --model gpt-5.6-sol \
+  --effort medium \
+  --result-dir /home/ned/benchmark-results/depot-role-v1/manual/codex-cli/gpt-5.6-sol/review-zero-deferral/run-1
+```
+
+Use `--transport claude-cli --model fable` for an admitted Claude subscription
+candidate. Native results record subscription billing and any CLI-reported
+tokens. Missing counters remain missing; billed cost is never invented.
+
+## Interpretation and promotion gates
+
+- Keep token counts and deterministic input bytes as separate units.
+- Keep provider-billed cost and subscription API-equivalent cost separately
+  labeled.
+- Count failed and incomplete attempts; never select only successful runs.
+- Require at least three successful attempts on every applicable local case.
+- Compare per-axis results—quality, success, duration, tokens, cost, fallback,
+  and production quality signals—not one opaque composite score.
+- A new OpenRouter model may enter a role only as a later canary rung after the
+  controlled gate. Moving it ahead of an incumbent additionally requires
+  production evidence from that canary position.
+- If an included-subscription native candidate remains within the accepted
+  quality/reliability floor, prefer it unless an OpenRouter model demonstrates
+  a material latency, context, capability, or capacity-preservation advantage.
+- Routing edits occur only on an isolated automation branch, pass the complete
+  validators, and never merge themselves.
+
+## Focused verification
+
+```sh
+python3 tests/test_model_intelligence.py -v
+./tools/test-openrouter-role-benchmark.sh
+./tools/validate-provider-neutral-routing.sh
+./tools/validate-routing-economics.sh
+```
+
+Run `./tools/validate-composition.sh --all` before committing a matrix, policy,
+plugin-version, or generated-manifest change.

--- a/docs/scheduled-model-intelligence/daily-prompt.md
+++ b/docs/scheduled-model-intelligence/daily-prompt.md
@@ -1,0 +1,177 @@
+# Daily Depot model pulse — scheduled-task prompt
+
+Run this task Monday through Saturday at 05:00 Asia/Makassar in an isolated Git
+worktree for `/home/ned/ai/depot`. Always return findings, including a clean
+"no material change" result.
+
+You are maintaining Depot's factual model matrix and longitudinal model-system
+report. Work only in the scheduled task's isolated worktree. Treat
+`/home/ned/ai/depot` as a read-only source of local, Git-ignored production run
+artifacts. Do not modify, commit, clean, stash, reset, or switch branches in
+that source checkout; another process may be using it.
+
+## Authority and boundaries
+
+- You may refresh existing factual entries in
+  `plugins/openrouter/skills/openrouter-delegate/references/model-matrix.json`.
+- You may update the dated catalog receipt, `model-selection.md`, the ongoing
+  aggregate report, version metadata required by those edits, and generated
+  Codex manifests.
+- Do not add a new model to the matrix during the daily pulse.
+- Do not edit `plugins/model-router/skills/model-router/references/role-policy.json`.
+- Do not run paid model benchmarks.
+- Never expose credentials, prompts, outputs, generation IDs, or concrete
+  private-router receipt records. Aggregate model/provider metrics are allowed.
+- Never merge to `main`. Commit only exact files created or changed by this run
+  on the automation worktree's `ai/` branch. Do not push unless this scheduled
+  task is separately configured to push.
+
+## 1. Preflight
+
+Run from the worktree root:
+
+```sh
+rtk git status --short --branch
+rtk git rev-parse --show-toplevel
+rtk python tests/test_model_intelligence.py -v
+```
+
+If the worktree contains changes that predate this run, stop without editing
+and report the exact paths. Do not attempt to reconcile them.
+
+Set the exact paths and capture one catalog snapshot:
+
+```sh
+SOURCE_REPO=/home/ned/ai/depot
+STATE_ROOT=/home/ned/.local/state/openrouter-model-pulse
+MATRIX=plugins/openrouter/skills/openrouter-delegate/references/model-matrix.json
+OBSERVED_AT="$(date --iso-8601=seconds)"
+RUN_DATE="$(date +%F)"
+CATALOG="$STATE_ROOT/catalog/models-$(date +%Y%m%dT%H%M%S%z).json"
+CATALOG_RECEIPT="$STATE_ROOT/receipts/catalog-$RUN_DATE.json"
+
+mkdir -p "$STATE_ROOT/catalog" "$STATE_ROOT/receipts"
+curl -fsS https://openrouter.ai/api/v1/models -o "$CATALOG"
+jq -e '.data | type == "array" and length > 0' "$CATALOG" >/dev/null
+sha256sum "$CATALOG"
+```
+
+If the catalog request or validation fails, retain the old matrix unchanged,
+continue to the production report, and mark catalog evidence unavailable.
+
+## 2. Compare and refresh the existing matrix
+
+When the catalog is valid, run:
+
+```sh
+rtk python tools/model-intelligence.py catalog-refresh \
+  --catalog "$CATALOG" \
+  --matrix "$MATRIX" \
+  --observed-at "$OBSERVED_AT" \
+  --output "$CATALOG_RECEIPT" \
+  --write
+
+jq '{observedAt,expiresAt,models_observed,material_change_count,changes,new_candidates}' \
+  "$CATALOG_RECEIPT"
+rtk git diff -- "$MATRIX"
+```
+
+The tool may update existing exact entries only. Review every changed field
+against the captured catalog. Do not infer quality, copy evidence from another
+model/version, admit moving `latest` aliases, or overwrite
+`native_api_equivalent_cost` dates.
+
+If `material_change_count` is nonzero:
+
+1. Create `docs/openrouter-model-matrix-refreshes/$RUN_DATE.md` with the exact
+   source, observed/expires timestamps, SHA-256, observed count, field changes,
+   new-candidate nominations, stale/unavailable evidence, and an explicit
+   statement that no paid inference or role-policy change occurred.
+2. Update the exact affected rows and snapshot reference in
+   `plugins/openrouter/skills/openrouter-delegate/references/model-selection.md`.
+3. Update the snapshot-date assertion in
+   `tools/validate-routing-economics.sh`; do not weaken any other assertion.
+4. Patch-bump `plugins/openrouter/.claude-plugin/plugin.json` and the matching
+   openrouter entry in `.claude-plugin/marketplace.json`, then run:
+
+```sh
+rtk ./tools/generate-codex-manifests.py
+rtk ./tools/generate-codex-command-skills.py --check
+```
+
+If there is no material catalog change, do not touch the matrix, selection
+guide, validator, versions, generated manifests, or dated matrix-refresh docs.
+
+## 3. Rebuild the ongoing production report
+
+Read actual run artifacts from the source checkout, not the isolated worktree:
+
+```sh
+REPORT_DIR=docs/model-intelligence
+DAILY_DIR="$REPORT_DIR/daily"
+BENCH_ROOT=/home/ned/benchmark-results/depot-role-v1
+mkdir -p "$DAILY_DIR"
+
+rtk python tools/model-intelligence.py report \
+  --run-root "$SOURCE_REPO/plans" \
+  --run-root "$SOURCE_REPO/.workflow-kernel/runs" \
+  --benchmark-root "$BENCH_ROOT" \
+  --observed-at "$OBSERVED_AT" \
+  --json-output "$DAILY_DIR/$RUN_DATE.json" \
+  --markdown-output "$DAILY_DIR/$RUN_DATE.md"
+
+cp "$DAILY_DIR/$RUN_DATE.json" "$REPORT_DIR/latest.json"
+cp "$DAILY_DIR/$RUN_DATE.md" "$REPORT_DIR/latest.md"
+jq '{production:{cost_summary_artifacts:.production.cost_summary_artifacts,
+  metrics_artifacts:.production.metrics_artifacts,
+  empty_cost_summaries:.production.empty_cost_summaries,
+  malformed_artifacts:.production.malformed_artifacts,
+  by_model:.production.by_model,
+  quality:.production.quality},benchmarks:.benchmarks}' "$REPORT_DIR/latest.json"
+```
+
+Interpret honestly:
+
+- `lanes: 0`, empty summaries, missing token/cost coverage, and unattributed
+  models are measurement gaps—not zero cost or successful efficiency.
+- Never add token counts to input bytes.
+- Provider-billed cost and imputed subscription-equivalent cost remain labeled.
+- Finding contribution, completion, fallback, retry, and first-pass validation
+  are workflow quality signals; do not claim isolated model causality when the
+  artifacts do not establish it.
+- Compare the new latest report with the previous tracked version and state the
+  actual deltas. Do not fill gaps with estimates outside the matrix contract.
+
+## 4. Validate and commit
+
+Run:
+
+```sh
+rtk python tests/test_model_intelligence.py -v
+rtk ./tools/test-openrouter-role-benchmark.sh
+rtk ./tools/validate-provider-neutral-routing.sh
+rtk ./tools/validate-routing-economics.sh
+rtk ./tools/validate-dual-compat.sh
+rtk ./tools/validate-composition.sh --all
+rtk git diff --check
+rtk git status --short
+```
+
+If validation fails, do not commit. Report the failing command, preserve the
+worktree for inspection, and do not change policy to make a test pass.
+
+If validation passes, stage only the paths this run intentionally changed and
+commit with `chore(models): daily pulse $RUN_DATE`. Never use `git add -A`.
+
+## 5. Findings returned to Scheduled
+
+Always report:
+
+- catalog status, timestamp, digest, and material changes;
+- new candidate nominations without promotion;
+- production evidence coverage and missing instrumentation;
+- model/role cost, duration, token or byte, fallback, retry, validation, and
+  finding-contribution changes actually supported by artifacts;
+- strong/weak points in the current routing system;
+- files changed, validation results, branch, and commit—or why no commit exists;
+- exactly one recommended follow-up, or `none`.

--- a/docs/scheduled-model-intelligence/weekly-prompt.md
+++ b/docs/scheduled-model-intelligence/weekly-prompt.md
@@ -1,0 +1,254 @@
+# Weekly Depot benchmark and routing review — scheduled-task prompt
+
+Run this task Sunday at 05:00 Asia/Makassar in an isolated Git worktree for
+`/home/ned/ai/depot`. It replaces Sunday's daily pulse. Always return findings,
+including a clean "no routing change justified" result.
+
+You are running Depot's weekly controlled benchmark and routing-effectiveness
+review. Work only in the scheduled task's isolated worktree. Treat
+`/home/ned/ai/depot` as a read-only source of local production evidence. Never
+modify, clean, reset, stash, commit, or switch branches in that source checkout;
+another process may be using it.
+
+Use the same catalog-refresh, reporting, evidence-interpretation, versioning,
+validation, privacy, and no-auto-merge rules in
+`docs/scheduled-model-intelligence/daily-prompt.md`, plus the procedure below.
+
+## 1. Preflight and daily pulse
+
+Run the daily prompt's preflight, live catalog capture, existing-entry matrix
+refresh, and production report first. Stop before paid calls if the catalog is
+unavailable, the worktree was not clean, a routed exact slug is absent, or the
+OpenRouter credential cannot be resolved and its dedicated weekly limit cannot
+be verified by:
+
+```sh
+CREDENTIAL=plugins/openrouter/skills/openrouter-delegate/references/openrouter-credential.sh
+KEY_STATE="/home/ned/benchmark-results/depot-role-v1/key-state-$(date +%F).json"
+(
+  set +x
+  . "$CREDENTIAL"
+  load_openrouter_api_key
+  umask 077
+  curl -fsS https://openrouter.ai/api/v1/key \
+    -H "Authorization: Bearer $OPENROUTER_API_KEY" \
+    -o "$KEY_STATE"
+)
+jq -e '.data.limit == 10 and .data.limit_reset == "weekly" and
+  (.data.limit_remaining | type) == "number" and .data.limit_remaining >= 0' \
+  "$KEY_STATE" >/dev/null
+jq '{limit:.data.limit,limit_remaining:.data.limit_remaining,
+  limit_reset:.data.limit_reset,usage_weekly:.data.usage_weekly}' "$KEY_STATE"
+```
+
+Use a dedicated OpenRouter key with a provider-side weekly limit of USD $10.
+The local receipt sum is a secondary guard, not a hard cap: one in-flight call
+can exceed a local pre-call total. If a provider-side $10 limit cannot be
+verified, do not run paid benchmarks; finish the production review and report
+`benchmark blocked: hard spend cap not proven`.
+
+Set:
+
+```sh
+RUN_DATE="$(date +%F)"
+BENCH=./plugins/openrouter/skills/openrouter-delegate/references/depot-role-benchmark.sh
+NATIVE_BENCH=./tools/run-native-depot-role-benchmark.sh
+SUITE=./plugins/openrouter/skills/openrouter-delegate/references/depot-role-benchmark-suite.json
+MATRIX=./plugins/openrouter/skills/openrouter-delegate/references/model-matrix.json
+POLICY=./plugins/model-router/skills/model-router/references/role-policy.json
+WEEK_ROOT="/home/ned/benchmark-results/depot-role-v1/$RUN_DATE"
+BUDGET_USD=10
+mkdir -p "$WEEK_ROOT"
+
+rtk "$BENCH" --list
+jq -r '.roles | to_entries[] | .key as $role | .value[] |
+  [$role,.transport,.model,.billing] | @tsv' "$POLICY"
+```
+
+## 2. Choose the bounded comparison set
+
+Use exact OpenRouter identities only. For native subscription transports, use
+only identities or aliases already admitted by `role-policy.json`, and require
+the native benchmark receipt to retain the actual served model when the CLI
+reports it. Build a written candidate plan at
+`$WEEK_ROOT/benchmark-plan.json` containing:
+
+- at most two newly nominated OpenRouter models from the fresh catalog receipt;
+- the current first OpenRouter candidate for each suite role;
+- the current first native subscription candidate for each suite role;
+- case IDs, three target attempts, effort, rationale, estimated call count, and
+  the order in which budget will be spent.
+
+Public rankings and external benchmarks are nomination evidence only. Record
+the exact model/harness variant, source version/date, and incompatibilities.
+Never transfer a score from a different version or harness.
+
+A nominated OpenRouter model must be admitted to the matrix before the runner
+can call it. Add only candidates selected in the bounded plan. Populate exact
+catalog identity, price, context, feature/parameter, provider-limit, reasoning,
+and source fields from the captured snapshot; use:
+
+- `recommendation_status: "catalogued-awaiting-local-benchmark"`
+- `quality_rank: null` unless exact comparable evidence exists
+- `local_evidence: "No local benchmark evidence before <RUN_DATE>."`
+- a role sentence that explicitly says the model is not routed
+
+Do not add aliases, `anthropic/*`, unpriced entries, or models lacking required
+case capabilities. Admission to the matrix is not admission to role policy.
+
+## 3. Run controlled comparisons
+
+For each OpenRouter candidate and applicable case, use a unique directory and
+disable fallback through the existing runner:
+
+```sh
+"$BENCH" --run \
+  --case "$CASE_ID" \
+  --model "$MODEL" \
+  --result-dir "$WEEK_ROOT/openrouter/$MODEL/$CASE_ID/run-$ATTEMPT"
+```
+
+For each native incumbent, run the same prompt and deterministic scorer:
+
+```sh
+"$NATIVE_BENCH" \
+  --case "$CASE_ID" \
+  --transport "$TRANSPORT" \
+  --model "$MODEL" \
+  --effort "$EFFORT" \
+  --result-dir "$WEEK_ROOT/$TRANSPORT/$MODEL/$CASE_ID/run-$ATTEMPT"
+```
+
+Run a one-attempt screen first. Count failures and incomplete directories.
+Only candidates that parse, satisfy every closed case assertion, and remain
+plausible on cost/duration proceed to attempts 2 and 3. Do not discard failed
+runs or rerun into the same directory.
+
+After every paid OpenRouter attempt, recalculate actual measured spend from all
+`result.json` files under `$WEEK_ROOT`; read `.usage.cost // 0`, record the sum
+in `$WEEK_ROOT/spend.json`, and stop paid calls when the provider key refuses
+the next call or the measured sum reaches $10. Never substitute list price for
+provider-reported billed cost. Use this exact rollup after each paid attempt:
+
+```sh
+rtk python tools/model-intelligence.py report \
+  --run-root "$WEEK_ROOT/no-production-evidence" \
+  --benchmark-root "$WEEK_ROOT" \
+  --json-output "$WEEK_ROOT/spend.json" >/dev/null
+SPEND_USD="$(jq -r '.benchmarks.measured_cost_usd' "$WEEK_ROOT/spend.json")"
+rtk awk -v spend="$SPEND_USD" -v cap="$BUDGET_USD" \
+  'BEGIN { if (spend >= cap) exit 1 }' || {
+    printf 'weekly benchmark spend cap reached: %s\n' "$SPEND_USD"
+    break
+  }
+```
+
+Report untested candidates and cases.
+
+## 4. Rebuild and inspect the combined report
+
+After attempts settle, run:
+
+```sh
+REPORT_DIR=docs/model-intelligence
+WEEKLY_DIR="$REPORT_DIR/weekly"
+SOURCE_REPO=/home/ned/ai/depot
+mkdir -p "$WEEKLY_DIR"
+
+rtk python tools/model-intelligence.py report \
+  --run-root "$SOURCE_REPO/plans" \
+  --run-root "$SOURCE_REPO/.workflow-kernel/runs" \
+  --benchmark-root "$WEEK_ROOT" \
+  --json-output "$WEEKLY_DIR/$RUN_DATE.json" \
+  --markdown-output "$WEEKLY_DIR/$RUN_DATE.md"
+
+rtk python tools/model-intelligence.py report \
+  --run-root "$SOURCE_REPO/plans" \
+  --run-root "$SOURCE_REPO/.workflow-kernel/runs" \
+  --benchmark-root /home/ned/benchmark-results/depot-role-v1 \
+  --json-output "$REPORT_DIR/latest.json" \
+  --markdown-output "$REPORT_DIR/latest.md"
+
+jq '.benchmarks.groups, .production.by_model, .production.quality' \
+  "$WEEKLY_DIR/$RUN_DATE.json"
+```
+
+Review each axis separately:
+
+- success rate and all retained failures;
+- median deterministic quality by case;
+- median duration;
+- prompt, completion, reasoning, and cache tokens when reported;
+- deterministic input bytes as a separate native measurement unit;
+- provider-billed OpenRouter cost;
+- subscription API-equivalent cost, explicitly labeled and never called spend;
+- quality per completion token and quality per measured dollar only when both
+  denominators have complete compatible coverage;
+- fallbacks, retries, completion rate, first-pass validation, rework, and
+  finding contributions from production metrics;
+- coverage gaps that prevent comparison.
+
+Do not produce one opaque weighted leaderboard.
+
+## 5. Guarded routing decisions
+
+Update matrix evidence and recommendations automatically from the retained
+results. A role-policy edit is allowed on this automation branch only when all
+applicable gates pass:
+
+1. The exact model remains available in the fresh matrix.
+2. Every applicable case has at least three retained successful attempts,
+   fallback is false, no case median is below 90, and overall median quality is
+   not worse than the comparable incumbent by more than two points.
+3. Duration/token/cost coverage is sufficient to support the claimed advantage;
+   missing evidence cannot be scored as zero.
+4. Family-independence and capability constraints remain satisfied.
+5. An included-subscription native incumbent stays ahead when it is within the
+   quality/reliability floor, unless the challenger proves a material latency,
+   context, capability, or subscription-capacity preservation advantage.
+6. A newly benchmarked OpenRouter model enters only as a later canary rung.
+   Moving it to role head requires at least five attributable production
+   attempts with acceptable completion, fallback, retry, and first-pass
+   validation evidence from that canary position.
+7. Security models remain confined to `security-review`; `anthropic/*` remains
+   forbidden on OpenRouter; GLM remains excluded unless exact local evidence
+   specifically reverses the existing constraint and validators are updated
+   without weakening unrelated invariants.
+
+When a gate fails, retain the evidence and write `no policy change` with the
+exact failed gate. Do not promote by intuition.
+
+When a gate passes, edit only
+`plugins/model-router/skills/model-router/references/role-policy.json`, update
+its `matrixSnapshot`, patch-bump model-router's Claude manifest and marketplace
+entry, regenerate Codex manifests, and document before/after role order plus
+rollback criteria in the weekly report. The branch commit is the review
+surface; never merge it automatically.
+
+## 6. Validate, commit, and report
+
+Run all daily validations plus:
+
+```sh
+rtk ./tools/test-model-router.sh
+rtk ./tools/validate-workflow-contracts.sh
+rtk git diff --check
+rtk git status --short
+```
+
+If any validation fails, do not commit. Never weaken a gate merely to land a
+candidate. If all pass, stage only intentional files and commit with
+`chore(models): weekly evidence $RUN_DATE`. Never use `git add -A`, never merge,
+and never modify the source checkout.
+
+Always return:
+
+- candidates and incumbents tested, attempts, failures, and skipped work;
+- actual OpenRouter spend against the $10 cap;
+- per-axis benchmark findings and production findings;
+- subscription-marginal-cost and API-equivalent views separately;
+- strong and weak points in the current system;
+- every matrix or role change with evidence and rollback condition;
+- every failed promotion gate and instrumentation gap;
+- validation, changed files, branch, and commit—or why no commit exists;
+- exactly one recommended next benchmark or instrumentation improvement.

--- a/tests/test_model_intelligence.py
+++ b/tests/test_model_intelligence.py
@@ -1,0 +1,321 @@
+"""Regression tests for scheduled model-intelligence tooling."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import stat
+import subprocess
+import tempfile
+import unittest
+
+
+REPO = Path(__file__).resolve().parents[1]
+TOOL = REPO / "tools/model-intelligence.py"
+NATIVE_BENCH = REPO / "tools/run-native-depot-role-benchmark.sh"
+
+
+class ModelIntelligenceTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self.tmp.name)
+
+    def tearDown(self) -> None:
+        self.tmp.cleanup()
+
+    def run_tool(self, *args: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [str(TOOL), *args], cwd=REPO, text=True, capture_output=True
+        )
+
+    def test_catalog_refresh_updates_existing_models_and_only_nominates_new(self) -> None:
+        matrix = self.root / "matrix.json"
+        matrix.write_text(
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "snapshot_date": "2026-08-01",
+                    "catalog_source": "https://openrouter.ai/api/v1/models",
+                    "freshness_rule_minutes": 15,
+                    "native_api_equivalent_cost": {"snapshot_date": "2026-07-31"},
+                    "models": [
+                        {
+                            "slug": "example/existing",
+                            "name": "Old",
+                            "catalog_status": "available",
+                            "input_usd_per_m": 1.0,
+                            "output_usd_per_m": 2.0,
+                            "local_evidence": "preserve me",
+                            "snapshot_date": "2026-08-01",
+                        }
+                    ],
+                }
+            )
+        )
+        catalog = self.root / "catalog.json"
+        catalog.write_text(
+            json.dumps(
+                {
+                    "data": [
+                        {
+                            "id": "example/existing",
+                            "canonical_slug": "example/existing-20260826",
+                            "name": "Existing 2",
+                            "created": 10,
+                            "context_length": 1000,
+                            "architecture": {
+                                "input_modalities": ["text"],
+                                "output_modalities": ["text"],
+                            },
+                            "pricing": {"prompt": "0.0000005", "completion": "0.000001"},
+                            "top_provider": {
+                                "context_length": 1000,
+                                "max_completion_tokens": 100,
+                                "is_moderated": False,
+                            },
+                            "supported_parameters": ["tools", "structured_outputs"],
+                            "default_parameters": {},
+                        },
+                        {
+                            "id": "example/new",
+                            "canonical_slug": "example/new-20260826",
+                            "name": "New",
+                            "created": 20,
+                            "context_length": 2000,
+                            "architecture": {
+                                "input_modalities": ["text"],
+                                "output_modalities": ["text"],
+                            },
+                            "pricing": {"prompt": "0.0000002", "completion": "0.0000004"},
+                            "top_provider": {},
+                            "supported_parameters": ["tools", "structured_outputs"],
+                            "default_parameters": {},
+                        },
+                    ]
+                }
+            )
+        )
+        receipt = self.root / "receipt.json"
+        result = self.run_tool(
+            "catalog-refresh",
+            "--catalog",
+            str(catalog),
+            "--matrix",
+            str(matrix),
+            "--observed-at",
+            "2026-08-26T05:00:00+08:00",
+            "--output",
+            str(receipt),
+            "--write",
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        evidence = json.loads(receipt.read_text())
+        self.assertGreater(evidence["material_change_count"], 0)
+        self.assertEqual(evidence["new_candidates"][0]["slug"], "example/new")
+        refreshed = json.loads(matrix.read_text())
+        self.assertEqual([model["slug"] for model in refreshed["models"]], ["example/existing"])
+        self.assertEqual(refreshed["models"][0]["input_usd_per_m"], 0.5)
+        self.assertEqual(refreshed["models"][0]["local_evidence"], "preserve me")
+        self.assertEqual(refreshed["native_api_equivalent_cost"]["snapshot_date"], "2026-07-31")
+        stale = self.run_tool(
+            "catalog-refresh",
+            "--catalog",
+            str(catalog),
+            "--matrix",
+            str(matrix),
+            "--observed-at",
+            "2026-08-26T05:00:00+08:00",
+            "--write",
+        )
+        self.assertEqual(stale.returncode, 2)
+        self.assertIn("not newer", stale.stderr)
+
+    def test_report_keeps_tokens_bytes_cost_and_quality_separate(self) -> None:
+        run = self.root / "runs" / "one"
+        run.mkdir(parents=True)
+        (run / "run-cost-summary.json").write_text(
+            json.dumps(
+                {
+                    "lanes": [
+                        {
+                            "model": "example/model",
+                            "duration_seconds": 3,
+                            "input_usage_count": 10,
+                            "output_usage_count": 4,
+                            "reasoning_usage_count": 2,
+                            "input_bytes": None,
+                            "cost_usd": 0.01,
+                            "usage_estimated": False,
+                            "measurement_source": "openrouter_api_receipt",
+                        },
+                        {
+                            "model": "native/model",
+                            "duration_seconds": 5,
+                            "input_usage_count": None,
+                            "output_usage_count": None,
+                            "reasoning_usage_count": None,
+                            "input_bytes": 400,
+                            "cost_usd": 0.02,
+                            "usage_estimated": True,
+                            "measurement_source": "estimated_input_bytes",
+                        },
+                    ]
+                }
+            )
+        )
+        (run / "metrics.json").write_text(
+            json.dumps(
+                {
+                    "finding_contributions_by_model": {"example/model": 2},
+                    "finding_contributions_by_provider": {"example": 2},
+                    "models": {"example/model": 1},
+                    "providers": {"example": 1},
+                    "retry_reasons": {"capacity": 1},
+                    "completion_rate": 1.0,
+                    "fallback_rate": 0.0,
+                    "validation_first_pass_rate": 0.5,
+                    "canonical_finding_count": 2,
+                }
+            )
+        )
+        benchmark = self.root / "bench" / "example" / "case" / "run-1"
+        benchmark.mkdir(parents=True)
+        (benchmark / "result.json").write_text(
+            json.dumps(
+                {
+                    "caseId": "case",
+                    "parsed": True,
+                    "qualityScore": 100,
+                    "durationSeconds": 2,
+                    "requestedModel": "example/model",
+                    "servedModel": "example/model",
+                    "transport": "openrouter",
+                    "usage": {"prompt_tokens": 10, "completion_tokens": 4, "cost": 0.01},
+                }
+            )
+        )
+        output = self.root / "latest.json"
+        markdown = self.root / "latest.md"
+        result = self.run_tool(
+            "report",
+            "--run-root",
+            str(self.root / "runs"),
+            "--benchmark-root",
+            str(self.root / "bench"),
+            "--observed-at",
+            "2026-08-26T05:00:00+08:00",
+            "--json-output",
+            str(output),
+            "--markdown-output",
+            str(markdown),
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        report = json.loads(output.read_text())
+        rows = {row["model"]: row for row in report["production"]["by_model"]}
+        self.assertEqual(rows["example/model"]["input_tokens"], 10)
+        self.assertEqual(rows["example/model"]["input_bytes"], 0)
+        self.assertEqual(rows["native/model"]["input_tokens"], 0)
+        self.assertEqual(rows["native/model"]["input_bytes"], 400)
+        self.assertEqual(rows["example/model"]["finding_contributions"], 2)
+        self.assertIn("different units", markdown.read_text())
+
+
+class NativeDepotBenchmarkTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self.tmp.name)
+
+    def tearDown(self) -> None:
+        self.tmp.cleanup()
+
+    def executable(self, name: str, content: str) -> Path:
+        path = self.root / name
+        path.write_text(content)
+        path.chmod(path.stat().st_mode | stat.S_IXUSR)
+        return path
+
+    def test_codex_subscription_attempt_uses_existing_scorer(self) -> None:
+        stub = self.executable(
+            "codex-stub",
+            """#!/usr/bin/env bash
+set -eu
+output=''
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --output-last-message) output="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+cat >/dev/null
+printf '%s\n' '{"findings":[{"id":"AUTH-1","severity":"P1"},{"id":"ROUTE-2","severity":"P2"},{"id":"DOC-3","severity":"P3"}],"deferred":false}' > "$output"
+printf '%s\n' '{"usage":{"input_tokens":20,"output_tokens":10}}'
+""",
+        )
+        result_dir = self.root / "codex-result"
+        env = os.environ.copy()
+        env["DEPOT_BENCH_CODEX_BIN"] = str(stub)
+        result = subprocess.run(
+            [
+                str(NATIVE_BENCH),
+                "--case",
+                "review-zero-deferral",
+                "--transport",
+                "codex-cli",
+                "--model",
+                "gpt-5.6-sol",
+                "--effort",
+                "medium",
+                "--result-dir",
+                str(result_dir),
+            ],
+            cwd=REPO,
+            text=True,
+            capture_output=True,
+            env=env,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        scored = json.loads((result_dir / "result.json").read_text())
+        self.assertEqual(scored["qualityScore"], 100)
+        self.assertEqual(scored["transport"], "codex-cli")
+        self.assertEqual(scored["billingMode"], "included-subscription")
+
+    def test_claude_subscription_attempt_uses_existing_scorer(self) -> None:
+        stub = self.executable(
+            "claude-stub",
+            """#!/usr/bin/env bash
+set -eu
+cat >/dev/null
+printf '%s\n' '{"structured_output":{"findings":[{"id":"AUTH-1","severity":"P1"},{"id":"ROUTE-2","severity":"P2"},{"id":"DOC-3","severity":"P3"}],"deferred":false},"usage":{"input_tokens":10,"output_tokens":5}}'
+""",
+        )
+        result_dir = self.root / "claude-result"
+        env = os.environ.copy()
+        env["DEPOT_BENCH_CLAUDE_BIN"] = str(stub)
+        result = subprocess.run(
+            [
+                str(NATIVE_BENCH),
+                "--case",
+                "review-zero-deferral",
+                "--transport",
+                "claude-cli",
+                "--model",
+                "fable",
+                "--effort",
+                "medium",
+                "--result-dir",
+                str(result_dir),
+            ],
+            cwd=REPO,
+            text=True,
+            capture_output=True,
+            env=env,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        scored = json.loads((result_dir / "result.json").read_text())
+        self.assertEqual(scored["qualityScore"], 100)
+        self.assertEqual(scored["transport"], "claude-cli")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/model-intelligence.py
+++ b/tools/model-intelligence.py
@@ -1,0 +1,745 @@
+#!/usr/bin/env python3
+"""Deterministic catalog, production-run, and benchmark intelligence for Depot.
+
+The command deliberately separates facts from policy:
+
+* ``catalog-refresh`` compares an OpenRouter catalog snapshot with the checked-in
+  matrix and can refresh existing exact entries. It never admits a new model or
+  changes role routing.
+* ``report`` aggregates repository-owned run-cost summaries, workflow metrics,
+  and Depot role benchmark results. It never reads prompt/model output content.
+
+Scheduled tasks use this command so daily and weekly runs share one evidence
+contract instead of reconstructing ad-hoc jq pipelines.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import statistics
+import sys
+from collections import Counter, defaultdict
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Iterable
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_MATRIX = (
+    REPO_ROOT
+    / "plugins/openrouter/skills/openrouter-delegate/references/model-matrix.json"
+)
+DEFAULT_RUN_ROOTS = (REPO_ROOT / "plans", REPO_ROOT / ".workflow-kernel" / "runs")
+
+
+class IntelligenceError(ValueError):
+    """Raised when evidence is malformed or unsafe to interpret."""
+
+
+def load_json(path: Path) -> Any:
+    if not path.is_file() or path.is_symlink():
+        raise IntelligenceError(f"regular JSON file required: {path}")
+    try:
+        return json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError) as exc:
+        raise IntelligenceError(f"invalid JSON: {path}: {exc}") from exc
+
+
+def canonical_json(data: Any) -> str:
+    return json.dumps(data, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+def pretty_json(data: Any) -> str:
+    return json.dumps(data, indent=2, ensure_ascii=False, sort_keys=True) + "\n"
+
+
+def matrix_json(data: Any) -> str:
+    """Preserve the matrix's reviewed field order instead of churning every key."""
+    return json.dumps(data, indent=2, ensure_ascii=False) + "\n"
+
+
+def sha256_bytes(content: bytes) -> str:
+    return hashlib.sha256(content).hexdigest()
+
+
+def write_atomic(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f".{path.name}.tmp")
+    temporary.write_text(content)
+    temporary.replace(path)
+
+
+def parse_observed_at(value: str | None) -> datetime:
+    if value is None:
+        return datetime.now(timezone.utc).astimezone()
+    normalized = value.replace("Z", "+00:00")
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError as exc:
+        raise IntelligenceError("--observed-at must be timezone-aware ISO-8601") from exc
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise IntelligenceError("--observed-at must include a timezone offset")
+    return parsed
+
+
+def number(value: Any) -> float | None:
+    if value is None or isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        try:
+            return float(value)
+        except ValueError:
+            return None
+    return None
+
+
+def integer(value: Any) -> int | None:
+    parsed = number(value)
+    if parsed is None or not parsed.is_integer():
+        return None
+    return int(parsed)
+
+
+def per_million(value: Any) -> float | None:
+    parsed = number(value)
+    return None if parsed is None else round(parsed * 1_000_000, 12)
+
+
+def modality_lists(catalog_model: dict[str, Any]) -> tuple[list[str], list[str]]:
+    architecture = catalog_model.get("architecture")
+    if not isinstance(architecture, dict):
+        return [], []
+    inputs = architecture.get("input_modalities")
+    outputs = architecture.get("output_modalities")
+    return (
+        sorted(item for item in inputs if isinstance(item, str))
+        if isinstance(inputs, list)
+        else [],
+        sorted(item for item in outputs if isinstance(item, str))
+        if isinstance(outputs, list)
+        else [],
+    )
+
+
+def normalized_pricing(catalog_model: dict[str, Any]) -> dict[str, Any]:
+    pricing = catalog_model.get("pricing")
+    pricing = pricing if isinstance(pricing, dict) else {}
+    result: dict[str, Any] = {
+        "input_usd_per_m": per_million(pricing.get("prompt")),
+        "output_usd_per_m": per_million(pricing.get("completion")),
+        "cache_read_usd_per_m": per_million(pricing.get("input_cache_read")),
+        "cache_write_usd_per_m": per_million(pricing.get("input_cache_write")),
+        "web_search_usd_per_request": number(pricing.get("web_search")),
+    }
+    overrides = pricing.get("overrides")
+    if isinstance(overrides, list):
+        normalized_overrides = []
+        for override in overrides:
+            if not isinstance(override, dict):
+                continue
+            normalized_overrides.append(
+                {
+                    "min_prompt_tokens": integer(override.get("min_prompt_tokens")),
+                    "prompt": per_million(override.get("prompt")),
+                    "completion": per_million(override.get("completion")),
+                    "input_cache_read": per_million(override.get("input_cache_read")),
+                    "input_cache_write": per_million(override.get("input_cache_write")),
+                }
+            )
+        result["pricing_overrides"] = normalized_overrides or None
+    else:
+        result["pricing_overrides"] = None
+    return result
+
+
+def catalog_projection(catalog_model: dict[str, Any]) -> dict[str, Any]:
+    parameters = catalog_model.get("supported_parameters")
+    parameters = sorted(item for item in parameters if isinstance(item, str)) if isinstance(parameters, list) else []
+    inputs, outputs = modality_lists(catalog_model)
+    top_provider = catalog_model.get("top_provider")
+    top_provider = top_provider if isinstance(top_provider, dict) else {}
+    reasoning = catalog_model.get("reasoning")
+    reasoning = reasoning if isinstance(reasoning, dict) else None
+    projection: dict[str, Any] = {
+        "catalog_name": catalog_model.get("name"),
+        "canonical_slug": catalog_model.get("canonical_slug"),
+        "catalog_status": "available",
+        "context_tokens": integer(catalog_model.get("context_length")),
+        "top_provider_context_tokens": integer(top_provider.get("context_length")),
+        "top_provider_max_completion_tokens": integer(top_provider.get("max_completion_tokens")),
+        "top_provider_is_moderated": top_provider.get("is_moderated")
+        if isinstance(top_provider.get("is_moderated"), bool)
+        else None,
+        "per_request_limits": catalog_model.get("per_request_limits"),
+        "input_modalities": inputs,
+        "output_modalities": outputs,
+        "supported_parameters": parameters,
+        "supports_tools": "tools" in parameters,
+        "supports_reasoning": "reasoning" in parameters or reasoning is not None,
+        "supports_reasoning_effort": "reasoning_effort" in parameters,
+        "supports_structured_outputs": "structured_outputs" in parameters,
+        "reasoning": reasoning,
+        "default_parameters": catalog_model.get("default_parameters")
+        if isinstance(catalog_model.get("default_parameters"), dict)
+        else {},
+    }
+    projection.update(normalized_pricing(catalog_model))
+    return projection
+
+
+def materially_different(left: Any, right: Any) -> bool:
+    if isinstance(left, (int, float)) and isinstance(right, (int, float)):
+        return not math.isclose(float(left), float(right), rel_tol=1e-9, abs_tol=1e-6)
+    if isinstance(left, list) and isinstance(right, list):
+        if all(isinstance(item, str) for item in left + right):
+            return sorted(left) != sorted(right)
+        if len(left) != len(right):
+            return True
+        return any(materially_different(a, b) for a, b in zip(left, right))
+    if isinstance(left, dict) and isinstance(right, dict):
+        keys = set(left) | set(right)
+        return any(
+            materially_different(left.get(key), right.get(key)) for key in keys
+        )
+    return left != right
+
+
+def eligible_new_candidate(model: dict[str, Any]) -> bool:
+    slug = model.get("id")
+    projection = catalog_projection(model)
+    input_price = projection["input_usd_per_m"]
+    output_price = projection["output_usd_per_m"]
+    return bool(
+        isinstance(slug, str)
+        and slug
+        and not slug.startswith("~")
+        and not slug.startswith("anthropic/")
+        and not slug.startswith("openrouter/")
+        and ":" not in slug
+        and "text" in projection["input_modalities"]
+        and projection["supports_tools"]
+        and projection["supports_structured_outputs"]
+        and input_price is not None
+        and output_price is not None
+        and input_price > 0
+        and output_price > 0
+    )
+
+
+def catalog_refresh(args: argparse.Namespace) -> int:
+    catalog_path = Path(args.catalog).resolve()
+    matrix_path = Path(args.matrix).resolve()
+    catalog = load_json(catalog_path)
+    matrix = load_json(matrix_path)
+    if not isinstance(catalog, dict) or not isinstance(catalog.get("data"), list):
+        raise IntelligenceError("catalog must contain a data array")
+    if not isinstance(matrix, dict) or not isinstance(matrix.get("models"), list):
+        raise IntelligenceError("matrix must contain a models array")
+
+    observed = parse_observed_at(args.observed_at)
+    observed_at = observed.isoformat(timespec="seconds")
+    expires_at = (observed + timedelta(minutes=int(matrix.get("freshness_rule_minutes", 15)))).isoformat(timespec="seconds")
+    snapshot_date = observed.date().isoformat()
+    catalog_digest = sha256_bytes(catalog_path.read_bytes())
+    live_models = {
+        item["id"]: item
+        for item in catalog["data"]
+        if isinstance(item, dict) and isinstance(item.get("id"), str)
+    }
+    matrix_slugs = {
+        item.get("slug")
+        for item in matrix["models"]
+        if isinstance(item, dict) and isinstance(item.get("slug"), str)
+    }
+    candidate_cutoff = 0.0
+    prior_observed = matrix.get("catalog_observed_at")
+    if isinstance(prior_observed, str):
+        try:
+            candidate_cutoff = parse_observed_at(prior_observed).timestamp()
+        except IntelligenceError:
+            candidate_cutoff = 0.0
+    if args.write and candidate_cutoff and observed.timestamp() <= candidate_cutoff:
+        raise IntelligenceError(
+            "refusing to write a catalog snapshot that is not newer than the matrix"
+        )
+
+    changes: list[dict[str, Any]] = []
+    updated_models: list[dict[str, Any]] = []
+    for existing in matrix["models"]:
+        if not isinstance(existing, dict) or not isinstance(existing.get("slug"), str):
+            raise IntelligenceError("every matrix model must have a string slug")
+        slug = existing["slug"]
+        updated = dict(existing)
+        live = live_models.get(slug)
+        if live is None:
+            if existing.get("catalog_status") != "unavailable":
+                changes.append({"slug": slug, "field": "catalog_status", "before": existing.get("catalog_status"), "after": "unavailable"})
+                updated["catalog_status"] = "unavailable"
+        else:
+            for field, after in catalog_projection(live).items():
+                before = existing.get(field)
+                if materially_different(before, after):
+                    changes.append({"slug": slug, "field": field, "before": before, "after": after})
+                    updated[field] = after
+        updated_models.append(updated)
+
+    new_candidates = sorted(
+        (
+            {
+                "slug": model["id"],
+                "canonical_slug": model.get("canonical_slug"),
+                "name": model.get("name"),
+                "created": integer(model.get("created")),
+                "context_tokens": integer(model.get("context_length")),
+                "input_usd_per_m": normalized_pricing(model)["input_usd_per_m"],
+                "output_usd_per_m": normalized_pricing(model)["output_usd_per_m"],
+            }
+            for model in live_models.values()
+            if model["id"] not in matrix_slugs
+            and eligible_new_candidate(model)
+            and (number(model.get("created")) or 0) > candidate_cutoff
+        ),
+        key=lambda item: item["created"] or 0,
+        reverse=True,
+    )[: args.candidate_limit]
+
+    receipt = {
+        "schema_version": 1,
+        "observedAt": observed_at,
+        "expiresAt": expires_at,
+        "catalog_source": matrix.get("catalog_source"),
+        "catalog_snapshot_sha256": catalog_digest,
+        "models_observed": len(live_models),
+        "matrix_models": len(updated_models),
+        "material_change_count": len(changes),
+        "changes": changes,
+        "new_candidates": new_candidates,
+        "write_applied": bool(args.write and changes),
+    }
+
+    if args.write and changes:
+        matrix["snapshot_date"] = snapshot_date
+        matrix["catalog_observed_at"] = observed_at
+        matrix["catalog_snapshot_sha256"] = catalog_digest
+        matrix["catalog_snapshot"] = str(catalog_path)
+        for model in updated_models:
+            model["snapshot_date"] = snapshot_date
+        matrix["models"] = updated_models
+        write_atomic(matrix_path, matrix_json(matrix))
+
+    if args.output:
+        write_atomic(Path(args.output).resolve(), pretty_json(receipt))
+    print(pretty_json(receipt), end="")
+    return 0
+
+
+def find_artifacts(roots: Iterable[Path], name: str) -> list[Path]:
+    found: set[Path] = set()
+    for root in roots:
+        if not root.exists():
+            continue
+        for path in root.rglob(name):
+            if path.is_file() and not path.is_symlink():
+                found.add(path.resolve())
+    return sorted(found)
+
+
+def safe_relative(path: Path) -> str:
+    try:
+        return str(path.relative_to(REPO_ROOT))
+    except ValueError:
+        return str(path)
+
+
+def median(values: Iterable[float | int | None]) -> float | None:
+    clean = [float(item) for item in values if item is not None]
+    return statistics.median(clean) if clean else None
+
+
+def add_numeric(target: dict[str, float], key: str, value: Any) -> None:
+    parsed = number(value)
+    if parsed is not None:
+        target[key] += parsed
+
+
+def production_rollup(roots: list[Path]) -> dict[str, Any]:
+    cost_paths = find_artifacts(roots, "run-cost-summary.json")
+    metrics_paths = find_artifacts(roots, "metrics.json")
+    by_model: dict[str, dict[str, Any]] = defaultdict(
+        lambda: {
+            "attempts": 0,
+            "duration_seconds": 0.0,
+            "input_tokens": 0.0,
+            "output_tokens": 0.0,
+            "reasoning_tokens": 0.0,
+            "input_bytes": 0.0,
+            "measured_cost_usd": 0.0,
+            "measured_cost_attempts": 0,
+            "estimated_attempts": 0,
+            "measurement_sources": Counter(),
+        }
+    )
+    by_lane_model: dict[tuple[str, str], dict[str, Any]] = defaultdict(
+        lambda: {
+            "attempts": 0,
+            "duration_seconds": 0.0,
+            "input_tokens": 0.0,
+            "output_tokens": 0.0,
+            "reasoning_tokens": 0.0,
+            "input_bytes": 0.0,
+            "measured_cost_usd": 0.0,
+            "measured_cost_attempts": 0,
+            "estimated_attempts": 0,
+        }
+    )
+    empty_cost_summaries = 0
+    malformed: list[str] = []
+
+    for path in cost_paths:
+        try:
+            artifact = load_json(path)
+            lanes = artifact.get("lanes") if isinstance(artifact, dict) else None
+            if not isinstance(lanes, list):
+                raise IntelligenceError("lanes array missing")
+            if not lanes:
+                empty_cost_summaries += 1
+            for lane in lanes:
+                if not isinstance(lane, dict):
+                    continue
+                model = lane.get("model")
+                model_key = model if isinstance(model, str) and model else "unattributed"
+                row = by_model[model_key]
+                lane_name = lane.get("lane")
+                lane_key = lane_name if isinstance(lane_name, str) and lane_name else "unattributed"
+                lane_row = by_lane_model[(lane_key, model_key)]
+                for target in (row, lane_row):
+                    target["attempts"] += 1
+                    add_numeric(target, "duration_seconds", lane.get("duration_seconds"))
+                    add_numeric(target, "input_tokens", lane.get("input_usage_count"))
+                    add_numeric(target, "output_tokens", lane.get("output_usage_count"))
+                    add_numeric(target, "reasoning_tokens", lane.get("reasoning_usage_count"))
+                    add_numeric(target, "input_bytes", lane.get("input_bytes"))
+                cost = number(lane.get("cost_usd"))
+                if cost is not None:
+                    for target in (row, lane_row):
+                        target["measured_cost_usd"] += cost
+                        target["measured_cost_attempts"] += 1
+                if lane.get("usage_estimated") is True:
+                    for target in (row, lane_row):
+                        target["estimated_attempts"] += 1
+                source = lane.get("measurement_source")
+                row["measurement_sources"][source if isinstance(source, str) else "unknown"] += 1
+        except IntelligenceError as exc:
+            malformed.append(f"{safe_relative(path)}: {exc}")
+
+    quality_by_model: Counter[str] = Counter()
+    quality_by_provider: Counter[str] = Counter()
+    completion_rates: list[float] = []
+    fallback_rates: list[float] = []
+    validation_rates: list[float] = []
+    canonical_findings = 0
+    retries: Counter[str] = Counter()
+    metric_models: Counter[str] = Counter()
+    metric_providers: Counter[str] = Counter()
+    for path in metrics_paths:
+        try:
+            artifact = load_json(path)
+            if not isinstance(artifact, dict):
+                raise IntelligenceError("metrics object required")
+            for source, target in (
+                (artifact.get("finding_contributions_by_model"), quality_by_model),
+                (artifact.get("finding_contributions_by_provider"), quality_by_provider),
+                (artifact.get("models"), metric_models),
+                (artifact.get("providers"), metric_providers),
+                (artifact.get("retry_reasons"), retries),
+            ):
+                if isinstance(source, dict):
+                    for key, value in source.items():
+                        parsed = integer(value)
+                        if isinstance(key, str) and parsed is not None:
+                            target[key] += parsed
+            for key, target in (
+                ("completion_rate", completion_rates),
+                ("fallback_rate", fallback_rates),
+                ("validation_first_pass_rate", validation_rates),
+            ):
+                parsed = number(artifact.get(key))
+                if parsed is not None:
+                    target.append(parsed)
+            parsed_findings = integer(artifact.get("canonical_finding_count"))
+            if parsed_findings is not None:
+                canonical_findings += parsed_findings
+        except IntelligenceError as exc:
+            malformed.append(f"{safe_relative(path)}: {exc}")
+
+    normalized_models = []
+    for model, row in sorted(by_model.items()):
+        normalized = dict(row)
+        normalized["model"] = model
+        normalized["measurement_sources"] = dict(sorted(row["measurement_sources"].items()))
+        normalized["finding_contributions"] = quality_by_model.get(model, 0)
+        normalized_models.append(normalized)
+    normalized_lanes = [
+        {"lane": lane, "model": model, **row}
+        for (lane, model), row in sorted(by_lane_model.items())
+    ]
+
+    return {
+        "cost_summary_artifacts": len(cost_paths),
+        "metrics_artifacts": len(metrics_paths),
+        "empty_cost_summaries": empty_cost_summaries,
+        "malformed_artifacts": malformed,
+        "by_model": normalized_models,
+        "by_lane_model": normalized_lanes,
+        "quality": {
+            "finding_contributions_by_model": dict(sorted(quality_by_model.items())),
+            "finding_contributions_by_provider": dict(sorted(quality_by_provider.items())),
+            "canonical_findings": canonical_findings,
+            "median_completion_rate": median(completion_rates),
+            "median_fallback_rate": median(fallback_rates),
+            "median_validation_first_pass_rate": median(validation_rates),
+            "retry_reasons": dict(sorted(retries.items())),
+            "model_attempt_counts_from_metrics": dict(sorted(metric_models.items())),
+            "provider_attempt_counts_from_metrics": dict(sorted(metric_providers.items())),
+        },
+        "artifact_paths": {
+            "run_cost_summaries": [safe_relative(path) for path in cost_paths],
+            "metrics": [safe_relative(path) for path in metrics_paths],
+        },
+    }
+
+
+def result_dirs(root: Path) -> list[Path]:
+    if not root.exists():
+        return []
+    candidates: set[Path] = set()
+    for filename in ("result.json", "prompt.txt", "receipt.json", "output.json"):
+        for path in root.rglob(filename):
+            if path.is_file() and not path.is_symlink():
+                candidates.add(path.parent.resolve())
+    return sorted(candidates)
+
+
+def benchmark_rollup(root: Path | None) -> dict[str, Any]:
+    if root is None:
+        return {"result_root": None, "attempts": 0, "groups": [], "incomplete_attempts": []}
+    directories = result_dirs(root)
+    grouped: dict[tuple[str, str, str], list[dict[str, Any]]] = defaultdict(list)
+    incomplete: list[str] = []
+    measured_cost_usd = 0.0
+    for directory in directories:
+        result_path = directory / "result.json"
+        if not result_path.is_file():
+            incomplete.append(str(directory))
+            continue
+        try:
+            result = load_json(result_path)
+        except IntelligenceError:
+            incomplete.append(str(directory))
+            continue
+        if not isinstance(result, dict):
+            incomplete.append(str(directory))
+            continue
+        usage = result.get("usage")
+        if isinstance(usage, dict):
+            cost = number(usage.get("cost") if "cost" in usage else usage.get("cost_usd"))
+            if cost is not None:
+                measured_cost_usd += cost
+        model = result.get("servedModel") or result.get("requestedModel") or "unknown"
+        case_id = result.get("caseId") or "unknown"
+        transport = result.get("transport") or result.get("provider") or "unknown"
+        grouped[(str(model), str(case_id), str(transport))].append(result)
+
+    groups = []
+    for (model, case_id, transport), results in sorted(grouped.items()):
+        parsed_successes = [item for item in results if item.get("parsed") is True]
+        quality = [number(item.get("qualityScore")) for item in parsed_successes]
+        duration = [number(item.get("durationSeconds")) for item in parsed_successes]
+        costs = []
+        prompt_tokens = []
+        completion_tokens = []
+        reasoning_tokens = []
+        for item in parsed_successes:
+            usage = item.get("usage")
+            if not isinstance(usage, dict):
+                continue
+            costs.append(number(usage.get("cost") if "cost" in usage else usage.get("cost_usd")))
+            prompt_tokens.append(number(usage.get("prompt_tokens") if "prompt_tokens" in usage else usage.get("input_tokens")))
+            completion_tokens.append(number(usage.get("completion_tokens") if "completion_tokens" in usage else usage.get("output_tokens")))
+            reasoning_tokens.append(number(usage.get("reasoning_tokens")))
+        groups.append(
+            {
+                "model": model,
+                "case_id": case_id,
+                "transport": transport,
+                "attempts": len(results),
+                "parsed_successes": len(parsed_successes),
+                "success_rate": len(parsed_successes) / len(results) if results else 0,
+                "median_quality_score": median(quality),
+                "median_duration_seconds": median(duration),
+                "median_cost_usd": median(costs),
+                "median_prompt_tokens": median(prompt_tokens),
+                "median_completion_tokens": median(completion_tokens),
+                "median_reasoning_tokens": median(reasoning_tokens),
+            }
+        )
+    return {
+        "result_root": str(root),
+        "attempts": sum(group["attempts"] for group in groups) + len(incomplete),
+        "groups": groups,
+        "incomplete_attempts": incomplete,
+        "measured_cost_usd": measured_cost_usd,
+    }
+
+
+def render_report(report: dict[str, Any]) -> str:
+    production = report["production"]
+    benchmark = report["benchmarks"]
+    lines = [
+        f"# Depot model intelligence — {report['generated_at'][:10]}",
+        "",
+        "## Evidence coverage",
+        "",
+        f"- Run cost summaries: {production['cost_summary_artifacts']}",
+        f"- Workflow metrics: {production['metrics_artifacts']}",
+        f"- Empty cost summaries: {production['empty_cost_summaries']}",
+        f"- Benchmark attempts: {benchmark['attempts']}",
+        f"- Incomplete benchmark attempts: {len(benchmark['incomplete_attempts'])}",
+    ]
+    if production["malformed_artifacts"]:
+        lines.append(f"- Malformed artifacts: {len(production['malformed_artifacts'])}")
+    lines.extend(["", "## Production economics by model", ""])
+    if production["by_model"]:
+        lines.extend(
+            [
+                "| Model | Attempts | Duration | Input tokens | Output tokens | Input bytes | Cost | Finding contributions |",
+                "|---|---:|---:|---:|---:|---:|---:|---:|",
+            ]
+        )
+        for row in production["by_model"]:
+            lines.append(
+                "| {model} | {attempts} | {duration_seconds:.1f}s | {input_tokens:.0f} | {output_tokens:.0f} | {input_bytes:.0f} | ${measured_cost_usd:.4f} | {finding_contributions} |".format(**row)
+            )
+    else:
+        lines.append("No model-attributed lane usage is available.")
+
+    lines.extend(["", "## Production economics by lane and model", ""])
+    if production["by_lane_model"]:
+        lines.extend(
+            [
+                "| Lane | Model | Attempts | Duration | Input tokens | Output tokens | Input bytes | Cost |",
+                "|---|---|---:|---:|---:|---:|---:|---:|",
+            ]
+        )
+        for row in production["by_lane_model"]:
+            lines.append(
+                "| {lane} | {model} | {attempts} | {duration_seconds:.1f}s | {input_tokens:.0f} | {output_tokens:.0f} | {input_bytes:.0f} | ${measured_cost_usd:.4f} |".format(**row)
+            )
+    else:
+        lines.append("No lane/model-attributed usage is available.")
+
+    quality = production["quality"]
+    lines.extend(
+        [
+            "",
+            "## Production quality signals",
+            "",
+            f"- Canonical findings: {quality['canonical_findings']}",
+            f"- Median completion rate: {quality['median_completion_rate']}",
+            f"- Median fallback rate: {quality['median_fallback_rate']}",
+            f"- Median first-pass validation rate: {quality['median_validation_first_pass_rate']}",
+            f"- Retry reasons: `{json.dumps(quality['retry_reasons'], sort_keys=True)}`",
+            "",
+            "These are workflow signals, not direct causal model-quality scores. Missing model attribution remains missing.",
+            "",
+            "## Controlled benchmarks",
+            "",
+        ]
+    )
+    if benchmark["groups"]:
+        lines.extend(
+            [
+                "| Model | Transport | Case | Success | Median quality | Median duration | Median cost |",
+                "|---|---|---|---:|---:|---:|---:|",
+            ]
+        )
+        for group in benchmark["groups"]:
+            cost = "n/a" if group["median_cost_usd"] is None else f"${group['median_cost_usd']:.4f}"
+            lines.append(
+                f"| {group['model']} | {group['transport']} | {group['case_id']} | {group['parsed_successes']}/{group['attempts']} | {group['median_quality_score']} | {group['median_duration_seconds']}s | {cost} |"
+            )
+    else:
+        lines.append("No benchmark results were found.")
+    lines.extend(
+        [
+            "",
+            "## Interpretation limits",
+            "",
+            "- Token counts and deterministic input bytes are different units and are never added together.",
+            "- Subscription API-equivalent cost is opportunity-cost evidence, not billed spend.",
+            "- A model-role change requires three successful attempts on every applicable local case plus production evidence; incomplete coverage cannot promote a model.",
+            "- Exact identity remains in private receipts; this report publishes aggregates only.",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def report_command(args: argparse.Namespace) -> int:
+    roots = [Path(item).resolve() for item in args.run_root] if args.run_root else list(DEFAULT_RUN_ROOTS)
+    benchmark_root = Path(args.benchmark_root).resolve() if args.benchmark_root else None
+    report = {
+        "schema_version": 1,
+        "generated_at": parse_observed_at(args.observed_at).isoformat(timespec="seconds"),
+        "repository": str(REPO_ROOT),
+        "run_roots": [str(root) for root in roots],
+        "production": production_rollup(roots),
+        "benchmarks": benchmark_rollup(benchmark_root),
+    }
+    if args.json_output:
+        write_atomic(Path(args.json_output).resolve(), pretty_json(report))
+    if args.markdown_output:
+        write_atomic(Path(args.markdown_output).resolve(), render_report(report))
+    print(pretty_json(report), end="")
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    catalog = subparsers.add_parser("catalog-refresh", help="compare a live catalog snapshot with the matrix")
+    catalog.add_argument("--catalog", required=True)
+    catalog.add_argument("--matrix", default=str(DEFAULT_MATRIX))
+    catalog.add_argument("--observed-at")
+    catalog.add_argument("--candidate-limit", type=int, default=20)
+    catalog.add_argument("--output")
+    catalog.add_argument("--write", action="store_true", help="refresh existing matrix entries when material changes exist")
+    catalog.set_defaults(func=catalog_refresh)
+
+    report = subparsers.add_parser("report", help="aggregate production and benchmark evidence")
+    report.add_argument("--run-root", action="append", default=[])
+    report.add_argument("--benchmark-root")
+    report.add_argument("--observed-at")
+    report.add_argument("--json-output")
+    report.add_argument("--markdown-output")
+    report.set_defaults(func=report_command)
+    return parser
+
+
+def main() -> int:
+    try:
+        args = build_parser().parse_args()
+        return int(args.func(args))
+    except IntelligenceError as exc:
+        print(f"model-intelligence: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/run-native-depot-role-benchmark.sh
+++ b/tools/run-native-depot-role-benchmark.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+# Run one depot-role-v1 case against one exact native subscription model.
+# This complements the OpenRouter-owned runner without changing its provider
+# boundary. It retains raw CLI telemetry privately and emits the same scored
+# result shape plus transport/billing provenance.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ROLE_POLICY="$ROOT/plugins/model-router/skills/model-router/references/role-policy.json"
+BENCH="$ROOT/plugins/openrouter/skills/openrouter-delegate/references/depot-role-benchmark.sh"
+CODEX_BIN="${DEPOT_BENCH_CODEX_BIN:-codex}"
+CLAUDE_BIN="${DEPOT_BENCH_CLAUDE_BIN:-claude}"
+
+CASE_ID=""
+MODEL=""
+TRANSPORT=""
+EFFORT="medium"
+RESULT_DIR=""
+
+usage() {
+  printf '%s\n' \
+    'usage: run-native-depot-role-benchmark.sh --case ID --transport codex-cli|claude-cli --model EXACT_ID --effort low|medium|high|max --result-dir PATH'
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --case) CASE_ID="${2:-}"; shift 2 ;;
+    --model) MODEL="${2:-}"; shift 2 ;;
+    --transport) TRANSPORT="${2:-}"; shift 2 ;;
+    --effort) EFFORT="${2:-}"; shift 2 ;;
+    --result-dir) RESULT_DIR="${2:-}"; shift 2 ;;
+    *) usage >&2; exit 2 ;;
+  esac
+done
+
+[ -n "$CASE_ID" ] && [ -n "$MODEL" ] && [ -n "$TRANSPORT" ] && [ -n "$RESULT_DIR" ] || { usage >&2; exit 2; }
+case "$TRANSPORT" in codex-cli|claude-cli) ;; *) usage >&2; exit 2 ;; esac
+case "$EFFORT" in low|medium|high|max) ;; *) usage >&2; exit 2 ;; esac
+[ -x "$BENCH" ] || { printf 'native benchmark: OpenRouter scorer unavailable\n' >&2; exit 2; }
+jq -e --arg model "$MODEL" --arg transport "$TRANSPORT" '
+  any(.roles[][]; .model == $model and .transport == $transport)
+' "$ROLE_POLICY" >/dev/null || {
+  printf 'native benchmark: exact model/transport pair must be admitted by role-policy.json\n' >&2
+  exit 2
+}
+
+mkdir -p "$RESULT_DIR"
+chmod 700 "$RESULT_DIR"
+RESULT_DIR="$(cd "$RESULT_DIR" && pwd)"
+PROMPT="$RESULT_DIR/prompt.txt"
+OUTPUT="$RESULT_DIR/output.json"
+RECEIPT="$RESULT_DIR/receipt.json"
+RESULT="$RESULT_DIR/result.json"
+RAW="$RESULT_DIR/native-events.json"
+STDERR_FILE="$RESULT_DIR/native-stderr.txt"
+
+"$BENCH" --prepare --case "$CASE_ID" --output-file "$PROMPT"
+start="$(date +%s)"
+status=0
+
+if [ "$TRANSPORT" = codex-cli ]; then
+  set +e
+  (
+    cd "$RESULT_DIR"
+    "$CODEX_BIN" exec --ephemeral --ignore-user-config --skip-git-repo-check \
+      --sandbox read-only --model "$MODEL" \
+      --config "model_reasoning_effort=\"$EFFORT\"" \
+      --json --output-last-message "$OUTPUT" - < "$PROMPT"
+  ) > "$RAW" 2> "$STDERR_FILE"
+  status=$?
+  set -e
+  [ -f "$OUTPUT" ] || : > "$OUTPUT"
+  usage_json="$(jq -sc '
+    [.. | objects | select(
+      has("input_tokens") or has("output_tokens") or has("reasoning_tokens") or
+      has("input_usage_count") or has("output_usage_count")
+    )] | last // {}
+    | {
+        prompt_tokens:(.input_tokens // .input_usage_count // null),
+        completion_tokens:(.output_tokens // .output_usage_count // null),
+        reasoning_tokens:(.reasoning_tokens // .reasoning_usage_count // null),
+        cache_read_tokens:(.cached_input_tokens // .cache_read_usage_count // null),
+        cost:null
+      }
+  ' "$RAW" 2>/dev/null || printf '{}')"
+  provider=openai
+  response_model="$(jq -sr --arg fallback "$MODEL" '
+    [.. | objects | .model? | select(type == "string" and length > 0)] | last // $fallback
+  ' "$RAW" 2>/dev/null || printf '%s' "$MODEL")"
+else
+  set +e
+  (
+    cd "$RESULT_DIR"
+    "$CLAUDE_BIN" --print --model "$MODEL" --effort "$EFFORT" --tools "" \
+      --no-session-persistence --output-format json < "$PROMPT"
+  ) > "$RAW" 2> "$STDERR_FILE"
+  status=$?
+  set -e
+  if jq -e '.structured_output | type == "object"' "$RAW" >/dev/null 2>&1; then
+    jq '.structured_output' "$RAW" > "$OUTPUT"
+  elif jq -e '.result | type == "string"' "$RAW" >/dev/null 2>&1; then
+    jq -r '.result' "$RAW" > "$OUTPUT"
+  else
+    : > "$OUTPUT"
+  fi
+  usage_json="$(jq -c '
+    (.usage // {}) as $usage
+    | {
+        prompt_tokens:($usage.input_tokens // null),
+        completion_tokens:($usage.output_tokens // null),
+        reasoning_tokens:($usage.reasoning_tokens // null),
+        cache_read_tokens:($usage.cache_read_input_tokens // null),
+        cache_creation_tokens:($usage.cache_creation_input_tokens // null),
+        cost:null
+      }
+  ' "$RAW" 2>/dev/null || printf '{}')"
+  provider=anthropic
+  response_model="$(jq -r --arg fallback "$MODEL" '
+    if (.model // null | type) == "string" then .model
+    elif (.modelUsage // null | type) == "object" and (.modelUsage | length) > 0 then (.modelUsage | keys[0])
+    else $fallback end
+  ' "$RAW" 2>/dev/null || printf '%s' "$MODEL")"
+fi
+
+end="$(date +%s)"
+duration="$((end-start))"
+outcome=success
+[ "$status" -eq 0 ] || outcome=failed
+jq -n \
+  --arg requested "$MODEL" --arg response "$response_model" --arg provider "$provider" \
+  --arg transport "$TRANSPORT" --arg billing included-subscription \
+  --arg effort "$EFFORT" --arg outcome "$outcome" --argjson usage "$usage_json" \
+  '{schemaVersion:1,requestedModel:$requested,responseModel:$response,
+    servingProvider:$provider,transport:$transport,billingMode:$billing,
+    effort:$effort,outcome:$outcome,usage:$usage,fallbackUsed:false,
+    tokenProvenance:(if (($usage.prompt_tokens // null) == null and ($usage.completion_tokens // null) == null)
+      then "native-cli-unavailable" else "native-cli" end),
+    costProvenance:"subscription-not-billed"}' > "$RECEIPT"
+
+"$BENCH" --score --case "$CASE_ID" --output-file "$OUTPUT" \
+  --receipt-file "$RECEIPT" --result-file "$RESULT" --duration-seconds "$duration"
+jq --arg transport "$TRANSPORT" --arg billing included-subscription \
+  --arg effort "$EFFORT" --arg outcome "$outcome" \
+  '. + {transport:$transport,billingMode:$billing,effort:$effort,outcome:$outcome}' \
+  "$RESULT" > "$RESULT.tmp"
+mv "$RESULT.tmp" "$RESULT"
+cat "$RESULT"
+exit "$status"


### PR DESCRIPTION
## Summary
- add executable daily and weekly model-intelligence prompts with exact commands and artifact paths
- add deterministic catalog refresh and combined production-plus-benchmark reporting
- add native Codex and Claude subscription benchmark parity with a weekly OpenRouter budget gate

## Validation
- python tests/test_model_intelligence.py -v
- tools/test-openrouter-role-benchmark.sh
- tools/validate-workflow-kernel.py
- tools/validate-composition.sh --all
- git diff --cached --check

## Safety
Created and validated in an isolated worktree so the concurrent process on the shared checkout was not touched.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Design-Machines-Studio/codesmith/depot/pr/93"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790296475&installation_model_id=428410&pr_number=93&repository=Design-Machines-Studio%2Fdepot&return_to=https%3A%2F%2Fgithub.com%2FDesign-Machines-Studio%2Fdepot%2Fpull%2F93&signature=dc7a742fb4c3df69dc24e9a257edc24db4d1da54d082c75888535fa5cd1e029d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->