### PR TITLE
chore(models): daily pulse 2026-08-26

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -456,7 +456,7 @@
     {
       "name": "openrouter",
       "source": "./plugins/openrouter",
-      "version": "1.19.0",
+      "version": "1.19.1",
       "author": {
         "name": "Design Machines",
         "url": "https://designmachines.studio"

--- a/docs/model-intelligence/daily/2026-08-26.json
+++ b/docs/model-intelligence/daily/2026-08-26.json
@@ -1,0 +1,155 @@
+{
+  "benchmarks": {
+    "attempts": 0,
+    "groups": [],
+    "incomplete_attempts": [],
+    "measured_cost_usd": 0.0,
+    "result_root": "/home/ned/benchmark-results/depot-role-v1"
+  },
+  "generated_at": "2026-08-26T08:39:02+08:00",
+  "production": {
+    "artifact_paths": {
+      "metrics": [
+        "/home/ned/ai/depot/plans/r0-measurement-backbone/metrics.json",
+        "/home/ned/ai/depot/plans/r1-review-burn-cuts/metrics.json",
+        "/home/ned/ai/depot/plans/r1-review-burn-cuts/prior-blocked-run/metrics.json"
+      ],
+      "run_cost_summaries": [
+        "/home/ned/ai/depot/plans/r0-measurement-backbone/run-cost-summary.json",
+        "/home/ned/ai/depot/plans/r1-review-burn-cuts/prior-blocked-run/run-cost-summary.json",
+        "/home/ned/ai/depot/plans/r1-review-burn-cuts/run-cost-summary.json"
+      ]
+    },
+    "by_lane_model": [
+      {
+        "attempts": 1,
+        "duration_seconds": 431.0,
+        "estimated_attempts": 0,
+        "input_bytes": 0.0,
+        "input_tokens": 24410.0,
+        "lane": "01-openrouter-usage-translator",
+        "measured_cost_attempts": 1,
+        "measured_cost_usd": 0.6670722,
+        "model": "moonshotai/kimi-k3",
+        "output_tokens": 39601.0,
+        "reasoning_tokens": 34999.0
+      },
+      {
+        "attempts": 1,
+        "duration_seconds": 400.0,
+        "estimated_attempts": 0,
+        "input_bytes": 0.0,
+        "input_tokens": 16158.0,
+        "lane": "02-lane-input-bytes",
+        "measured_cost_attempts": 1,
+        "measured_cost_usd": 0.6608562,
+        "model": "moonshotai/kimi-k3",
+        "output_tokens": 40837.0,
+        "reasoning_tokens": 35155.0
+      },
+      {
+        "attempts": 1,
+        "duration_seconds": 300.0,
+        "estimated_attempts": 0,
+        "input_bytes": 0.0,
+        "input_tokens": 20394.0,
+        "lane": "03-emission-contract-and-baselines",
+        "measured_cost_attempts": 1,
+        "measured_cost_usd": 0.1614712,
+        "model": "z-ai/glm-5.2",
+        "output_tokens": 30209.0,
+        "reasoning_tokens": 24272.0
+      },
+      {
+        "attempts": 1,
+        "duration_seconds": 3600.0,
+        "estimated_attempts": 0,
+        "input_bytes": 0.0,
+        "input_tokens": 52660.0,
+        "lane": "adversary-r1",
+        "measured_cost_attempts": 1,
+        "measured_cost_usd": 0.6914922,
+        "model": "moonshotai/kimi-k3",
+        "output_tokens": 35579.0,
+        "reasoning_tokens": 32395.0
+      },
+      {
+        "attempts": 1,
+        "duration_seconds": 900.0,
+        "estimated_attempts": 0,
+        "input_bytes": 0.0,
+        "input_tokens": 63769.0,
+        "lane": "adversary-r2",
+        "measured_cost_attempts": 1,
+        "measured_cost_usd": 0.8151192,
+        "model": "moonshotai/kimi-k3",
+        "output_tokens": 41599.0,
+        "reasoning_tokens": 41182.0
+      }
+    ],
+    "by_model": [
+      {
+        "attempts": 4,
+        "duration_seconds": 5331.0,
+        "estimated_attempts": 0,
+        "finding_contributions": 0,
+        "input_bytes": 0.0,
+        "input_tokens": 156997.0,
+        "measured_cost_attempts": 4,
+        "measured_cost_usd": 2.8345398,
+        "measurement_sources": {
+          "openrouter_api_receipt": 4
+        },
+        "model": "moonshotai/kimi-k3",
+        "output_tokens": 157616.0,
+        "reasoning_tokens": 143731.0
+      },
+      {
+        "attempts": 1,
+        "duration_seconds": 300.0,
+        "estimated_attempts": 0,
+        "finding_contributions": 0,
+        "input_bytes": 0.0,
+        "input_tokens": 20394.0,
+        "measured_cost_attempts": 1,
+        "measured_cost_usd": 0.1614712,
+        "measurement_sources": {
+          "openrouter_api_receipt": 1
+        },
+        "model": "z-ai/glm-5.2",
+        "output_tokens": 30209.0,
+        "reasoning_tokens": 24272.0
+      }
+    ],
+    "cost_summary_artifacts": 3,
+    "empty_cost_summaries": 2,
+    "malformed_artifacts": [],
+    "metrics_artifacts": 3,
+    "quality": {
+      "canonical_findings": 0,
+      "finding_contributions_by_model": {},
+      "finding_contributions_by_provider": {},
+      "median_completion_rate": 1.0,
+      "median_fallback_rate": 0.1,
+      "median_validation_first_pass_rate": 0.0,
+      "model_attempt_counts_from_metrics": {
+        "moonshotai/kimi-k3": 4,
+        "z-ai/glm-5.2": 1
+      },
+      "provider_attempt_counts_from_metrics": {
+        "Friendli": 1,
+        "Modal": 4
+      },
+      "retry_reasons": {
+        "cascade_exhausted": 1,
+        "codex_usage_cap": 5
+      }
+    }
+  },
+  "repository": "/home/ned/ai/depot-daily-pulse-2026-08-26-0835",
+  "run_roots": [
+    "/home/ned/ai/depot/plans",
+    "/home/ned/ai/depot/.workflow-kernel/runs"
+  ],
+  "schema_version": 1
+}

--- a/docs/model-intelligence/daily/2026-08-26.md
+++ b/docs/model-intelligence/daily/2026-08-26.md
@@ -1,0 +1,47 @@
+# Depot model intelligence — 2026-08-26
+
+## Evidence coverage
+
+- Run cost summaries: 3
+- Workflow metrics: 3
+- Empty cost summaries: 2
+- Benchmark attempts: 0
+- Incomplete benchmark attempts: 0
+
+## Production economics by model
+
+| Model | Attempts | Duration | Input tokens | Output tokens | Input bytes | Cost | Finding contributions |
+|---|---:|---:|---:|---:|---:|---:|---:|
+| moonshotai/kimi-k3 | 4 | 5331.0s | 156997 | 157616 | 0 | $2.8345 | 0 |
+| z-ai/glm-5.2 | 1 | 300.0s | 20394 | 30209 | 0 | $0.1615 | 0 |
+
+## Production economics by lane and model
+
+| Lane | Model | Attempts | Duration | Input tokens | Output tokens | Input bytes | Cost |
+|---|---|---:|---:|---:|---:|---:|---:|
+| 01-openrouter-usage-translator | moonshotai/kimi-k3 | 1 | 431.0s | 24410 | 39601 | 0 | $0.6671 |
+| 02-lane-input-bytes | moonshotai/kimi-k3 | 1 | 400.0s | 16158 | 40837 | 0 | $0.6609 |
+| 03-emission-contract-and-baselines | z-ai/glm-5.2 | 1 | 300.0s | 20394 | 30209 | 0 | $0.1615 |
+| adversary-r1 | moonshotai/kimi-k3 | 1 | 3600.0s | 52660 | 35579 | 0 | $0.6915 |
+| adversary-r2 | moonshotai/kimi-k3 | 1 | 900.0s | 63769 | 41599 | 0 | $0.8151 |
+
+## Production quality signals
+
+- Canonical findings: 0
+- Median completion rate: 1.0
+- Median fallback rate: 0.1
+- Median first-pass validation rate: 0.0
+- Retry reasons: `{"cascade_exhausted": 1, "codex_usage_cap": 5}`
+
+These are workflow signals, not direct causal model-quality scores. Missing model attribution remains missing.
+
+## Controlled benchmarks
+
+No benchmark results were found.
+
+## Interpretation limits
+
+- Token counts and deterministic input bytes are different units and are never added together.
+- Subscription API-equivalent cost is opportunity-cost evidence, not billed spend.
+- A model-role change requires three successful attempts on every applicable local case plus production evidence; incomplete coverage cannot promote a model.
+- Exact identity remains in private receipts; this report publishes aggregates only.

--- a/docs/model-intelligence/latest.json
+++ b/docs/model-intelligence/latest.json
@@ -1,0 +1,155 @@
+{
+  "benchmarks": {
+    "attempts": 0,
+    "groups": [],
+    "incomplete_attempts": [],
+    "measured_cost_usd": 0.0,
+    "result_root": "/home/ned/benchmark-results/depot-role-v1"
+  },
+  "generated_at": "2026-08-26T08:39:02+08:00",
+  "production": {
+    "artifact_paths": {
+      "metrics": [
+        "/home/ned/ai/depot/plans/r0-measurement-backbone/metrics.json",
+        "/home/ned/ai/depot/plans/r1-review-burn-cuts/metrics.json",
+        "/home/ned/ai/depot/plans/r1-review-burn-cuts/prior-blocked-run/metrics.json"
+      ],
+      "run_cost_summaries": [
+        "/home/ned/ai/depot/plans/r0-measurement-backbone/run-cost-summary.json",
+        "/home/ned/ai/depot/plans/r1-review-burn-cuts/prior-blocked-run/run-cost-summary.json",
+        "/home/ned/ai/depot/plans/r1-review-burn-cuts/run-cost-summary.json"
+      ]
+    },
+    "by_lane_model": [
+      {
+        "attempts": 1,
+        "duration_seconds": 431.0,
+        "estimated_attempts": 0,
+        "input_bytes": 0.0,
+        "input_tokens": 24410.0,
+        "lane": "01-openrouter-usage-translator",
+        "measured_cost_attempts": 1,
+        "measured_cost_usd": 0.6670722,
+        "model": "moonshotai/kimi-k3",
+        "output_tokens": 39601.0,
+        "reasoning_tokens": 34999.0
+      },
+      {
+        "attempts": 1,
+        "duration_seconds": 400.0,
+        "estimated_attempts": 0,
+        "input_bytes": 0.0,
+        "input_tokens": 16158.0,
+        "lane": "02-lane-input-bytes",
+        "measured_cost_attempts": 1,
+        "measured_cost_usd": 0.6608562,
+        "model": "moonshotai/kimi-k3",
+        "output_tokens": 40837.0,
+        "reasoning_tokens": 35155.0
+      },
+      {
+        "attempts": 1,
+        "duration_seconds": 300.0,
+        "estimated_attempts": 0,
+        "input_bytes": 0.0,
+        "input_tokens": 20394.0,
+        "lane": "03-emission-contract-and-baselines",
+        "measured_cost_attempts": 1,
+        "measured_cost_usd": 0.1614712,
+        "model": "z-ai/glm-5.2",
+        "output_tokens": 30209.0,
+        "reasoning_tokens": 24272.0
+      },
+      {
+        "attempts": 1,
+        "duration_seconds": 3600.0,
+        "estimated_attempts": 0,
+        "input_bytes": 0.0,
+        "input_tokens": 52660.0,
+        "lane": "adversary-r1",
+        "measured_cost_attempts": 1,
+        "measured_cost_usd": 0.6914922,
+        "model": "moonshotai/kimi-k3",
+        "output_tokens": 35579.0,
+        "reasoning_tokens": 32395.0
+      },
+      {
+        "attempts": 1,
+        "duration_seconds": 900.0,
+        "estimated_attempts": 0,
+        "input_bytes": 0.0,
+        "input_tokens": 63769.0,
+        "lane": "adversary-r2",
+        "measured_cost_attempts": 1,
+        "measured_cost_usd": 0.8151192,
+        "model": "moonshotai/kimi-k3",
+        "output_tokens": 41599.0,
+        "reasoning_tokens": 41182.0
+      }
+    ],
+    "by_model": [
+      {
+        "attempts": 4,
+        "duration_seconds": 5331.0,
+        "estimated_attempts": 0,
+        "finding_contributions": 0,
+        "input_bytes": 0.0,
+        "input_tokens": 156997.0,
+        "measured_cost_attempts": 4,
+        "measured_cost_usd": 2.8345398,
+        "measurement_sources": {
+          "openrouter_api_receipt": 4
+        },
+        "model": "moonshotai/kimi-k3",
+        "output_tokens": 157616.0,
+        "reasoning_tokens": 143731.0
+      },
+      {
+        "attempts": 1,
+        "duration_seconds": 300.0,
+        "estimated_attempts": 0,
+        "finding_contributions": 0,
+        "input_bytes": 0.0,
+        "input_tokens": 20394.0,
+        "measured_cost_attempts": 1,
+        "measured_cost_usd": 0.1614712,
+        "measurement_sources": {
+          "openrouter_api_receipt": 1
+        },
+        "model": "z-ai/glm-5.2",
+        "output_tokens": 30209.0,
+        "reasoning_tokens": 24272.0
+      }
+    ],
+    "cost_summary_artifacts": 3,
+    "empty_cost_summaries": 2,
+    "malformed_artifacts": [],
+    "metrics_artifacts": 3,
+    "quality": {
+      "canonical_findings": 0,
+      "finding_contributions_by_model": {},
+      "finding_contributions_by_provider": {},
+      "median_completion_rate": 1.0,
+      "median_fallback_rate": 0.1,
+      "median_validation_first_pass_rate": 0.0,
+      "model_attempt_counts_from_metrics": {
+        "moonshotai/kimi-k3": 4,
+        "z-ai/glm-5.2": 1
+      },
+      "provider_attempt_counts_from_metrics": {
+        "Friendli": 1,
+        "Modal": 4
+      },
+      "retry_reasons": {
+        "cascade_exhausted": 1,
+        "codex_usage_cap": 5
+      }
+    }
+  },
+  "repository": "/home/ned/ai/depot-daily-pulse-2026-08-26-0835",
+  "run_roots": [
+    "/home/ned/ai/depot/plans",
+    "/home/ned/ai/depot/.workflow-kernel/runs"
+  ],
+  "schema_version": 1
+}

--- a/docs/model-intelligence/latest.md
+++ b/docs/model-intelligence/latest.md
@@ -1,0 +1,47 @@
+# Depot model intelligence — 2026-08-26
+
+## Evidence coverage
+
+- Run cost summaries: 3
+- Workflow metrics: 3
+- Empty cost summaries: 2
+- Benchmark attempts: 0
+- Incomplete benchmark attempts: 0
+
+## Production economics by model
+
+| Model | Attempts | Duration | Input tokens | Output tokens | Input bytes | Cost | Finding contributions |
+|---|---:|---:|---:|---:|---:|---:|---:|
+| moonshotai/kimi-k3 | 4 | 5331.0s | 156997 | 157616 | 0 | $2.8345 | 0 |
+| z-ai/glm-5.2 | 1 | 300.0s | 20394 | 30209 | 0 | $0.1615 | 0 |
+
+## Production economics by lane and model
+
+| Lane | Model | Attempts | Duration | Input tokens | Output tokens | Input bytes | Cost |
+|---|---|---:|---:|---:|---:|---:|---:|
+| 01-openrouter-usage-translator | moonshotai/kimi-k3 | 1 | 431.0s | 24410 | 39601 | 0 | $0.6671 |
+| 02-lane-input-bytes | moonshotai/kimi-k3 | 1 | 400.0s | 16158 | 40837 | 0 | $0.6609 |
+| 03-emission-contract-and-baselines | z-ai/glm-5.2 | 1 | 300.0s | 20394 | 30209 | 0 | $0.1615 |
+| adversary-r1 | moonshotai/kimi-k3 | 1 | 3600.0s | 52660 | 35579 | 0 | $0.6915 |
+| adversary-r2 | moonshotai/kimi-k3 | 1 | 900.0s | 63769 | 41599 | 0 | $0.8151 |
+
+## Production quality signals
+
+- Canonical findings: 0
+- Median completion rate: 1.0
+- Median fallback rate: 0.1
+- Median first-pass validation rate: 0.0
+- Retry reasons: `{"cascade_exhausted": 1, "codex_usage_cap": 5}`
+
+These are workflow signals, not direct causal model-quality scores. Missing model attribution remains missing.
+
+## Controlled benchmarks
+
+No benchmark results were found.
+
+## Interpretation limits
+
+- Token counts and deterministic input bytes are different units and are never added together.
+- Subscription API-equivalent cost is opportunity-cost evidence, not billed spend.
+- A model-role change requires three successful attempts on every applicable local case plus production evidence; incomplete coverage cannot promote a model.
+- Exact identity remains in private receipts; this report publishes aggregates only.

--- a/docs/openrouter-model-matrix-refreshes/2026-08-26.md
+++ b/docs/openrouter-model-matrix-refreshes/2026-08-26.md
@@ -1,0 +1,47 @@
+# OpenRouter model matrix refresh — 2026-08-26
+
+This is the compact catalog evidence receipt for the 2026-08-26 daily model
+pulse. No paid model inference or live canary was run, and no role-policy
+change occurred.
+
+## Catalog receipt
+
+- Source: `https://openrouter.ai/api/v1/models`
+- Observed: `2026-08-26T08:39:02+08:00`
+- Expires: `2026-08-26T08:54:02+08:00`
+- Models observed: 417
+- SHA-256: `94200dc1cbef54a3818614334b49abaf17877e8c24c52ab8042e32adec177b91`
+
+Every existing matrix slug remained present. The catalog reported these
+changes to existing exact entries:
+
+- `deepseek/deepseek-v4-flash-0731`: provider output limit 131,072 to
+  943,718; input/output/cache-read prices $0.14/$0.28/$0.028 to
+  $0.04/$0.08/$0.008 per million tokens.
+- `deepseek/deepseek-v4-pro-0813`: provider output limit became available at
+  943,717.
+- `qwen/qwen3.8-27b`: provider context 262,144 to 1,000,000; input/output/
+  cache-read prices $0.40/$3/$0.05 to $0.425/$2.55/$0.085 per million; cache
+  write became available at $0.53125 per million.
+- `x-ai/grok-4.6`: provider output limit became available at 450,000; `stop`
+  and `top_k` joined its supported parameters.
+- `meta/muse-spark-1.2`: provider output limit became available at 943,718.
+- `moonshotai/kimi-k3`: provider output limit 1,048,576 to 943,718.
+
+## Candidate and evidence status
+
+The catalog tool nominated no new candidates, and no model was added or
+promoted. Vendor-release and benchmark evidence was not refreshed by this
+catalog-only run, so comparative quality claims remain at their prior
+provenance. The independent native API-equivalent cost snapshot remains dated
+2026-08-12 and was not restamped.
+
+## Routing decision
+
+No role-policy change was made. DeepSeek Flash remains the cheap bounded
+execution and routine-review preference, DeepSeek Pro remains an evaluation
+candidate for long-context analysis, Kimi K3 remains security-review only,
+and GLM retains no default seat. Qwen and Grok changes remain factual matrix
+evidence rather than promotion evidence.
+
+## Source

--- a/plugins/openrouter/.claude-plugin/plugin.json
+++ b/plugins/openrouter/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "openrouter",
   "description": "OpenRouter provider with sensitive-payload refusal, routed DeepSeek/Qwen/Grok/Kimi/Luna workflows, and MCP controls.",
-  "version": "1.19.0",
+  "version": "1.19.1",
   "author": {
     "name": "Design Machines",
     "url": "https://designmachines.studio"

--- a/plugins/openrouter/.codex-plugin/plugin.json
+++ b/plugins/openrouter/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "openrouter",
-  "version": "1.19.0",
+  "version": "1.19.1",
   "description": "OpenRouter provider with sensitive-payload refusal, routed DeepSeek/Qwen/Grok/Kimi/Luna workflows, and MCP controls.",
   "author": {
     "name": "Design Machines",

--- a/plugins/openrouter/skills/openrouter-delegate/references/model-matrix.json
+++ b/plugins/openrouter/skills/openrouter-delegate/references/model-matrix.json
@@ -1,10 +1,10 @@
 {
   "_comment": "CANONICAL machine-readable OpenRouter model matrix. This file records current provider catalog, pricing, feature, and compatibility evidence; model-router's private role-policy.json is the cross-transport routing authority. Native Codex identities and native Claude aliases are absent from OpenRouter catalog models. native_api_equivalent_cost is observation-only pricing evidence and never routing authority. anthropic/* routing slugs are rejected before provider contact.",
   "schema_version": 1,
-  "snapshot_date": "2026-08-25",
-  "catalog_observed_at": "2026-08-25T09:09:40+08:00",
+  "snapshot_date": "2026-08-26",
+  "catalog_observed_at": "2026-08-26T08:39:02+08:00",
   "catalog_source": "https://openrouter.ai/api/v1/models",
-  "catalog_snapshot_sha256": "73ee416b957d30dcefc08917b3452b619e2d7e317a262e2e508240c3f9bef4f5",
+  "catalog_snapshot_sha256": "94200dc1cbef54a3818614334b49abaf17877e8c24c52ab8042e32adec177b91",
   "native_api_equivalent_cost": {
     "schema_version": 1,
     "snapshot_date": "2026-08-12",
@@ -112,12 +112,12 @@
       "catalog_name": "DeepSeek: DeepSeek V4 Flash 0731",
       "catalog_status": "available",
       "recommendation_status": "candidate-bounded-execution-evidence",
-      "input_usd_per_m": 0.14,
-      "output_usd_per_m": 0.28,
-      "cache_read_usd_per_m": 0.028,
+      "input_usd_per_m": 0.04,
+      "output_usd_per_m": 0.08,
+      "cache_read_usd_per_m": 0.008,
       "context_tokens": 1310720,
       "top_provider_context_tokens": 1048576,
-      "top_provider_max_completion_tokens": 131072,
+      "top_provider_max_completion_tokens": 943718,
       "per_request_limits": null,
       "input_modalities": [
         "text"
@@ -153,7 +153,7 @@
       },
       "local_evidence": "2026-08-17 canary reached OpenRouter once and failed with HTTP 429 before output; this does not disprove the executor contract.",
       "role": "Catalog evidence supports low-cost bounded text, tool, reasoning, and structured-output work; model-router decides consumers and order.",
-      "snapshot_date": "2026-08-25",
+      "snapshot_date": "2026-08-26",
       "sources": [
         "https://openrouter.ai/deepseek/deepseek-v4-flash-0731",
         "https://api-docs.deepseek.com/news/news260424/",
@@ -214,7 +214,7 @@
       "cache_read_usd_per_m": 0.0374,
       "context_tokens": 1048576,
       "top_provider_context_tokens": 1048575,
-      "top_provider_max_completion_tokens": null,
+      "top_provider_max_completion_tokens": 943717,
       "per_request_limits": null,
       "pricing_overrides": null,
       "input_modalities": [
@@ -233,7 +233,7 @@
       },
       "local_evidence": "2026-08-17 canary produced a valid seven-line minimal unified diff in 7 seconds; 125 prompt, 709 completion, 661 reasoning tokens; $0.00297264.",
       "role": "Catalog evidence supports long-context reasoning, tools, and structured output; exact-variant benchmark evidence remains provisional.",
-      "snapshot_date": "2026-08-25",
+      "snapshot_date": "2026-08-26",
       "sources": [
         "https://openrouter.ai/deepseek/deepseek-v4-pro-0813",
         "https://api-docs.deepseek.com/news/news260424/"
@@ -313,7 +313,7 @@
       },
       "local_evidence": "2026-08-17 canary found the seeded arithmetic defect in the required one-line format in 5 seconds; 203 prompt, 174 completion, 138 reasoning tokens; $0.00145.",
       "role": "Catalog evidence supports long-context independent analysis, tools, and structured output when resolver family constraints permit.",
-      "snapshot_date": "2026-08-25",
+      "snapshot_date": "2026-08-26",
       "sources": [
         "https://openrouter.ai/qwen/qwen3.8-max",
         "https://qwenlm.github.io/qwen-code-docs/en/blog/updates/weekly-update-2026-07-23/"
@@ -382,7 +382,7 @@
       "benchmark_evidence": null,
       "local_evidence": "No local call authorized for this refresh.",
       "role": "Catalog evidence only; model-router policy owns any active use.",
-      "snapshot_date": "2026-08-25",
+      "snapshot_date": "2026-08-26",
       "sources": [
         "https://openrouter.ai/qwen/qwen3.8-2.4t-a95b"
       ],
@@ -438,11 +438,11 @@
       "catalog_name": "Qwen: Qwen3.8 27B",
       "catalog_status": "available",
       "recommendation_status": "catalogued-not-routed",
-      "input_usd_per_m": 0.4,
-      "output_usd_per_m": 3,
-      "cache_read_usd_per_m": 0.05,
+      "input_usd_per_m": 0.425,
+      "output_usd_per_m": 2.55,
+      "cache_read_usd_per_m": 0.085,
       "context_tokens": 1000000,
-      "top_provider_context_tokens": 262144,
+      "top_provider_context_tokens": 1000000,
       "top_provider_max_completion_tokens": 131072,
       "per_request_limits": null,
       "input_modalities": [
@@ -458,12 +458,12 @@
       "benchmark_evidence": null,
       "local_evidence": "No local call authorized for this refresh.",
       "role": "Catalogued compact evidence; context and feature fields do not imply an active resolver assignment.",
-      "snapshot_date": "2026-08-25",
+      "snapshot_date": "2026-08-26",
       "sources": [
         "https://openrouter.ai/qwen/qwen3.8-27b"
       ],
       "canonical_slug": "qwen/qwen3.8-27b-20260814",
-      "cache_write_usd_per_m": null,
+      "cache_write_usd_per_m": 0.53125,
       "web_search_usd_per_request": null,
       "top_provider_is_moderated": false,
       "pricing_overrides": null,
@@ -551,7 +551,7 @@
       "benchmark_evidence": null,
       "local_evidence": "No local call authorized for this refresh.",
       "role": "Catalogued economical evidence; the incomplete parameter contract does not establish resolver eligibility.",
-      "snapshot_date": "2026-08-25",
+      "snapshot_date": "2026-08-26",
       "sources": [
         "https://openrouter.ai/qwen/qwen3.7-flash"
       ],
@@ -601,7 +601,7 @@
       "web_search_usd_per_request": 0.005,
       "context_tokens": 500000,
       "top_provider_context_tokens": 500000,
-      "top_provider_max_completion_tokens": null,
+      "top_provider_max_completion_tokens": 450000,
       "per_request_limits": null,
       "pricing_overrides": [
         {
@@ -629,7 +629,7 @@
       },
       "local_evidence": "2026-08-17 canary found the seeded arithmetic defect in the exact one-line format in 5 seconds; 352 prompt, 295 completion, 274 reasoning tokens; $0.002282.",
       "role": "Catalog evidence supports demanding bounded reasoning, tools, structured output, and a distinct model family.",
-      "snapshot_date": "2026-08-25",
+      "snapshot_date": "2026-08-26",
       "sources": [
         "https://openrouter.ai/x-ai/grok-4.6"
       ],
@@ -647,10 +647,12 @@
         "reasoning_effort",
         "response_format",
         "seed",
+        "stop",
         "structured_outputs",
         "temperature",
         "tool_choice",
         "tools",
+        "top_k",
         "top_logprobs",
         "top_p"
       ],
@@ -712,7 +714,7 @@
       },
       "local_evidence": "No local call authorized for this refresh.",
       "role": "Catalog evidence includes multimodal, tool, structured-output, and priced web-search support; resolver policy owns active use.",
-      "snapshot_date": "2026-08-25",
+      "snapshot_date": "2026-08-26",
       "sources": [
         "https://openrouter.ai/google/gemini-3.7-flash"
       ],
@@ -761,7 +763,7 @@
       "web_search_usd_per_request": 0.0025,
       "context_tokens": 1048576,
       "top_provider_context_tokens": 1048576,
-      "top_provider_max_completion_tokens": null,
+      "top_provider_max_completion_tokens": 943718,
       "per_request_limits": null,
       "input_modalities": [
         "text",
@@ -778,7 +780,7 @@
       "benchmark_evidence": null,
       "local_evidence": "No local call authorized for this refresh.",
       "role": "Catalogued multimodal evidence only; resolver policy owns active use.",
-      "snapshot_date": "2026-08-25",
+      "snapshot_date": "2026-08-26",
       "sources": [
         "https://openrouter.ai/meta/muse-spark-1.2"
       ],
@@ -861,7 +863,7 @@
       },
       "local_evidence": "Prior Depot/Assembly operator evidence found repeated handholding; no call was authorized in this refresh.",
       "role": "Catalog evidence only; no active resolver assignment is established here.",
-      "snapshot_date": "2026-08-25",
+      "snapshot_date": "2026-08-26",
       "sources": [
         "https://openrouter.ai/z-ai/glm-5.2",
         "https://z.ai/blog/glm-5.2"
@@ -926,7 +928,7 @@
       "cache_read_usd_per_m": 0.3,
       "context_tokens": 1048576,
       "top_provider_context_tokens": 1048576,
-      "top_provider_max_completion_tokens": 1048576,
+      "top_provider_max_completion_tokens": 943718,
       "per_request_limits": null,
       "input_modalities": [
         "text",
@@ -957,7 +959,7 @@
       },
       "local_evidence": "Recent Baseplate review: 5 attempts, about $1.334, with useful security evidence but excessive cost for routine review.",
       "role": "Catalog and local evidence support focused security analysis at high cost; resolver policy owns every assignment and exclusion.",
-      "snapshot_date": "2026-08-25",
+      "snapshot_date": "2026-08-26",
       "sources": [
         "https://openrouter.ai/moonshotai/kimi-k3",
         "https://artificialanalysis.ai/models/kimi-k3"
@@ -1054,7 +1056,7 @@
       },
       "local_evidence": "Recent Baseplate review: 5 attempts, about $0.019; economical but no longer primary for all routine reviewers.",
       "role": "Catalog and local evidence support economical mechanical analysis; resolver policy owns candidate order.",
-      "snapshot_date": "2026-08-25",
+      "snapshot_date": "2026-08-26",
       "sources": [
         "https://openrouter.ai/openai/gpt-5.6-luna",
         "https://developers.openai.com/api/docs/models/gpt-5.6-luna"
@@ -1135,7 +1137,7 @@
       "benchmark_evidence": null,
       "local_evidence": "No local call authorized for this refresh.",
       "role": "Catalogued explicit-choice evidence only; resolver policy owns active use.",
-      "snapshot_date": "2026-08-25",
+      "snapshot_date": "2026-08-26",
       "sources": [
         "https://openrouter.ai/openai/gpt-5.6-terra",
         "https://developers.openai.com/api/docs/models/gpt-5.6-terra"
@@ -1249,11 +1251,11 @@
       },
       "local_evidence": "No live canary request was sent because no configured OpenRouter credential was available in this worktree session.",
       "role": "Catalog evidence records mandatory reasoning and default max; it does not establish an active resolver assignment.",
-      "snapshot_date": "2026-08-25",
+      "snapshot_date": "2026-08-26",
       "sources": [
         "https://openrouter.ai/api/v1/models"
       ]
     }
   ],
-  "catalog_snapshot": "/home/ned/.local/state/openrouter-model-pulse/catalog/models-2026-08-21T092022+0800.json"
+  "catalog_snapshot": "/home/ned/.local/state/openrouter-model-pulse/catalog/models-20260826T083902+0800.json"
 }

--- a/plugins/openrouter/skills/openrouter-delegate/references/model-selection.md
+++ b/plugins/openrouter/skills/openrouter-delegate/references/model-selection.md
@@ -10,18 +10,18 @@ engine.
 
 ## Available Models
 
-Prices below are a checked-in planning snapshot from 2026-08-25, in USD per
+Prices below are a checked-in planning snapshot from 2026-08-26, in USD per
 million input/output tokens. The compact refresh receipt is
-`docs/openrouter-model-matrix-refreshes/2026-08-25.md`; use a fresh catalog
+`docs/openrouter-model-matrix-refreshes/2026-08-26.md`; use a fresh catalog
 receipt before a later paid or policy-changing run.
 
 | Exact slug | Input / output | Context | Catalog evidence |
 |---|---:|---:|---|
-| `deepseek/deepseek-v4-flash-0731` | $0.14 / $0.28 | 1,310,720 | Low-cost bounded reasoning/tools/structured output |
+| `deepseek/deepseek-v4-flash-0731` | $0.04 / $0.08 | 1,310,720 | Low-cost bounded reasoning/tools/structured output |
 | `deepseek/deepseek-v4-pro-0813` | $1.122 / $3.366 | 1,048,576 | Provisional long-context reasoning evidence |
 | `qwen/qwen3.8-max` | $2 / $6 | 1,000,000 | Long-context independent analysis evidence |
 | `qwen/qwen3.8-2.4t-a95b` | $2 / $6 | 1,048,576 | Catalogued; no active consumer |
-| `qwen/qwen3.8-27b` | $0.40 / $3 | 1,000,000 | Catalogued; no active consumer |
+| `qwen/qwen3.8-27b` | $0.425 / $2.55 | 1,000,000 | Catalogued; no active consumer |
 | `qwen/qwen3.7-flash` | $0.03 / $0.13 | 1,000,000 | Catalogued; no active consumer |
 | `x-ai/grok-4.6` | $2 / $6 | 500,000 | Demanding bounded reasoning and distinct-family evidence |
 | `google/gemini-3.7-flash` | $0.375 / $1.875 | 1,048,576 | Fast multimodal/tools/web-search evidence |

--- a/tools/validate-routing-economics.sh
+++ b/tools/validate-routing-economics.sh
@@ -43,7 +43,7 @@ check 'tracked policy carries no operator identity or billing preference' sh -c 
   "! grep -Eiq 'travis|jeremy|email|allowPaidClaudeCredits' '$POLICY'"
 
 check 'OpenRouter matrix retains usage and price evidence' jq -e '
-  .snapshot_date == "2026-08-25" and
+  .snapshot_date == "2026-08-26" and
   all(.models[]; (.slug|type)=="string" and (.input_usd_per_m|type)=="number" and (.output_usd_per_m|type)=="number")' "$MATRIX"
 
 check 'OpenRouter wrapper retains content-free receipt fields' sh -c \


### PR DESCRIPTION
## Summary
- refresh existing OpenRouter matrix facts from the 2026-08-26 official catalog snapshot
- publish the first tracked aggregate production model-intelligence baseline
- patch-bump OpenRouter to 1.19.1 and regenerate its Codex manifest

## Evidence
- 417 catalog models observed; 14 existing-entry field changes; no new candidate nominations
- no paid model calls and no model-router role-policy change
- production report keeps measured cost, tokens, bytes, duration, fallback, retry, validation, and finding contribution distinct

## Validation
- rtk python tests/test_model_intelligence.py -v
- rtk ./tools/validate-composition.sh --all
- clean worktree and byte-identical validated tree after rebasing onto current main

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Design-Machines-Studio/codesmith/depot/pr/97"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790315812&installation_model_id=428410&pr_number=97&repository=Design-Machines-Studio%2Fdepot&return_to=https%3A%2F%2Fgithub.com%2FDesign-Machines-Studio%2Fdepot%2Fpull%2F97&signature=dafc1d30ca071d3b502105666968900902ac311fd62759b95a262526de7defc5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->