### PR TITLE
ROUTE-03: Repair Codex 0.147 availability and UI review readiness

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -283,7 +283,7 @@
     {
       "name": "dm-review",
       "source": "./plugins/dm-review",
-      "version": "1.72.0",
+      "version": "1.73.0",
       "author": {
         "name": "Design Machines",
         "url": "https://designmachines.studio"
@@ -388,7 +388,7 @@
     {
       "name": "model-router",
       "source": "./plugins/model-router",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "author": {
         "name": "Design Machines",
         "url": "https://designmachines.studio"

--- a/docs/dependency-graph.md
+++ b/docs/dependency-graph.md
@@ -64,7 +64,7 @@ graph LR
 | dm-review | live-wires | required | `>=1.8.0` |
 | dm-review | ghostwriter | required | `>=3.7.0` |
 | dm-review | council | required | `>=1.5.0` |
-| dm-review | model-router | required | `>=0.2.0` |
+| dm-review | model-router | required | `>=0.3.0` |
 | dm-review | workflow-kernel | required | `>=0.17.0` |
 | dm-review | ned | optional | `>=1.4.0` |
 | dm-review | superpowers | optional | `>=1.0.0` |

--- a/plugins/dm-review/.claude-plugin/plugin.json
+++ b/plugins/dm-review/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dm-review",
   "description": "Code review orchestrator with evidence-backed severity, minimum-adequate repairs, zero-deferral convergence, full security and browser coverage, and stable finding receipts",
-  "version": "1.72.0",
+  "version": "1.73.0",
   "author": {
     "name": "Design Machines",
     "url": "https://designmachines.io"
@@ -11,7 +11,7 @@
     "live-wires": ">=1.8.0",
     "ghostwriter": ">=3.7.0",
     "council": ">=1.5.0",
-    "model-router": ">=0.2.0",
+    "model-router": ">=0.3.0",
     "workflow-kernel": ">=0.17.0"
   },
   "optionalPluginDependencies": {

--- a/plugins/dm-review/.codex-plugin/plugin.json
+++ b/plugins/dm-review/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dm-review",
-  "version": "1.72.0",
+  "version": "1.73.0",
   "description": "Code review orchestrator with evidence-backed severity, minimum-adequate repairs, zero-deferral convergence, full security and browser coverage, and stable finding receipts",
   "author": {
     "name": "Design Machines",
@@ -316,7 +316,7 @@
     "live-wires": ">=1.8.0",
     "ghostwriter": ">=3.7.0",
     "council": ">=1.5.0",
-    "model-router": ">=0.2.0",
+    "model-router": ">=0.3.0",
     "workflow-kernel": ">=0.17.0"
   },
   "optionalPluginDependencies": {

--- a/plugins/dm-review/agents/review/ui-standards-reviewer.md
+++ b/plugins/dm-review/agents/review/ui-standards-reviewer.md
@@ -1,6 +1,6 @@
 ---
 name: ui-standards-reviewer
-description: Evaluates rendered UI against modern best-in-class SaaS standards (Stripe, Notion, Linear, Figma quality). Checks component quality, spacing system compliance, state completeness, visual polish, and token usage. Runs when template or CSS files change and a dev server is detected. Also runs in quick mode for UI files to catch design issues per-chunk during pipeline execution.
+description: Evaluates host-captured rendered UI evidence against modern best-in-class SaaS standards (Stripe, Notion, Linear, Figma quality). Checks component quality, spacing system compliance, state completeness, visual polish, and token usage after the required app/browser readiness gate. Also runs in quick mode for UI files to catch design issues per-chunk during pipeline execution.
 model: inherit
 ---
 
@@ -30,7 +30,17 @@ You complement the ux-quality-reviewer (which evaluates design philosophy and us
 
 ## Precondition
 
-A dev server must be running. `browser_navigate` these in order: `http://localhost:8080` (Go+Templ+Datastar), `http://localhost:3000` (Node/general), `https://[project-name].ddev.site` (Craft CMS DDEV), `http://localhost:5173` (Vite). If none respond, report: "No dev server detected. Start the application and re-run the review."
+The host must supply a `## Host Browser Evidence` section produced only after
+`ui-review-readiness.md` confirmed the repository-declared application and a
+real local interactive browser navigation. It contains bounded screenshots,
+accessibility snapshots, route/viewport IDs, console summaries, interaction
+observations, and computed-style results. Analyze that evidence; do not call or
+search for browser tools. OpenRouter web search and generic `tool-use` are not
+local browser evidence. If the section is absent or incomplete, emit no product
+finding; return `NOT-COVERED: required host browser evidence unavailable`.
+
+Every later `browser_*` instruction names evidence the host must have captured,
+not a tool this participant may invoke.
 
 ## Phase 0: Token Discovery
 

--- a/plugins/dm-review/agents/review/ux-quality-reviewer.md
+++ b/plugins/dm-review/agents/review/ux-quality-reviewer.md
@@ -1,6 +1,6 @@
 ---
 name: ux-quality-reviewer
-description: Reviews rendered pages for UX/UI quality -- information hierarchy, spacing consistency, state completeness, navigation clarity, typography, layout composition, and interaction polish. Runs when template or CSS files change and a dev server is detected. Complements the visual-browser-tester (which checks rendering/responsive/a11y) with a creative director's eye for design quality and usability.
+description: Reviews host-captured rendered-page evidence for UX/UI quality -- information hierarchy, spacing consistency, state completeness, navigation clarity, typography, layout composition, and interaction polish -- after the required app/browser readiness gate. Complements the visual-browser-tester (which checks rendering/responsive/a11y) with a creative director's eye for design quality and usability.
 model: inherit
 ---
 
@@ -40,7 +40,10 @@ Cite BOTH the theoretical principle (Muller-Brockmann, Gerstner, and the rest) A
 
 The dispatch skill injects `## Visual Finding Rules` (spec-primary evaluation, the missing-spec P2 process finding, and the mandatory citation format) plus any `## Design Spec Context`. Follow them; do not restate them.
 
-Your lens on a spec is **design quality**: for each approved decision, capture the element with `browser_take_screenshot` (CSS selector or coordinates) and judge whether the render carries the intended hierarchy, weight, and grouping -- not merely the right class name. Never invent a spec.
+Your lens on a spec is **design quality**: for each approved decision, use the
+host-captured element screenshot and judge whether the render carries the
+intended hierarchy, weight, and grouping -- not merely the right class name.
+Never invent a spec.
 
 ## Live Wires Compliance
 
@@ -48,7 +51,12 @@ All design recommendations MUST use Live Wires vocabulary: `.stack` not "add mar
 
 ## Precondition
 
-A dev server must be running. `browser_navigate` these in order: `http://localhost:8080` (Go+Templ+Datastar), `http://localhost:3000` (Node/general), `https://[project-name].ddev.site` (Craft CMS DDEV), `http://localhost:5173` (Vite). If none respond, report: "No dev server detected. Start the application and re-run the review."
+The host must supply a `## Host Browser Evidence` section produced only after
+`ui-review-readiness.md` confirmed the declared application and real local
+interactive browser navigation. Analyze its bounded screenshots,
+accessibility snapshots, console summary, route/viewport IDs, interaction
+observations, and computed-style results. Do not call or search for browser
+tools. Missing evidence is a coverage gap, not a product finding.
 
 ## Screenshot Evidence
 
@@ -318,13 +326,15 @@ Total: [score]/40 ([rating band])
 - **P2** -- Tasks complete but with confusion or extra effort. Inconsistent patterns that erode trust. Missing feedback states (loading, empty, success). Poor hierarchy burying important content. Visual regressions from a previous review.
 - **P3** -- Polish. Spacing inconsistencies. Minor alignment drift. Suboptimal typography. Missing hover states. Edge case overflow. Orphaned headings.
 
-## Playwright MCP Tools
+## Host browser evidence
 
-Same Playwright MCP tools as `visual-browser-tester`, prefixed `mcp__plugin_compound-engineering_pw__browser_*`. Load each on demand before calling it (`ToolSearch query: "+pw browser_navigate"`), likewise for `browser_take_screenshot`, `browser_resize`, `browser_snapshot`, `browser_hover`, `browser_click`, `browser_evaluate`, `browser_console_messages`.
+This routed participant receives no Playwright/T3 browser capability. Every
+`browser_*` instruction below names an observation the host must already have
+captured in bounded evidence; remote web search cannot substitute for it.
 
 ## Rules
 
-1. Verify the dev server is running before testing.
+1. Verify the supplied readiness/browser evidence binds the declared target before analysis.
 2. Save screenshots for every page reviewed in this invocation's exact-owned
    raw-output directory and update its `manifest.json`. Do not compare or delete
    paths owned by another run.

--- a/plugins/dm-review/agents/review/visual-browser-tester.md
+++ b/plugins/dm-review/agents/review/visual-browser-tester.md
@@ -1,6 +1,6 @@
 ---
 name: visual-browser-tester
-description: Tests rendered pages in a browser for visual regressions, responsive layout, interactive states, and runtime accessibility using Playwright MCP tools. Runs when template or CSS files change and a dev server is detected.
+description: Analyzes bounded host-captured local-browser evidence for visual regressions, responsive layout, interactive states, and runtime accessibility after the required app/browser readiness gate.
 model: inherit
 ---
 
@@ -22,23 +22,25 @@ model: inherit
 
 # Visual Browser Tester
 
-You load pages in a real browser and verify visual rendering, responsive behavior, interactive states, and runtime accessibility. You complement the static code analysis agents by testing what actually renders.
+You analyze bounded evidence captured from a real local browser and verify
+visual rendering, responsive behavior, interactive states, and runtime
+accessibility. You complement static code analysis with what actually rendered.
 
 ## Precondition
 
-A dev server must be running. If the prompt supplies a specific URL, use it and skip detection. Otherwise `browser_navigate` these in order and use the first that loads:
-
-1. `http://[project-name].coop.site` or `http://[project-name].test` (local `.site`/`.test` TLDs -- preferred for Assembly projects using Caddy/DDEV)
-2. `http://localhost:8080` (Go+Templ+Datastar default)
-3. `http://localhost:3000` (Node/general default)
-4. `https://[project-name].ddev.site` (Craft CMS DDEV -- derive the project name from the working directory)
-5. `http://localhost:5173` (Vite dev server)
-
-If none respond, record `target unavailable` and emit a blocked `human_help_required` receipt naming the exact missing persona/scenario/route/engine/viewport cases. Ask the user to start the application or provide the authoritative target URL. Never return a bare stop, skip, approval, or pass.
+A `## Host Browser Evidence` section must bind the repository-declared target,
+real local interactive transport, screenshots, accessibility snapshots,
+console summary, route/viewport case IDs, interaction observations, and
+computed-style results. The host has already completed the app/browser
+recovery contract. Do not scan URLs, call browser tools, or substitute remote
+web search. If evidence is absent or incomplete, return the exact missing case
+IDs under `NOT-COVERED:` and no product finding. Treat host evidence marked
+`target unavailable` as the corresponding terminal coverage receipt, never as
+permission to rediscover or silently skip the target.
 
 ## Browser Fallback Chain
 
-Use `plugins/workflow-kernel/skills/workflow-kernel/references/verification-contract.md`. On failure, capture safe screenshot/trace/console/error evidence before recovery. Quit the primary browser process/engine session, relaunch it with a fresh profile and changed session identity, and retry once. If that proof is unavailable, record `primary_restart_unavailable`. Then launch one genuinely different engine and retry once. Closing a tab/context, changing tool wrappers for the same engine, or restarting the application/container does not prove browser restart.
+The host owns `plugins/workflow-kernel/skills/workflow-kernel/references/verification-contract.md`, browser recovery, and lifecycle receipts. Validate that the supplied bounded evidence identifies the completed attempt and recovery receipt; do not perform recovery yourself.
 
 If the alternate engine fails or cannot launch, **stop the review and tell the user**:
 
@@ -256,13 +258,15 @@ Reference style: `[/proposals @ 320px]` for a specific breakpoint, `[/proposals 
 - **P2** -- Layout degraded at mobile (content cut off, overlapping, horizontal scroll), interactive states not visually distinct (hover identical to default), axe-core serious violations, console JavaScript errors, contrast failures on rendered colors, missing scheme tokens in Live Wires
 - **P3** -- Minor spacing inconsistencies, axe-core moderate violations, responsive polish issues (awkward but usable), baseline rhythm misalignment, minor visual state inconsistencies
 
-## Playwright MCP Tools Reference
+## Host browser evidence
 
-Load each tool with `ToolSearch` before calling it (`ToolSearch query: "+pw browser_navigate"`). Exact names are `mcp__plugin_compound-engineering_pw__browser_` plus `navigate`, `take_screenshot`, `resize`, `snapshot`, `press_key`, `hover`, `click`, `evaluate`, `console_messages`, `fill_form`, `wait_for`.
+This routed participant receives no Playwright/T3 browser capability. Every
+later `browser_*` instruction names an observation that must already exist in
+the bounded host evidence. Missing observations remain explicit coverage gaps.
 
 ## Rules
 
-1. Verify the dev server is running before testing. If the target is unavailable, emit blocked `human_help_required` with the exact missing cases and ask for help. If Playwright fails, follow the Browser Fallback Chain before giving up.
+1. Verify the supplied readiness and browser evidence bind the declared target before analysis; missing cases stay `NOT-COVERED:` and never become product findings.
 2. Test every discovered URL, not just the homepage.
 3. Screenshot all four breakpoints for every URL when CSS changes are involved.
 4. Find interactive elements via the accessibility snapshot -- never hardcode CSS selectors.

--- a/plugins/dm-review/skills/review/SKILL.md
+++ b/plugins/dm-review/skills/review/SKILL.md
@@ -249,6 +249,8 @@ DM_REVIEW_REQUIRED_ASSETS=(
   "agents/workflow/review-consolidator.md"
   "agents/workflow/review-memory-recorder.md"
   "skills/review/references/reviewer-output-contract.md"
+  "skills/review/references/ui-review-readiness.md"
+  "skills/review/references/ui-review-readiness.sh"
 )
 ACCESSIBILITY_REQUIRED_ASSETS=()
 LIVE_WIRES_REQUIRED_ASSETS=()
@@ -401,6 +403,25 @@ Input guardrails applied:
 Load `${CLAUDE_SKILL_DIR}/references/full-lane-dispatch.md`. It owns the closed
 lane-to-role mapping and anonymous public receipt. Do not load a provider/model
 table or print concrete routing identity.
+
+### Phase 3.9: Required UI readiness
+
+When any browser/UI lane is selected, load
+`${CLAUDE_SKILL_DIR}/references/ui-review-readiness.md` and complete its
+application and local-browser gate before model dispatch. Use only the
+repository-declared target and exact start/readiness procedure. Start an exact
+declared process through its helper, or an exact declared Compose consumer
+through the existing review Docker contract. Track and clean only resources
+this invocation created.
+
+Verify application reachability and actual local interactive browser
+navigation independently. OpenRouter web search and generic `tool-use` never
+satisfy local browser readiness. Current browser interaction is host-owned;
+pass bounded evidence to the mapped provider-neutral analysis role without a
+`browser` capability request. If app or browser recovery fails, dispatch no UI
+participant and keep `REVIEW INCOMPLETE` with one safe reason and one next
+action. If readiness succeeds but the role is unavailable, report
+`model_participant_unavailable` distinctly.
 
 ---
 
@@ -582,7 +603,7 @@ invocation.
 
 ## Reference Files
 
-Loaded on demand during review: `reviewer-prompt-template.md` (common reviewer prompt contract, loaded before dispatch in both modes), `selective-lane-allowlist.md` (only when `review_lane_allowlist` input is present), `severity-mapping.md` (P1/P2/P3 mapping), `agent-registry.md` (agent catalog and triggers), `output-format.md` (report template), `issue-tracking.md` (todo template and GitHub conventions), `guardrails.md` (input/output validation, failure policies), `graceful-degradation.md` (failure classification and merge overrides), `ai-slop-detector.md` (25-point AI output checklist), `ui-design-patterns.md`, `token-discovery.md`, `repo-cleanup-contract.md` (exact worktree/branch registry, safe-to-delete table, feature-branch protection, inventory; shared with pipeline), and `datastar-pro.md` (Pro attributes/actions, substitution table, bundle-presence rule). All under `${CLAUDE_SKILL_DIR}/references/`.
+Loaded on demand during review: `reviewer-prompt-template.md` (common reviewer prompt contract, loaded before dispatch in both modes), `ui-review-readiness.md` (required UI application/browser gate), `selective-lane-allowlist.md` (only when `review_lane_allowlist` input is present), `severity-mapping.md` (P1/P2/P3 mapping), `agent-registry.md` (agent catalog and triggers), `output-format.md` (report template), `issue-tracking.md` (todo template and GitHub conventions), `guardrails.md` (input/output validation, failure policies), `graceful-degradation.md` (failure classification and merge overrides), `ai-slop-detector.md` (25-point AI output checklist), `ui-design-patterns.md`, `token-discovery.md`, `repo-cleanup-contract.md` (exact worktree/branch registry, safe-to-delete table, feature-branch protection, inventory; shared with pipeline), and `datastar-pro.md` (Pro attributes/actions, substitution table, bundle-presence rule). All under `${CLAUDE_SKILL_DIR}/references/`.
 
 ## Agent Definition Paths
 

--- a/plugins/dm-review/skills/review/references/full-lane-dispatch.md
+++ b/plugins/dm-review/skills/review/references/full-lane-dispatch.md
@@ -17,7 +17,8 @@ For every lane that requires separation from implementation, load
 | documentation | `review-fast` | `read-repository`, `structured-output` | `medium` |
 | tests/build | `review-fast` | `read-repository`, `tool-use`, `structured-output` | `medium` |
 | second perspective | `plan-critic` | `read-repository`, `long-context`, `structured-output`, `independent-family` | `high` |
-| triggered domain/UI lane | `review-deep` | explicit required capabilities only | `high` |
+| triggered domain lane | `review-deep` | explicit required capabilities only | `high` |
+| triggered UI analysis lane | `review-deep` | `read-repository`, `long-context`, `structured-output` | `high` |
 
 Keep the complete selected roster. Role mapping does not drop a required lane.
 Quick mode keeps its existing smaller roster but uses the same role mapping.
@@ -26,7 +27,7 @@ Quick mode keeps its existing smaller roster but uses the same role mapping.
 
 Resolve one coherent model-router bundle with Workflow Kernel and require
 `skills/model-router/references/role-dispatch.sh`, the request schema, and role
-policy at minimum version `0.2.0`. When this invocation owns terminal reporting,
+policy at minimum version `0.3.0`. When this invocation owns terminal reporting,
 require `skills/model-router/references/render-terminal-report.sh` from that
 same bundle. For each selected lane:
 
@@ -52,6 +53,30 @@ same bundle. For each selected lane:
    repair provenance is unavailable, the independent lane remains unavailable.
    The two origin forms are mutually exclusive.
 6. Launch selected lanes in parallel when the host supports it.
+
+### Required UI prerequisite
+
+Before any selected UI lane is dispatched, load `ui-review-readiness.md` and
+run its ordered application/browser gate. The application target and start
+procedure come only from `.dm/ui-review.json`. A declared Compose consumer uses
+the existing review Docker creation/cleanup contracts; an exact declared
+process uses `ui-review-readiness.sh`. Verify reachability independently, then
+prove actual local browser navigation independently.
+
+Current routed transports do not receive the host's local interactive browser.
+Keep browser interaction host-owned and materialize bounded screenshots,
+accessibility snapshots, console summaries, route/viewport case IDs,
+interaction observations, and computed-style evidence. Pass that evidence to
+the provider-neutral UI analysis role above. Never request `browser` or generic
+`tool-use`, and never treat OpenRouter web search as local navigation.
+
+If application or browser recovery fails, do not dispatch a participant. Keep
+the lane and review incomplete with exactly `dev_server_unavailable` or
+`browser_transport_unavailable` plus the contract's one next action. If both
+are ready but role dispatch is unavailable, settle as
+`model_participant_unavailable`. Prerequisite failures are coverage gaps, not
+code findings. Settle and clean only resources registered by this review;
+pre-existing resources remain untouched.
 
 The terminal report owner supplies this exact private directory and its
 `terminal-receipt-index.json`. After a parallel fan-out joins, extend the index

--- a/plugins/dm-review/skills/review/references/output-format.md
+++ b/plugins/dm-review/skills/review/references/output-format.md
@@ -187,6 +187,11 @@ Coverage Gaps; they never support clean. This index creates no transcript.
 ### Coverage Gaps
 
 List incomplete required coverage, its evidence pointer, and one next action.
+For a required UI lane, emit exactly one of `dev_server_unavailable`,
+`browser_transport_unavailable`, `model_participant_unavailable`, or
+`resource_cleanup_failed`; never include raw tool/provider output, a private
+path, account data, or quota details. These readiness failures are not code
+findings.
 If none, state `Coverage Gaps: none -- all required lanes completed.`
 
 ---
@@ -272,7 +277,10 @@ The consolidator preserves the original citation format from each agent.
 ## Merge Recommendation Logic
 
 ```text
-if any P1 findings:
+if any required lane is incomplete:
+  recommendation = "REVIEW INCOMPLETE"
+  summary = "<one exact safe reason code>; next: <one action>."
+elif any P1 findings:
   recommendation = "BLOCKS MERGE"
   summary = "X critical issues must be fixed before merging."
 elif any P2 or P3 findings:

--- a/plugins/dm-review/skills/review/references/ui-review-readiness.md
+++ b/plugins/dm-review/skills/review/references/ui-review-readiness.md
@@ -1,0 +1,109 @@
+# Required UI-lane readiness
+
+This contract is consumed only by dm-review's required rendered UI lanes. It
+prevents participant dispatch when no rendered application or real local
+interactive browser exists. It replaces reviewer-owned localhost scanning,
+generic `tool-use` guesses, and OpenRouter web-search substitution. It is not a
+browser broker, capability negotiation framework, or workflow engine.
+
+## Repository declaration
+
+Discover only `<repository>/.dm/ui-review.json`; never scan generic localhost
+ports or infer a start command from incidental files. The closed version 1
+shape is:
+
+```json
+{
+  "schemaVersion": 1,
+  "targetUrl": "http://localhost:8080",
+  "readiness": {
+    "argv": ["./tools/ui-review-ready"],
+    "attempts": 10,
+    "timeoutSeconds": 5
+  },
+  "start": {
+    "resourceKind": "process",
+    "argv": ["./tools/ui-review-start"],
+    "cleanupArgv": ["./tools/ui-review-stop"],
+    "timeoutSeconds": 30
+  }
+}
+```
+
+`start` may be `null` for a consumer that must already be running. Every argv
+is an array, never a shell string. Its executable must be a tracked,
+non-symlinked repository-owned `./` path. The target must be an explicit local
+HTTP(S) URL. Unknown fields or unsupported values fail closed.
+
+`resourceKind: process` is prepared and settled by
+`ui-review-readiness.sh`. `resourceKind: compose` is executed only through
+`review-docker-create.md`, using the exact declaration argv and exact composed
+consumer. Run the helper again after Compose readiness; cleanup remains owned
+by `review-docker-cleanup.md`. Never start the whole stack when one declared
+consumer is sufficient.
+
+## Ordered gate
+
+1. Check declared application readiness independently with
+   `ui-review-readiness.sh prepare`.
+2. If a stopped `process` consumer has an exact start procedure, start it and
+   register only that created resource. `prepare` returns `app_ready` with
+   `dispatchAllowed: false` and leaves that registered process available for
+   host browser navigation. A pre-existing ready consumer is never registered
+   or stopped.
+3. For declared Compose, follow the existing Docker creation contract, then
+   rerun the independent readiness check.
+4. On the host, inspect actual callable browser tools. In T3 Code, call
+   `preview_status`; if no automation-capable preview is attached, call
+   `preview_open`, then navigate the exact declared target. A tool name or
+   generic `tool-use` is not readiness evidence.
+5. Materialize a private bounded browser evidence file only after successful
+   local navigation:
+
+   ```json
+   {
+     "schemaVersion": 1,
+     "status": "ready",
+     "transportClass": "local-interactive",
+     "localNavigation": "confirmed",
+     "targetUrl": "http://localhost:8080",
+     "evidenceRef": "review/browser/navigation.json"
+   }
+   ```
+
+6. Run `ui-review-readiness.sh confirm-browser` with that evidence and the
+   exact state file created by `prepare`. It rechecks the registered target and
+   consumes the browser proof. Only `dispatchAllowed: true` permits a
+   participant call.
+7. Keep browser interaction host-owned. Give each UI analysis role the bounded
+   screenshots, accessibility snapshots, console summary, route/viewport IDs,
+   interaction observations, and computed-style results it needs. Request
+   `review-deep` with `read-repository`, `long-context`, and
+   `structured-output`; do not request `browser` or generic `tool-use`.
+8. Settle the public participant result through `ui-review-readiness.sh
+   settle`, then clean every exact registered process or Compose resource.
+   Install the same cleanup call on interruption and failure paths.
+
+The private state has a closed `app_ready` -> `ready` -> `settled` lifecycle.
+It snapshots the exact readiness and cleanup argv/timeouts when the process is
+registered; cleanup never reloads a mutable declaration. A failed confirmation
+closes the state after exact cleanup. A settled state cannot be reused for a
+second participant, and repeated cleanup reports zero resources removed.
+
+OpenRouter web search is remote public-web retrieval. It never satisfies this
+local browser contract. No model-router candidate currently advertises local
+`browser`; a future candidate may do so only after its transport has a runtime
+probe that proves local navigation.
+
+## Closed outcomes
+
+| Reason | Review state | One next action |
+|---|---|---|
+| `dev_server_unavailable` | `REVIEW INCOMPLETE` | Declare or recover the exact repository-owned consumer and rerun. |
+| `browser_transport_unavailable` | `REVIEW INCOMPLETE` | Attach a local interactive browser, navigate the target, and rerun. |
+| `model_participant_unavailable` | `REVIEW INCOMPLETE` | Restore an eligible provider-neutral analysis participant and rerun the lane. |
+| `resource_cleanup_failed` | `REVIEW INCOMPLETE` | Run only the recorded repository-owned cleanup and inspect that resource. |
+
+These are prerequisite/coverage outcomes, never code-quality findings. Emit
+one exact cause and one next action. Do not dispatch a doomed participant,
+silently omit a required lane, or convert missing evidence into approval.

--- a/plugins/dm-review/skills/review/references/ui-review-readiness.sh
+++ b/plugins/dm-review/skills/review/references/ui-review-readiness.sh
@@ -1,0 +1,373 @@
+#!/usr/bin/env bash
+# ui-review-readiness.sh -- dm-review UI-lane prerequisite and cleanup helper.
+#
+# Current consumer: dm-review required UI lanes. It prevents doomed model
+# dispatch when the repository's rendered app or the host's local interactive
+# browser is unavailable. It replaces per-reviewer localhost scanning and
+# unowned start/stop guesses; it is not an orchestration layer or browser broker.
+#
+# Usage:
+#   ui-review-readiness.sh prepare --repository-root ROOT --state-file FILE
+#   ui-review-readiness.sh confirm-browser --repository-root ROOT \
+#     --state-file FILE --browser-evidence-file FILE
+#   ui-review-readiness.sh settle --repository-root ROOT --state-file FILE \
+#     --participant-result-file FILE
+#   ui-review-readiness.sh cleanup --repository-root ROOT --state-file FILE
+set -uo pipefail
+
+PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
+export PATH
+umask 077
+
+ACTION="${1:-}"
+[ "$#" -gt 0 ] && shift
+REPOSITORY_ROOT=""
+STATE_FILE=""
+BROWSER_EVIDENCE_FILE=""
+PARTICIPANT_RESULT_FILE=""
+
+usage() {
+  printf '%s\n' 'ui-review-readiness: invalid invocation' >&2
+  exit 2
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --repository-root) [ "$#" -ge 2 ] || usage; REPOSITORY_ROOT="$2"; shift 2 ;;
+    --state-file) [ "$#" -ge 2 ] || usage; STATE_FILE="$2"; shift 2 ;;
+    --browser-evidence-file) [ "$#" -ge 2 ] || usage; BROWSER_EVIDENCE_FILE="$2"; shift 2 ;;
+    --participant-result-file) [ "$#" -ge 2 ] || usage; PARTICIPANT_RESULT_FILE="$2"; shift 2 ;;
+    *) usage ;;
+  esac
+done
+
+case "$ACTION" in prepare|confirm-browser|settle|cleanup) ;; *) usage ;; esac
+command -v jq >/dev/null 2>&1 || { printf '%s\n' 'ui-review-readiness: unavailable (missing runtime dependency)' >&2; exit 76; }
+[ -n "$REPOSITORY_ROOT" ] && [ -d "$REPOSITORY_ROOT" ] && [ ! -L "$REPOSITORY_ROOT" ] || usage
+REPOSITORY_ROOT="$(cd "$REPOSITORY_ROOT" && pwd -P)" || usage
+git -C "$REPOSITORY_ROOT" rev-parse --show-toplevel >/dev/null 2>&1 || usage
+[ -n "$STATE_FILE" ] && [ -d "$(dirname "$STATE_FILE")" ] || usage
+
+emit_closed() {
+  local reason="$1" next_action="$2"
+  jq -cn --arg reason "$reason" --arg next_action "$next_action" \
+    '{state:"closed",dispatchAllowed:false,reason:$reason,nextAction:$next_action,
+      reviewDisposition:"REVIEW INCOMPLETE"}'
+}
+
+load_argv() {
+  local source="$1" query="$2" arg
+  UI_ARGV=()
+  while IFS= read -r arg; do UI_ARGV+=("$arg"); done < <(jq -r "$query[]" "$source")
+  [ "${#UI_ARGV[@]}" -gt 0 ] || return 1
+}
+
+validate_repo_executable() {
+  local relative="$1" physical
+  case "$relative" in ./*) ;; *) return 1 ;; esac
+  case "$relative" in *'/../'*|../*|*/..|*'\'*|*$'\n'*|*$'\r'*) return 1 ;; esac
+  [ -f "$REPOSITORY_ROOT/${relative#./}" ] && [ -x "$REPOSITORY_ROOT/${relative#./}" ] &&
+    [ ! -L "$REPOSITORY_ROOT/${relative#./}" ] || return 1
+  physical="$(cd "$(dirname "$REPOSITORY_ROOT/${relative#./}")" && pwd -P)/$(basename "$relative")"
+  case "$physical" in "$REPOSITORY_ROOT"/*) ;; *) return 1 ;; esac
+  git -C "$REPOSITORY_ROOT" ls-files --error-unmatch -- "${relative#./}" >/dev/null 2>&1
+}
+
+run_bounded_argv() {
+  local limit="$1" output pid waited=0 rc
+  shift
+  output="$(mktemp "${TMPDIR:-/tmp}/dm-review-ui-command.XXXXXX")" || return 1
+  (cd "$REPOSITORY_ROOT" && "$@" > "$output" 2>&1) &
+  pid=$!
+  while [ "$waited" -lt "$limit" ]; do
+    kill -0 "$pid" 2>/dev/null || break
+    sleep 1
+    waited=$((waited + 1))
+  done
+  if kill -0 "$pid" 2>/dev/null; then
+    kill -TERM "$pid" 2>/dev/null || true
+    sleep 1
+    kill -KILL "$pid" 2>/dev/null || true
+    wait "$pid" 2>/dev/null || true
+    rm -f "$output"
+    return 124
+  fi
+  wait "$pid" 2>/dev/null; rc=$?
+  rm -f "$output"
+  return "$rc"
+}
+
+validate_declaration() {
+  local declaration="$1"
+  [ -f "$declaration" ] && [ ! -L "$declaration" ] || return 1
+  jq -e '
+    type == "object" and
+    (keys | sort) == (["readiness","schemaVersion","start","targetUrl"] | sort) and
+    .schemaVersion == 1 and
+    (.targetUrl | type) == "string" and
+    (.targetUrl | test("^https?://(localhost|127\\.0\\.0\\.1|[a-z0-9.-]+\\.(test|site)|[a-z0-9.-]+\\.ddev\\.site)(:[0-9]{1,5})?(/[^[:space:]]*)?$")) and
+    (.readiness | type) == "object" and
+    (.readiness | keys | sort) == (["argv","attempts","timeoutSeconds"] | sort) and
+    (.readiness.argv | type) == "array" and (.readiness.argv | length) > 0 and
+    all(.readiness.argv[]; type == "string" and length > 0 and length <= 4096) and
+    (.readiness.attempts | type) == "number" and (.readiness.attempts | floor) == .readiness.attempts and .readiness.attempts >= 1 and .readiness.attempts <= 30 and
+    (.readiness.timeoutSeconds | type) == "number" and (.readiness.timeoutSeconds | floor) == .readiness.timeoutSeconds and .readiness.timeoutSeconds >= 1 and .readiness.timeoutSeconds <= 60 and
+    ((.start == null) or (
+      (.start | type) == "object" and
+      (.start | keys | sort) == (["argv","cleanupArgv","resourceKind","timeoutSeconds"] | sort) and
+      (.start.resourceKind == "process" or .start.resourceKind == "compose") and
+      (.start.argv | type) == "array" and (.start.argv | length) > 0 and
+      (.start.cleanupArgv | type) == "array" and (.start.cleanupArgv | length) > 0 and
+      all(.start.argv[], .start.cleanupArgv[]; type == "string" and length > 0 and length <= 4096) and
+      (.start.timeoutSeconds | type) == "number" and (.start.timeoutSeconds | floor) == .start.timeoutSeconds and .start.timeoutSeconds >= 1 and .start.timeoutSeconds <= 300
+    ))
+  ' "$declaration" >/dev/null 2>&1 &&
+    git -C "$REPOSITORY_ROOT" ls-files --error-unmatch -- .dm/ui-review.json >/dev/null 2>&1
+}
+
+write_state() {
+  local target_url="$1" stage="$2" dispatch_allowed="$3" created="$4" cleanup_pending="$5"
+  local readiness_argv="$6" readiness_attempts="$7" readiness_timeout="$8"
+  local cleanup_argv="$9" cleanup_timeout="${10}" tmp
+  tmp="$(mktemp "$(dirname "$STATE_FILE")/.ui-review-state.XXXXXX")" || return 1
+  jq -cn --arg target_url "$target_url" --arg stage "$stage" \
+    --argjson dispatch_allowed "$dispatch_allowed" --argjson created "$created" \
+    --argjson cleanup_pending "$cleanup_pending" --argjson readiness_argv "$readiness_argv" \
+    --argjson readiness_attempts "$readiness_attempts" --argjson readiness_timeout "$readiness_timeout" \
+    --argjson cleanup_argv "$cleanup_argv" --argjson cleanup_timeout "$cleanup_timeout" \
+    '{schemaVersion:1,targetUrl:$target_url,stage:$stage,dispatchAllowed:$dispatch_allowed,
+      createdByReview:$created,cleanupPending:$cleanup_pending,
+      readinessArgv:$readiness_argv,readinessAttempts:$readiness_attempts,
+      readinessTimeoutSeconds:$readiness_timeout,cleanupArgv:$cleanup_argv,
+      cleanupTimeoutSeconds:$cleanup_timeout}' > "$tmp" || { rm -f "$tmp"; return 1; }
+  mv "$tmp" "$STATE_FILE"
+}
+
+validate_state() {
+  [ -f "$STATE_FILE" ] && [ ! -L "$STATE_FILE" ] || return 1
+  jq -e '
+    type == "object" and
+    (keys | sort) == (["cleanupArgv","cleanupPending","cleanupTimeoutSeconds","createdByReview","dispatchAllowed","readinessArgv","readinessAttempts","readinessTimeoutSeconds","schemaVersion","stage","targetUrl"] | sort) and
+    .schemaVersion == 1 and (.targetUrl | type) == "string" and
+    (.stage == "app_ready" or .stage == "ready" or .stage == "closed" or .stage == "settled") and
+    (.dispatchAllowed | type) == "boolean" and (.createdByReview | type) == "boolean" and
+    (.cleanupPending | type) == "boolean" and
+    (.readinessArgv | type) == "array" and (.readinessArgv | length) > 0 and
+    all(.readinessArgv[]; type == "string" and length > 0 and length <= 4096) and
+    (.readinessAttempts | type) == "number" and (.readinessAttempts | floor) == .readinessAttempts and .readinessAttempts >= 1 and .readinessAttempts <= 30 and
+    (.readinessTimeoutSeconds | type) == "number" and (.readinessTimeoutSeconds | floor) == .readinessTimeoutSeconds and .readinessTimeoutSeconds >= 1 and .readinessTimeoutSeconds <= 60 and
+    (.cleanupArgv | type) == "array" and all(.cleanupArgv[]; type == "string" and length > 0 and length <= 4096) and
+    (.cleanupTimeoutSeconds | type) == "number" and (.cleanupTimeoutSeconds | floor) == .cleanupTimeoutSeconds and .cleanupTimeoutSeconds >= 0 and .cleanupTimeoutSeconds <= 300 and
+    (if .createdByReview then (.cleanupArgv | length) > 0 and .cleanupTimeoutSeconds >= 1 else true end)
+  ' "$STATE_FILE" >/dev/null 2>&1
+}
+
+update_state() {
+  local stage="$1" dispatch_allowed="$2" cleanup_pending="${3:-}" tmp
+  tmp="$(mktemp "$(dirname "$STATE_FILE")/.ui-review-state.XXXXXX")" || return 1
+  if [ -n "$cleanup_pending" ]; then
+    jq --arg stage "$stage" --argjson dispatch "$dispatch_allowed" --argjson pending "$cleanup_pending" \
+      '.stage=$stage | .dispatchAllowed=$dispatch | .cleanupPending=$pending' "$STATE_FILE" > "$tmp" || { rm -f "$tmp"; return 1; }
+  else
+    jq --arg stage "$stage" --argjson dispatch "$dispatch_allowed" \
+      '.stage=$stage | .dispatchAllowed=$dispatch' "$STATE_FILE" > "$tmp" || { rm -f "$tmp"; return 1; }
+  fi
+  mv "$tmp" "$STATE_FILE"
+}
+
+cleanup_owned() {
+  local created pending timeout_seconds rc=0
+  CLEANUP_REMOVED=0
+  validate_state || return 1
+  created="$(jq -r '.createdByReview // false' "$STATE_FILE" 2>/dev/null)"
+  pending="$(jq -r '.cleanupPending // false' "$STATE_FILE" 2>/dev/null)"
+  [ "$created" = true ] && [ "$pending" = true ] || return 0
+  load_argv "$STATE_FILE" '.cleanupArgv' || return 1
+  validate_repo_executable "${UI_ARGV[0]}" || return 1
+  timeout_seconds="$(jq -r '.cleanupTimeoutSeconds' "$STATE_FILE")"
+  run_bounded_argv "$timeout_seconds" "${UI_ARGV[@]}" || rc=$?
+  [ "$rc" -eq 0 ] || return "$rc"
+  update_state "$(jq -r '.stage' "$STATE_FILE")" "$(jq -r '.dispatchAllowed' "$STATE_FILE")" false || return 1
+  CLEANUP_REMOVED=1
+}
+
+if [ "$ACTION" = cleanup ]; then
+  if ! validate_state; then
+    emit_closed resource_cleanup_failed 'inspect the exact UI review state and run only its recorded cleanup'
+    exit 76
+  fi
+  if cleanup_owned; then
+    created="$(jq -r '.createdByReview // false' "$STATE_FILE" 2>/dev/null)"
+    update_state settled false false || exit 76
+    jq -cn --argjson created "$created" --argjson removed "$CLEANUP_REMOVED" \
+      '{state:(if $removed == 1 then "cleaned" else "already_clean" end),
+        removedCount:$removed,preexistingUntouched:($created | not)}'
+    exit 0
+  fi
+  emit_closed resource_cleanup_failed 'run the registered UI cleanup command and inspect only the recorded review resource'
+  exit 76
+fi
+
+if [ "$ACTION" = settle ]; then
+  validate_state &&
+    jq -e '.stage == "ready" and .dispatchAllowed == true' "$STATE_FILE" >/dev/null 2>&1 || usage
+  [ -f "$PARTICIPANT_RESULT_FILE" ] && [ ! -L "$PARTICIPANT_RESULT_FILE" ] || usage
+  disposition="$(jq -r '.disposition // "invalid"' "$PARTICIPANT_RESULT_FILE" 2>/dev/null)"
+  participant_valid=false
+  if jq -e '
+    type == "object" and .role == "review-deep" and
+    (.capabilities | type) == "array" and
+    (.capabilities | index("browser") | not) and
+    (.disposition == "completed" or .disposition == "unavailable") and
+    ((.disposition != "completed") or (.evidenceSource == "live" and .transportStub == false))
+  ' "$PARTICIPANT_RESULT_FILE" >/dev/null 2>&1; then participant_valid=true; fi
+  # Consume the ready state before cleanup so a repeated settle can never
+  # complete against stale browser evidence. Explicit cleanup remains valid
+  # if the registered cleanup command subsequently fails.
+  update_state settled false || exit 76
+  cleanup_rc=0
+  cleanup_owned || cleanup_rc=$?
+  if [ "$cleanup_rc" -ne 0 ]; then
+    emit_closed resource_cleanup_failed 'run the registered UI cleanup command and inspect only the recorded review resource'
+    exit 76
+  fi
+  if [ "$participant_valid" != true ] || [ "$disposition" != completed ]; then
+    emit_closed model_participant_unavailable 'restore an eligible provider-neutral review participant and rerun the required UI lane'
+    exit 76
+  fi
+  jq -cn '{state:"completed",dispatchAllowed:false,reason:"available",
+    reviewDisposition:"completed",cleanup:"complete"}'
+  exit 0
+fi
+
+DECLARATION="$REPOSITORY_ROOT/.dm/ui-review.json"
+close_registered_state() {
+  local reason="$1" next_action="$2" cleanup_rc=0
+  trap - EXIT HUP INT TERM
+  cleanup_owned || cleanup_rc=$?
+  if [ "$cleanup_rc" -ne 0 ]; then
+    emit_closed resource_cleanup_failed 'run the registered UI cleanup command and inspect only the recorded review resource'
+    exit 76
+  fi
+  update_state closed false false || exit 76
+  emit_closed "$reason" "$next_action"
+  exit 76
+}
+
+cleanup_on_unexpected_exit() {
+  local action_rc=$?
+  trap - EXIT HUP INT TERM
+  cleanup_owned >/dev/null 2>&1 || true
+  update_state closed false false >/dev/null 2>&1 || true
+  exit "$action_rc"
+}
+
+if [ "$ACTION" = prepare ]; then
+  if ! validate_declaration "$DECLARATION"; then
+    emit_closed dev_server_unavailable 'declare .dm/ui-review.json with exact repository-owned readiness/start/cleanup argv and rerun'
+    exit 76
+  fi
+  TARGET_URL="$(jq -r '.targetUrl' "$DECLARATION")"
+  load_argv "$DECLARATION" '.readiness.argv' || usage
+  validate_repo_executable "${UI_ARGV[0]}" || {
+    emit_closed dev_server_unavailable 'repair the tracked repository-owned readiness command and rerun'
+    exit 76
+  }
+  READINESS_ARGV=("${UI_ARGV[@]}")
+  READINESS_ARGV_JSON="$(jq -c '.readiness.argv' "$DECLARATION")"
+  READINESS_TIMEOUT="$(jq -r '.readiness.timeoutSeconds' "$DECLARATION")"
+  READINESS_ATTEMPTS="$(jq -r '.readiness.attempts' "$DECLARATION")"
+  CREATED=false
+
+  if [ -e "$STATE_FILE" ]; then
+    validate_state &&
+      jq -e --arg target "$TARGET_URL" '.stage == "app_ready" and .dispatchAllowed == false and .targetUrl == $target' "$STATE_FILE" >/dev/null 2>&1 || usage
+    if ! run_bounded_argv "$READINESS_TIMEOUT" "${READINESS_ARGV[@]}"; then
+      close_registered_state dev_server_unavailable 'inspect the registered application readiness command and rerun'
+    fi
+    CREATED="$(jq -r '.createdByReview' "$STATE_FILE")"
+  elif run_bounded_argv "$READINESS_TIMEOUT" "${READINESS_ARGV[@]}"; then
+    write_state "$TARGET_URL" app_ready false false false "$READINESS_ARGV_JSON" \
+      "$READINESS_ATTEMPTS" "$READINESS_TIMEOUT" '[]' 0 || exit 76
+  else
+    if [ "$(jq -r '.start == null' "$DECLARATION")" = true ]; then
+      emit_closed dev_server_unavailable 'run the repository-declared application consumer and rerun'
+      exit 76
+    fi
+    if [ "$(jq -r '.start.resourceKind' "$DECLARATION")" = compose ]; then
+      emit_closed dev_server_unavailable 'start the exact declared Compose consumer through the dm-review Docker creation contract, then rerun readiness'
+      exit 76
+    fi
+    load_argv "$DECLARATION" '.start.cleanupArgv' || usage
+    validate_repo_executable "${UI_ARGV[0]}" || {
+      emit_closed dev_server_unavailable 'repair the tracked repository-owned cleanup command and rerun'
+      exit 76
+    }
+    CLEANUP_ARGV_JSON="$(jq -c '.start.cleanupArgv' "$DECLARATION")"
+    START_TIMEOUT="$(jq -r '.start.timeoutSeconds' "$DECLARATION")"
+    load_argv "$DECLARATION" '.start.argv' || usage
+    validate_repo_executable "${UI_ARGV[0]}" || {
+      emit_closed dev_server_unavailable 'repair the tracked repository-owned start command and rerun'
+      exit 76
+    }
+    CREATED=true
+    write_state "$TARGET_URL" app_ready false true true "$READINESS_ARGV_JSON" \
+      "$READINESS_ATTEMPTS" "$READINESS_TIMEOUT" "$CLEANUP_ARGV_JSON" "$START_TIMEOUT" || exit 76
+    trap cleanup_on_unexpected_exit EXIT
+    trap 'exit 130' HUP INT TERM
+    if ! run_bounded_argv "$START_TIMEOUT" "${UI_ARGV[@]}"; then
+      close_registered_state dev_server_unavailable 'run the repository-declared application consumer and rerun'
+    fi
+    ready=false
+    attempt=0
+    while [ "$attempt" -lt "$READINESS_ATTEMPTS" ]; do
+      if run_bounded_argv "$READINESS_TIMEOUT" "${READINESS_ARGV[@]}"; then ready=true; break; fi
+      attempt=$((attempt + 1))
+      [ "$attempt" -ge "$READINESS_ATTEMPTS" ] || sleep 1
+    done
+    if [ "$ready" != true ]; then
+      close_registered_state dev_server_unavailable 'inspect the declared application start/readiness commands and rerun'
+    fi
+    trap - EXIT HUP INT TERM
+  fi
+  jq -cn --arg target_url "$TARGET_URL" --argjson created "$CREATED" \
+    '{state:"app_ready",dispatchAllowed:false,reason:"browser_evidence_required",
+      targetUrl:$target_url,createdResources:(if $created then 1 else 0 end),
+      nextAction:"navigate the declared target with the host local browser, then run confirm-browser"}'
+  exit 0
+fi
+
+# confirm-browser consumes the exact readiness snapshot registered by prepare.
+validate_state &&
+  jq -e '.stage == "app_ready" and .dispatchAllowed == false' "$STATE_FILE" >/dev/null 2>&1 || usage
+TARGET_URL="$(jq -r '.targetUrl' "$STATE_FILE")"
+load_argv "$STATE_FILE" '.readinessArgv' || usage
+validate_repo_executable "${UI_ARGV[0]}" || close_registered_state dev_server_unavailable 'repair the registered readiness command and rerun'
+READINESS_ARGV=("${UI_ARGV[@]}")
+READINESS_TIMEOUT="$(jq -r '.readinessTimeoutSeconds' "$STATE_FILE")"
+if [ "$(jq -r '.createdByReview and .cleanupPending' "$STATE_FILE")" = true ]; then
+  trap cleanup_on_unexpected_exit EXIT
+  trap 'exit 130' HUP INT TERM
+fi
+if ! run_bounded_argv "$READINESS_TIMEOUT" "${READINESS_ARGV[@]}"; then
+  close_registered_state dev_server_unavailable 'inspect the registered application readiness command and rerun'
+fi
+if [ ! -f "$BROWSER_EVIDENCE_FILE" ] || [ -L "$BROWSER_EVIDENCE_FILE" ] ||
+   ! jq -e --arg target_url "$TARGET_URL" '
+     type == "object" and
+     (keys | sort) == (["evidenceRef","localNavigation","schemaVersion","status","targetUrl","transportClass"] | sort) and
+     .schemaVersion == 1 and .status == "ready" and
+     .transportClass == "local-interactive" and .localNavigation == "confirmed" and
+     .targetUrl == $target_url and
+     (.evidenceRef | type) == "string" and (.evidenceRef | test("^[a-z0-9][a-z0-9._/-]{0,255}$"))
+   ' "$BROWSER_EVIDENCE_FILE" >/dev/null 2>&1; then
+  close_registered_state browser_transport_unavailable 'attach a local interactive browser, navigate the declared target, and rerun'
+fi
+update_state ready true || exit 76
+trap - EXIT HUP INT TERM
+CREATED="$(jq -r '.createdByReview' "$STATE_FILE")"
+jq -cn --arg target_url "$TARGET_URL" --argjson created "$CREATED" \
+  '{state:"ready",dispatchAllowed:true,reason:"available",targetUrl:$target_url,
+    browserTransport:"local-interactive",browserEvidence:"bounded-host-evidence",
+    createdResources:(if $created then 1 else 0 end),
+    nextAction:"dispatch provider-neutral UI analysis without browser capability"}'

--- a/plugins/model-router/.claude-plugin/plugin.json
+++ b/plugins/model-router/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "model-router",
   "description": "Internal deterministic role resolver and one-shot dispatcher for provider-neutral model work",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "author": {
     "name": "Design Machines",
     "url": "https://designmachines.studio"

--- a/plugins/model-router/.codex-plugin/plugin.json
+++ b/plugins/model-router/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "model-router",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Internal deterministic role resolver and one-shot dispatcher for provider-neutral model work",
   "author": {
     "name": "Design Machines",

--- a/plugins/model-router/skills/model-router/SKILL.md
+++ b/plugins/model-router/skills/model-router/SKILL.md
@@ -35,6 +35,24 @@ The dispatcher:
 8. writes exact, content-free identity and measurement evidence to the private
    receipt.
 
+For Codex subscription candidates, an optional policy `rateLimitId` is valid
+only when an authoritative model-to-allowance mapping exists. The probe parses
+response shapes structurally, validates that every 0.147 map key matches its
+snapshot `limitId`, and evaluates only the mapped bucket's five-hour and weekly
+windows at the existing 8% threshold. It never selects the best bucket. The
+legacy 0.146 `rateLimits.primary`/`secondary` snapshot and a single 0.147 bucket
+are unambiguous defaults. Multiple 0.147 buckets without an authoritative
+candidate mapping close as `rate_limit_mapping_unknown`; the current Codex
+app-server schema does not expose that mapping, so the policy does not invent
+one for current candidates. Missing, malformed, unsupported, exhausted, or
+unmappable evidence fails closed with a content-safe reason; unknown never
+means exhausted.
+
+The `browser` request capability means access to the caller's local interactive
+browser, not public web search. No current one-shot transport advertises that
+capability. dm-review keeps browser interaction host-owned and dispatches only
+bounded evidence analysis after its separate readiness gate.
+
 OpenRouter remains the authority for its credentials, provider catalog,
 response identity, usage, and cost receipt. The router owns provider-neutral
 input eligibility: any prompt and evidence eligible for an available native

--- a/plugins/model-router/skills/model-router/references/availability-probe.sh
+++ b/plugins/model-router/skills/model-router/references/availability-probe.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 # availability-probe.sh -- private live availability evidence for model-router.
 #
-# Parser baselines probed 2026-08-08: Claude Code 2.1.220 statusLine
-# rate_limits; Codex CLI 0.146.0 app-server account/rateLimits/read; curl
-# 8.7.1 against OpenRouter /api/v1/credits. Claude subscription telemetry is
-# session-scoped and may be absent before the first response; absence remains
-# distinct from exhaustion.
+# Parser baselines: Claude Code 2.1.220 statusLine rate_limits; Codex CLI
+# 0.146.0 and 0.147.0 app-server account/rateLimits/read; curl 8.7.1 against
+# OpenRouter /api/v1/credits. Claude subscription telemetry is session-scoped
+# and may be absent before the first response; absence remains distinct from
+# exhaustion.
 #
 # Subscription rails emit one conservative limiting-window object:
 #   {"state":"ok|limited|unknown","remaining_pct":<number>,"window":"<name>"}
@@ -159,43 +159,188 @@ claude_json() {
       allowances:{interactive:.,agent_sdk:$sdk_windows}}'
 }
 
-codex_app_server_output() {
-  [ -n "$CODEX_CLI" ] && [ -x "$CODEX_CLI" ] || return 1
-  {
-    printf '%s\n' \
-      '{"method":"initialize","id":0,"params":{"clientInfo":{"name":"depot-usage-probe","title":"Depot usage probe","version":"1"},"capabilities":{"experimentalApi":true}}}' \
-      '{"method":"initialized","params":{}}' \
-      '{"method":"account/rateLimits/read","id":7,"params":{}}'
-  } | run_bounded 20 "$CODEX_CLI" app-server --stdio 2>/dev/null
+wait_for_rpc_response() {
+  local response_file="$1" response_id="$2" server_pid="$3" limit="$4" waited=0
+  while [ "$waited" -lt "$limit" ]; do
+    if jq -s -e --argjson response_id "$response_id" \
+      'any(.[]; .id? == $response_id)' "$response_file" >/dev/null 2>&1; then
+      return 0
+    fi
+    kill -0 "$server_pid" 2>/dev/null || return 1
+    sleep 1
+    waited=$((waited + 1))
+  done
+  return 1
+}
+
+# Current consumer: codex_json below. This bounded FIFO exchange prevents the
+# 0.147 app-server from receiving account requests before initialization has
+# completed, replacing the former fire-and-forget three-line pipe.
+codex_app_server_exchange() (
+  local rpc_dir request_fifo response_file error_file server_pid="" rpc_timeout response
+  [ -n "$CODEX_CLI" ] && [ -x "$CODEX_CLI" ] || {
+    jq -cn '{state:"closed",reason:"rate_limit_probe_no_response"}'
+    exit 0
+  }
+  rpc_timeout="${MODEL_ROUTER_CODEX_RPC_TIMEOUT:-15}"
+  case "$rpc_timeout" in ''|*[!0-9]*|0) rpc_timeout=15 ;; esac
+  [ "$rpc_timeout" -le 30 ] || rpc_timeout=30
+  rpc_dir="$(mktemp -d "${TMPDIR:-/tmp}/codex-rate-limit-rpc.XXXXXX")" || {
+    jq -cn '{state:"closed",reason:"rate_limit_probe_no_response"}'
+    exit 0
+  }
+  request_fifo="$rpc_dir/request"
+  response_file="$rpc_dir/response"
+  error_file="$rpc_dir/error"
+  : > "$response_file"
+  : > "$error_file"
+  mkfifo "$request_fifo" || {
+    rm -rf "$rpc_dir"
+    jq -cn '{state:"closed",reason:"rate_limit_probe_no_response"}'
+    exit 0
+  }
+  cleanup_codex_rpc() {
+    exec 3>&- 2>/dev/null || true
+    if [ -n "$server_pid" ] && kill -0 "$server_pid" 2>/dev/null; then
+      kill -TERM "$server_pid" 2>/dev/null || true
+      sleep 1
+      kill -KILL "$server_pid" 2>/dev/null || true
+    fi
+    [ -z "$server_pid" ] || wait "$server_pid" 2>/dev/null || true
+    rm -rf "$rpc_dir"
+  }
+  trap cleanup_codex_rpc EXIT
+  trap 'exit 130' HUP INT TERM
+
+  "$CODEX_CLI" app-server --stdio < "$request_fifo" > "$response_file" 2> "$error_file" &
+  server_pid=$!
+  exec 3> "$request_fifo" || {
+    jq -cn '{state:"closed",reason:"rate_limit_probe_no_response"}'
+    exit 0
+  }
+  printf '%s\n' '{"method":"initialize","id":0,"params":{"clientInfo":{"name":"depot-usage-probe","title":"Depot usage probe","version":"1"},"capabilities":{"experimentalApi":true}}}' >&3
+  if ! wait_for_rpc_response "$response_file" 0 "$server_pid" "$rpc_timeout"; then
+    jq -cn '{state:"closed",reason:"rate_limit_probe_no_response"}'
+    exit 0
+  fi
+  response="$(jq -sc 'map(select(.id? == 0)) | last' "$response_file" 2>/dev/null)" || response=""
+  if ! printf '%s' "$response" | jq -e \
+    'type == "object" and .id == 0 and (.result | type) == "object" and (.error? == null)' >/dev/null 2>&1; then
+    jq -cn '{state:"closed",reason:"rate_limit_response_malformed"}'
+    exit 0
+  fi
+
+  printf '%s\n' \
+    '{"method":"initialized","params":{}}' \
+    '{"method":"account/rateLimits/read","id":7,"params":{}}' >&3
+  if ! wait_for_rpc_response "$response_file" 7 "$server_pid" "$rpc_timeout"; then
+    jq -cn '{state:"closed",reason:"rate_limit_probe_no_response"}'
+    exit 0
+  fi
+  response="$(jq -sc 'map(select(.id? == 7)) | last' "$response_file" 2>/dev/null)" || response=""
+  if ! printf '%s' "$response" | jq -e \
+    'type == "object" and .id == 7 and (.result | type) == "object" and (.error? == null)' >/dev/null 2>&1; then
+    jq -cn '{state:"closed",reason:"rate_limit_response_malformed"}'
+    exit 0
+  fi
+  jq -cn --argjson response "$response" '{state:"response",response:$response}'
+)
+
+normalize_codex_snapshot() {
+  local snapshot="$1"
+  printf '%s' "$snapshot" | jq -c --argjson threshold "$THRESHOLD" '
+    def closed($reason): {state:"unknown",reason:$reason};
+    if type != "object" then closed("rate_limit_response_malformed")
+    else
+      [.primary?, .secondary?]
+      | map(select(. != null)) as $raw
+      | if any($raw[]; type != "object"
+          or (.usedPercent | type) != "number"
+          or .usedPercent < 0 or .usedPercent > 100
+          or (.windowDurationMins | type) != "number") then
+          closed("rate_limit_response_malformed")
+        else
+          [$raw[] | {
+            window:(if .windowDurationMins == 300 then "five_hour"
+                    elif .windowDurationMins == 10080 then "weekly"
+                    else "unsupported" end),
+            remaining:(100 - .usedPercent)
+          }] as $windows
+          | if any($windows[]; .window == "unsupported")
+              or ([$windows[] | select(.window == "five_hour")] | length) != 1
+              or ([$windows[] | select(.window == "weekly")] | length) != 1 then
+              closed("required_window_missing")
+            elif any($windows[]; .remaining <= $threshold) then
+              {state:"limited",reason:"rate_limit_exhausted"}
+            else
+              {state:"ok",reason:"available"}
+            end
+        end
+    end'
 }
 
 codex_json() {
-  local out="" observations='[]' auth_mode="unknown" state="unknown" windows
+  local exchange='{}' response='{}' result='{}' auth_mode="unknown" state="unknown"
+  local reason="rate_limit_probe_no_response" allowances='{}' map_type="" entry key normalized
+  local default_allowance_id=""
   if [ -n "$CODEX_CLI" ] && [ -x "$CODEX_CLI" ]; then
     login="$(run_bounded 10 "$CODEX_CLI" login status 2>/dev/null)" || login=""
     case "$login" in *'Logged in using ChatGPT'*) auth_mode="subscription" ;; *'API key'*) auth_mode="api" ;; esac
   fi
-  if out="$(codex_app_server_output)"; then
-    if [ -n "$out" ]; then
-      observations="$(printf '%s\n' "$out" | jq -sc '
-        (map(select(.id == 7 and .result.rateLimits != null)) | last
-          | .result.rateLimits // {}) as $limits
-        | [$limits.primary, $limits.secondary]
-        | map(select(type == "object"
-            and (.usedPercent | type) == "number"
-            and (.windowDurationMins | type) == "number")
-          | {window:(if .windowDurationMins == 300 then "five_hour"
-                     elif .windowDurationMins == 10080 then "weekly"
-                     else ("window_" + (.windowDurationMins | tostring) + "m") end),
-             remaining_pct:([0, (100 - .usedPercent), 100] | sort | .[1])})
-      ' 2>/dev/null)" || observations='[]'
+  exchange="$(codex_app_server_exchange)" || exchange='{"state":"closed","reason":"rate_limit_probe_no_response"}'
+  if [ "$(printf '%s' "$exchange" | jq -r '.state // "closed"')" != response ]; then
+    reason="$(printf '%s' "$exchange" | jq -r '.reason // "rate_limit_probe_no_response"')"
+  else
+    response="$(printf '%s' "$exchange" | jq -c '.response')"
+    result="$(printf '%s' "$response" | jq -c '.result')"
+    map_type="$(printf '%s' "$result" | jq -r 'if has("rateLimitsByLimitId") then (.rateLimitsByLimitId | type) else "absent" end')"
+    if [ "$map_type" = object ]; then
+      if [ "$(printf '%s' "$result" | jq '.rateLimitsByLimitId | length')" -eq 0 ] ||
+         ! printf '%s' "$result" | jq -e '
+           .rateLimitsByLimitId
+           | all(to_entries[]; (.value | type) == "object"
+               and (.value.limitId | type) == "string"
+               and .value.limitId == .key)' >/dev/null 2>&1; then
+        reason="rate_limit_response_malformed"
+      else
+        while IFS= read -r entry; do
+          key="$(printf '%s' "$entry" | jq -r '.key')"
+          normalized="$(normalize_codex_snapshot "$(printf '%s' "$entry" | jq -c '.value')")"
+          allowances="$(printf '%s' "$allowances" | jq -c --arg key "$key" --argjson value "$normalized" '. + {($key):$value}')"
+        done <<EOF
+$(printf '%s' "$result" | jq -c '.rateLimitsByLimitId | to_entries[]')
+EOF
+        if printf '%s' "$allowances" | jq -e 'any(to_entries[]; .value.reason == "rate_limit_response_malformed")' >/dev/null; then
+          reason="rate_limit_response_malformed"
+        elif [ "$(printf '%s' "$allowances" | jq 'length')" -eq 1 ]; then
+          # A single returned bucket is unambiguous. Multiple 0.147 buckets
+          # require an authoritative candidate mapping at dispatch time; the
+          # app-server does not currently expose that join.
+          default_allowance_id="$(printf '%s' "$allowances" | jq -r 'keys[0]')"
+          state="$(printf '%s' "$allowances" | jq -r --arg key "$default_allowance_id" '.[$key].state')"
+          reason="$(printf '%s' "$allowances" | jq -r --arg key "$default_allowance_id" '.[$key].reason')"
+        else
+          reason="rate_limit_mapping_unknown"
+        fi
+      fi
+    elif [ "$map_type" != absent ] && [ "$map_type" != null ]; then
+      reason="rate_limit_response_malformed"
+    elif printf '%s' "$result" | jq -e '(.rateLimits | type) == "object"' >/dev/null 2>&1; then
+      normalized="$(normalize_codex_snapshot "$(printf '%s' "$result" | jq -c '.rateLimits')")"
+      allowances="$(jq -cn --argjson normalized "$normalized" '{codex:$normalized}')"
+      default_allowance_id="codex"
+      state="$(printf '%s' "$normalized" | jq -r '.state')"
+      reason="$(printf '%s' "$normalized" | jq -r '.reason')"
+    else
+      reason="rate_limit_shape_unsupported"
     fi
   fi
-  [ -n "$observations" ] || observations='[]'
-  windows="$(aggregate_windows '["five_hour","weekly"]' "$observations")"
-  [ "$auth_mode" = subscription ] && [ "$(printf '%s' "$windows" | jq -r '.state')" = ok ] && state=ok
-  printf '%s' "$windows" | jq -c --arg state "$state" --arg auth_mode "$auth_mode" \
-    '. + {state:$state,authMode:$auth_mode}'
+  [ "$auth_mode" = subscription ] || state=unknown
+  jq -cn --arg state "$state" --arg auth_mode "$auth_mode" --arg reason "$reason" \
+    --arg default_allowance_id "$default_allowance_id" --argjson allowances "$allowances" \
+    '{state:$state,authMode:$auth_mode,reason:$reason,allowances:$allowances,
+      allowanceCount:($allowances | length)}
+      + if $default_allowance_id == "" then {} else {defaultAllowanceId:$default_allowance_id} end'
 }
 
 openrouter_json() {

--- a/plugins/model-router/skills/model-router/references/receipt-contract.md
+++ b/plugins/model-router/skills/model-router/references/receipt-contract.md
@@ -5,6 +5,13 @@ contains request role and effort, anonymous participant ID, requested and
 effective effort, attempted candidates, served model/provider/transport,
 billing mode, duration, token and cost provenance, fallback reason, matrix
 snapshot, and family-independence result. It contains no prompt or model output.
+Availability/fallback reasons are limited to router-authored content-safe codes,
+including `rate_limit_probe_no_response`, `rate_limit_response_malformed`,
+`rate_limit_shape_unsupported`, `rate_limit_mapping_unknown`,
+`required_window_missing`, `rate_limit_exhausted`,
+`browser_transport_unavailable`, and `model_participant_unavailable`. They
+never contain raw CLI/provider output, account identity, quota balances,
+credentials, prompts, or private paths.
 
 The ordinary caller sees only role, normalized capabilities, requested and
 effective effort, anonymous participant ID, disposition, fallback state, and

--- a/plugins/model-router/skills/model-router/references/role-dispatch.sh
+++ b/plugins/model-router/skills/model-router/references/role-dispatch.sh
@@ -191,6 +191,11 @@ TRANSPORT_STUB=false
 
 ATTEMPTS='[]'
 LAST_REASON="none"
+if printf '%s' "$CAPABILITIES_JSON" | jq -e 'index("browser") != null' >/dev/null; then
+  # No current one-shot transport can prove access to the caller's local
+  # interactive browser. Browser interaction remains host-owned.
+  LAST_REASON="browser_transport_unavailable"
+fi
 ATTEMPT_INDEX=0
 EXHAUSTED_TRANSPORTS='[]'
 EXHAUSTED_MODELS='[]'
@@ -227,18 +232,56 @@ candidate_has_capabilities() {
 }
 
 transport_eligibility() {
-  local transport="$1" model="$2" state auth_mode plan fable_state observed sdk_observed five weekly paid
+  local transport="$1" model="$2" rate_limit_id="${3:-}" state auth_mode plan fable_state observed sdk_observed five weekly paid allowance_reason
   BILLING_MODE="unavailable"
   ALLOWANCE_WINDOW="unavailable"
+  ELIGIBILITY_REASON="model_participant_unavailable"
   case "$transport" in
     codex-cli)
-      state="$(printf '%s' "$AVAILABILITY" | jq -r '.codex.state // "unknown"')"
+      if [ -z "$rate_limit_id" ]; then
+        rate_limit_id="$(printf '%s' "$AVAILABILITY" | jq -r '.codex.defaultAllowanceId // empty')"
+        # Pre-0.3 fixture/observation files had one implicit legacy Codex
+        # bucket and no allowances object. Preserve that closed single-bucket
+        # interpretation without applying it to a 0.147 multi-bucket result.
+        if [ -z "$rate_limit_id" ] &&
+           [ "$(printf '%s' "$AVAILABILITY" | jq -r '.codex.allowances? | type')" != object ]; then
+          rate_limit_id="codex"
+        fi
+      fi
+      [ -n "$rate_limit_id" ] || {
+        ELIGIBILITY_REASON="rate_limit_mapping_unknown"
+        return 1
+      }
+      if [ "$(printf '%s' "$AVAILABILITY" | jq -r '.codex.allowances? | type')" = object ]; then
+        if ! printf '%s' "$AVAILABILITY" | jq -e --arg limit_id "$rate_limit_id" \
+          '.codex.allowances | has($limit_id)' >/dev/null 2>&1; then
+          ELIGIBILITY_REASON="rate_limit_mapping_unknown"
+          return 1
+        fi
+        state="$(printf '%s' "$AVAILABILITY" | jq -r --arg limit_id "$rate_limit_id" '.codex.allowances[$limit_id].state')"
+        allowance_reason="$(printf '%s' "$AVAILABILITY" | jq -r --arg limit_id "$rate_limit_id" '.codex.allowances[$limit_id].reason')"
+      else
+        [ "$rate_limit_id" = codex ] || {
+          ELIGIBILITY_REASON="rate_limit_mapping_unknown"
+          return 1
+        }
+        state="$(printf '%s' "$AVAILABILITY" | jq -r '.codex.state // "unknown"')"
+        allowance_reason="$(printf '%s' "$AVAILABILITY" | jq -r '.codex.reason // "rate_limit_mapping_unknown"')"
+      fi
       auth_mode="$(printf '%s' "$AVAILABILITY" | jq -r '.codex.authMode // .codex.auth_mode // "unknown"')"
-      five="$(printf '%s' "$AVAILABILITY" | jq -r '.codex.windows.five_hour.remaining_pct // .codex.fiveHourRemainingPct // 0')"
-      weekly="$(printf '%s' "$AVAILABILITY" | jq -r '.codex.windows.weekly.remaining_pct // .codex.weeklyRemainingPct // 0')"
-      [ "$state" = ok ] && [ "$auth_mode" = subscription ] && awk -v a="$five" -v b="$weekly" -v t="$THRESHOLD" 'BEGIN{exit !(a>t && b>t)}' || return 1
+      if [ "$state" != ok ] || [ "$auth_mode" != subscription ]; then
+        [ "$state" != limited ] || allowance_reason="rate_limit_exhausted"
+        case "$allowance_reason" in
+          rate_limit_probe_no_response|rate_limit_response_malformed|rate_limit_shape_unsupported|rate_limit_mapping_unknown|required_window_missing|rate_limit_exhausted)
+            ELIGIBILITY_REASON="$allowance_reason"
+            ;;
+          *) ELIGIBILITY_REASON="model_participant_unavailable" ;;
+        esac
+        return 1
+      fi
       BILLING_MODE="included-subscription"
-      ALLOWANCE_WINDOW="subscription"
+      ALLOWANCE_WINDOW="$rate_limit_id"
+      ELIGIBILITY_REASON="available"
       ;;
     claude-cli)
       state="$(printf '%s' "$AVAILABILITY" | jq -r '.claude.state // "unknown"')"
@@ -306,7 +349,7 @@ resolve_openrouter_root() {
 }
 
 invoke_candidate() {
-  local transport="$1" model="$2" effective="$3" rc=0 root system_file prompt_copy result_json sandbox web_search=0
+  local transport="$1" model="$2" effective="$3" rc=0 root system_file prompt_copy result_json sandbox
   : > "$TRANSPORT_OUTPUT"
   : > "$PROVIDER_RECEIPT"
   if [ -n "${MODEL_ROUTER_TRANSPORT_STUB:-}" ]; then
@@ -372,9 +415,8 @@ invoke_candidate() {
         argv=("$root/skills/openrouter-delegate/references/delegation-boundary.sh" --mode artifact-delegation --policy "$root/skills/openrouter-delegate/references/delegation-security-policy.json" --content-file "$system_file" --content-file "$prompt_copy")
         "${argv[@]}" >>"$PRIVATE_LOG" 2>&1 || { rm -f "$system_file" "$prompt_copy"; return 77; }
         argv=(bash "$root/skills/openrouter-delegate/references/openrouter-wrapper.sh" "$model" - 3600)
-        printf '%s' "$CAPABILITIES_JSON" | jq -e 'index("browser") != null' >/dev/null && web_search=1
         env -u OPENROUTER_SYSTEM OPENROUTER_SYSTEM_FILE="$system_file" \
-          OPENROUTER_WORKLOAD=mechanical OPENROUTER_WEB_SEARCH="$web_search" \
+          OPENROUTER_WORKLOAD=mechanical OPENROUTER_WEB_SEARCH=0 \
           OPENROUTER_RECEIPT_FILE="$PROVIDER_RECEIPT" "${argv[@]}" \
           < "$prompt_copy" > "$TRANSPORT_OUTPUT" 2>>"$PRIVATE_LOG"
         rc=$?
@@ -404,13 +446,14 @@ while IFS= read -r candidate; do
   transport="$(printf '%s' "$candidate" | jq -r '.transport')"
   model="$(printf '%s' "$candidate" | jq -r '.model')"
   provider="$(printf '%s' "$candidate" | jq -r '.provider')"
+  rate_limit_id="$(printf '%s' "$candidate" | jq -r '.rateLimitId // empty')"
   if printf '%s' "$EXHAUSTED_TRANSPORTS" | jq -e --arg value "$transport" 'index($value) != null' >/dev/null ||
      printf '%s' "$EXHAUSTED_MODELS" | jq -e --arg value "$model" 'index($value) != null' >/dev/null; then
     continue
   fi
   ATTEMPT_INDEX=$((ATTEMPT_INDEX + 1))
-  if ! transport_eligibility "$transport" "$model"; then
-    reason="unavailable"
+  if ! transport_eligibility "$transport" "$model" "$rate_limit_id"; then
+    reason="$ELIGIBILITY_REASON"
     ATTEMPTS="$(printf '%s' "$ATTEMPTS" | jq -c --arg model "$model" --arg provider "$provider" --arg transport "$transport" --arg reason "$reason" '. + [{model:$model,provider:$provider,transport:$transport,outcome:"skipped",reason:$reason}]')"
     LAST_REASON="$reason"
     continue

--- a/plugins/model-router/skills/model-router/references/role-policy.json
+++ b/plugins/model-router/skills/model-router/references/role-policy.json
@@ -29,8 +29,8 @@
       {"model": "gpt-5.6-luna", "provider": "openai", "transport": "codex-cli", "family": "openai", "billing": "included-subscription", "capabilities": ["read-repository", "write-repository", "tool-use", "structured-output"]}
     ],
     "builder-deep": [
-      {"model": "gpt-5.6-sol", "provider": "openai", "transport": "codex-cli", "family": "openai", "billing": "included-subscription", "capabilities": ["read-repository", "write-repository", "tool-use", "browser", "long-context", "structured-output"]},
-      {"model": "gpt-5.6-terra", "provider": "openai", "transport": "codex-cli", "family": "openai", "billing": "included-subscription", "capabilities": ["read-repository", "write-repository", "tool-use", "browser", "long-context", "structured-output"]},
+      {"model": "gpt-5.6-sol", "provider": "openai", "transport": "codex-cli", "family": "openai", "billing": "included-subscription", "capabilities": ["read-repository", "write-repository", "tool-use", "long-context", "structured-output"]},
+      {"model": "gpt-5.6-terra", "provider": "openai", "transport": "codex-cli", "family": "openai", "billing": "included-subscription", "capabilities": ["read-repository", "write-repository", "tool-use", "long-context", "structured-output"]},
       {"model": "deepseek/deepseek-v4-pro-0813", "provider": "openrouter", "transport": "openrouter", "family": "deepseek", "billing": "api", "capabilities": ["read-repository", "write-repository", "long-context", "structured-output"]},
       {"model": "x-ai/grok-4.6", "provider": "openrouter", "transport": "openrouter", "family": "x-ai", "billing": "api", "capabilities": ["read-repository", "write-repository", "long-context", "structured-output"]}
     ],
@@ -51,8 +51,8 @@
       {"model": "gpt-5.6-terra", "provider": "openai", "transport": "codex-cli", "family": "openai", "billing": "included-subscription", "capabilities": ["read-repository", "tool-use", "long-context", "structured-output", "independent-family"]}
     ],
     "research-fast": [
-      {"model": "google/gemini-3.7-flash", "provider": "openrouter", "transport": "openrouter", "family": "google", "billing": "api", "capabilities": ["read-repository", "browser", "long-context", "structured-output"]},
-      {"model": "gpt-5.6-luna", "provider": "openai", "transport": "codex-cli", "family": "openai", "billing": "included-subscription", "capabilities": ["read-repository", "tool-use", "browser", "structured-output"]}
+      {"model": "google/gemini-3.7-flash", "provider": "openrouter", "transport": "openrouter", "family": "google", "billing": "api", "capabilities": ["read-repository", "long-context", "structured-output"]},
+      {"model": "gpt-5.6-luna", "provider": "openai", "transport": "codex-cli", "family": "openai", "billing": "included-subscription", "capabilities": ["read-repository", "tool-use", "structured-output"]}
     ],
     "editorial": [
       {"model": "fable", "provider": "anthropic", "transport": "claude-cli", "family": "anthropic", "billing": "subscription-or-local-paid-credits", "capabilities": ["long-context", "structured-output"]},

--- a/tools/test-dm-review-ui-readiness.sh
+++ b/tools/test-dm-review-ui-readiness.sh
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+HELPER="$ROOT/plugins/dm-review/skills/review/references/ui-review-readiness.sh"
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/dm-review-ui-readiness.XXXXXX")"
+trap 'rm -rf "$TMP"' EXIT
+REPO="$TMP/repository"
+mkdir -p "$REPO/.dm" "$REPO/tools"
+git -C "$REPO" init -q
+
+pass=0
+assert() { "$@" >/dev/null || { printf 'FAIL: %s\n' "$*" >&2; exit 1; }; pass=$((pass + 1)); }
+
+cat > "$REPO/tools/ui-review-ready" <<'STUB'
+#!/usr/bin/env bash
+[ -f "$TEST_SERVER_MARKER" ]
+STUB
+cat > "$REPO/tools/ui-review-start" <<'STUB'
+#!/usr/bin/env bash
+printf '%s\n' start >> "$TEST_RESOURCE_LOG"
+touch "$TEST_SERVER_MARKER"
+STUB
+cat > "$REPO/tools/ui-review-stop" <<'STUB'
+#!/usr/bin/env bash
+printf '%s\n' cleanup >> "$TEST_RESOURCE_LOG"
+rm -f "$TEST_SERVER_MARKER"
+STUB
+cat > "$REPO/tools/ui-review-wrong-stop" <<'STUB'
+#!/usr/bin/env bash
+printf '%s\n' wrong-cleanup >> "$TEST_RESOURCE_LOG"
+STUB
+chmod +x "$REPO"/tools/ui-review-*
+git -C "$REPO" add tools
+git -C "$REPO" -c user.name=test -c user.email=test@example.invalid commit -qm fixture
+
+export TEST_SERVER_MARKER="$TMP/server-ready"
+export TEST_RESOURCE_LOG="$TMP/resources.log"
+: > "$TEST_RESOURCE_LOG"
+
+run_prepare() {
+  local name="$1" rc=0
+  rm -f "$TMP/$name.state" "$TMP/$name.result"
+  "$HELPER" prepare --repository-root "$REPO" --state-file "$TMP/$name.state" \
+    > "$TMP/$name.result" || rc=$?
+  printf '%s\n' "$rc"
+}
+
+run_confirm() {
+  local name="$1" browser_file="$2" rc=0
+  "$HELPER" confirm-browser --repository-root "$REPO" --state-file "$TMP/$name.state" \
+    --browser-evidence-file "$browser_file" > "$TMP/$name.confirmed" || rc=$?
+  printf '%s\n' "$rc"
+}
+
+# No declaration means no guessed localhost scan and no participant dispatch.
+no_decl_rc="$(run_prepare no-declaration)"
+assert test "$no_decl_rc" -eq 76
+assert jq -e '.dispatchAllowed == false and .reason == "dev_server_unavailable" and .reviewDisposition == "REVIEW INCOMPLETE"' "$TMP/no-declaration.result"
+
+cat > "$REPO/.dm/ui-review.json" <<'JSON'
+{
+  "schemaVersion": 1,
+  "targetUrl": "http://localhost:8080/review",
+  "readiness": {
+    "argv": ["./tools/ui-review-ready"],
+    "attempts": 2,
+    "timeoutSeconds": 2
+  },
+  "start": {
+    "resourceKind": "process",
+    "argv": ["./tools/ui-review-start"],
+    "cleanupArgv": ["./tools/ui-review-stop"],
+    "timeoutSeconds": 2
+  }
+}
+JSON
+git -C "$REPO" add .dm/ui-review.json
+git -C "$REPO" -c user.name=test -c user.email=test@example.invalid commit -qm declaration
+
+# Fractional retry/timeout values are rejected before Bash integer loops.
+jq '.readiness.attempts = 1.5' "$REPO/.dm/ui-review.json" > "$TMP/fractional.json"
+cp "$TMP/fractional.json" "$REPO/.dm/ui-review.json"
+fractional_rc="$(run_prepare fractional)"
+assert test "$fractional_rc" -eq 76
+assert jq -e '.reason == "dev_server_unavailable" and .dispatchAllowed == false' "$TMP/fractional.result"
+git -C "$REPO" show HEAD:.dm/ui-review.json > "$REPO/.dm/ui-review.json"
+
+cat > "$TMP/browser-ready.json" <<'JSON'
+{"schemaVersion":1,"status":"ready","transportClass":"local-interactive","localNavigation":"confirmed","targetUrl":"http://localhost:8080/review","evidenceRef":"review/browser/navigation.json"}
+JSON
+cat > "$TMP/browser-web-search.json" <<'JSON'
+{"schemaVersion":1,"status":"ready","transportClass":"remote-web-search","localNavigation":"confirmed","targetUrl":"http://localhost:8080/review","evidenceRef":"review/browser/navigation.json"}
+JSON
+
+# A server started by the review is cleaned immediately when the local browser
+# is unavailable. Remote web search never satisfies the browser gate.
+web_prepare_rc="$(run_prepare remote-web)"
+assert test "$web_prepare_rc" -eq 0
+assert jq -e '.state == "app_ready" and .dispatchAllowed == false and .reason == "browser_evidence_required"' "$TMP/remote-web.result"
+assert test -e "$TEST_SERVER_MARKER"
+"$HELPER" prepare --repository-root "$REPO" --state-file "$TMP/remote-web.state" \
+  > "$TMP/remote-web-reprepare.result"
+assert jq -e '.createdResources == 1 and .dispatchAllowed == false' "$TMP/remote-web-reprepare.result"
+assert jq -e '.createdByReview == true and .cleanupPending == true and .stage == "app_ready"' "$TMP/remote-web.state"
+assert test "$(grep -c '^start$' "$TEST_RESOURCE_LOG")" -eq 1
+web_rc="$(run_confirm remote-web "$TMP/browser-web-search.json")"
+assert test "$web_rc" -eq 76
+assert jq -e '.dispatchAllowed == false and .reason == "browser_transport_unavailable"' "$TMP/remote-web.confirmed"
+assert test "$(grep -c '^start$' "$TEST_RESOURCE_LOG")" -eq 1
+assert test "$(grep -c '^cleanup$' "$TEST_RESOURCE_LOG")" -eq 1
+assert test ! -e "$TEST_SERVER_MARKER"
+
+# A pre-existing ready server remains untouched when browser readiness fails.
+touch "$TEST_SERVER_MARKER"
+preexisting_prepare_rc="$(run_prepare preexisting)"
+assert test "$preexisting_prepare_rc" -eq 0
+preexisting_rc="$(run_confirm preexisting "$TMP/missing-browser.json")"
+assert test "$preexisting_rc" -eq 76
+assert jq -e '.reason == "browser_transport_unavailable" and .dispatchAllowed == false' "$TMP/preexisting.confirmed"
+assert test "$(grep -c '^start$' "$TEST_RESOURCE_LOG")" -eq 1
+assert test "$(grep -c '^cleanup$' "$TEST_RESOURCE_LOG")" -eq 1
+assert test -e "$TEST_SERVER_MARKER"
+
+# Server plus real local browser permits the provider-neutral analysis lane.
+ready_prepare_rc="$(run_prepare ready)"
+assert test "$ready_prepare_rc" -eq 0
+ready_rc="$(run_confirm ready "$TMP/browser-ready.json")"
+assert test "$ready_rc" -eq 0
+assert jq -e '.state == "ready" and .dispatchAllowed == true and .browserTransport == "local-interactive"' "$TMP/ready.confirmed"
+cat > "$TMP/participant-completed.json" <<'JSON'
+{"role":"review-deep","capabilities":["read-repository","long-context","structured-output"],"disposition":"completed","evidenceSource":"live","transportStub":false}
+JSON
+"$HELPER" settle --repository-root "$REPO" --state-file "$TMP/ready.state" \
+  --participant-result-file "$TMP/participant-completed.json" > "$TMP/ready-settled.json"
+assert jq -e '.state == "completed" and .dispatchAllowed == false and .cleanup == "complete"' "$TMP/ready-settled.json"
+assert test -e "$TEST_SERVER_MARKER"
+set +e
+"$HELPER" settle --repository-root "$REPO" --state-file "$TMP/ready.state" \
+  --participant-result-file "$TMP/participant-completed.json" >/dev/null 2>&1
+repeated_settle_rc=$?
+set -e
+assert test "$repeated_settle_rc" -eq 2
+
+# Browser evidence can be ready while the analysis participant is unavailable;
+# that cause is distinct, and only the resource created by this run is cleaned.
+rm -f "$TEST_SERVER_MARKER"
+participant_prepare_rc="$(run_prepare participant-unavailable)"
+assert test "$participant_prepare_rc" -eq 0
+participant_ready_rc="$(run_confirm participant-unavailable "$TMP/browser-ready.json")"
+assert test "$participant_ready_rc" -eq 0
+assert jq -e '.createdResources == 1 and .dispatchAllowed == true' "$TMP/participant-unavailable.confirmed"
+cat > "$TMP/participant-unavailable.json" <<'JSON'
+{"role":"review-deep","capabilities":["read-repository","long-context","structured-output"],"disposition":"unavailable","evidenceSource":"live","transportStub":false}
+JSON
+set +e
+"$HELPER" settle --repository-root "$REPO" --state-file "$TMP/participant-unavailable.state" \
+  --participant-result-file "$TMP/participant-unavailable.json" > "$TMP/participant-unavailable-settled.json"
+settle_rc=$?
+set -e
+assert test "$settle_rc" -eq 76
+assert jq -e '.reason == "model_participant_unavailable" and .reviewDisposition == "REVIEW INCOMPLETE"' "$TMP/participant-unavailable-settled.json"
+assert test "$(grep -c '^start$' "$TEST_RESOURCE_LOG")" -eq 2
+assert test "$(grep -c '^cleanup$' "$TEST_RESOURCE_LOG")" -eq 2
+assert test ! -e "$TEST_SERVER_MARKER"
+
+# Successful created-resource path also performs exactly one cleanup.
+completed_prepare_rc="$(run_prepare completed-created)"
+assert test "$completed_prepare_rc" -eq 0
+jq '.start.cleanupArgv = ["./tools/ui-review-wrong-stop"]' "$REPO/.dm/ui-review.json" > "$TMP/changed-declaration.json"
+cp "$TMP/changed-declaration.json" "$REPO/.dm/ui-review.json"
+completed_ready_rc="$(run_confirm completed-created "$TMP/browser-ready.json")"
+assert test "$completed_ready_rc" -eq 0
+"$HELPER" settle --repository-root "$REPO" --state-file "$TMP/completed-created.state" \
+  --participant-result-file "$TMP/participant-completed.json" > "$TMP/completed-created-settled.json"
+assert jq -e '.state == "completed" and .cleanup == "complete"' "$TMP/completed-created-settled.json"
+assert test "$(grep -c '^start$' "$TEST_RESOURCE_LOG")" -eq 3
+assert test "$(grep -c '^cleanup$' "$TEST_RESOURCE_LOG")" -eq 3
+assert test "$(grep -c '^wrong-cleanup$' "$TEST_RESOURCE_LOG" || true)" -eq 0
+assert test ! -e "$TEST_SERVER_MARKER"
+
+# Cleanup is idempotent and reports what this invocation actually removed.
+"$HELPER" cleanup --repository-root "$REPO" --state-file "$TMP/completed-created.state" \
+  > "$TMP/already-clean.json"
+assert jq -e '.state == "already_clean" and .removedCount == 0' "$TMP/already-clean.json"
+
+printf 'dm-review-ui-readiness: %d assertions passed\n' "$pass"

--- a/tools/test-model-router.sh
+++ b/tools/test-model-router.sh
@@ -94,7 +94,48 @@ cat > "$TMP/bin/codex" <<'STUB'
 case "${1:-}:${2:-}" in
   login:status) printf '%s\n' 'Logged in using ChatGPT' ;;
   app-server:--stdio)
-    printf '%s\n' '{"id":7,"result":{"rateLimits":{"primary":{"usedPercent":20,"windowDurationMins":300},"secondary":{"usedPercent":25,"windowDurationMins":10080}}}}'
+    initialized=0
+    while IFS= read -r request; do
+      method="$(printf '%s' "$request" | jq -r '.method // empty')"
+      [ -z "${MODEL_ROUTER_CODEX_RPC_LOG:-}" ] || printf '%s\n' "$method" >> "$MODEL_ROUTER_CODEX_RPC_LOG"
+      case "$method" in
+        initialize)
+          [ "${MODEL_ROUTER_CODEX_FIXTURE:-legacy}" = init-no-response ] ||
+            printf '%s\n' '{"id":0,"result":{"serverInfo":{"name":"fixture"}}}'
+          ;;
+        initialized) initialized=1 ;;
+        account/rateLimits/read)
+          [ "$initialized" -eq 1 ] || exit 91
+          case "${MODEL_ROUTER_CODEX_FIXTURE:-legacy}" in
+            rate-no-response) : ;;
+            legacy)
+              printf '%s\n' '{"id":7,"result":{"rateLimits":{"primary":{"usedPercent":20,"windowDurationMins":300},"secondary":{"usedPercent":25,"windowDurationMins":10080}}}}'
+              ;;
+            v147)
+              printf '%s\n' '{"id":7,"result":{"rateLimits":{"limitId":"codex","primary":null,"secondary":{"usedPercent":25,"windowDurationMins":10080}},"rateLimitsByLimitId":{"codex":{"limitId":"codex","limitName":null,"primary":null,"secondary":{"usedPercent":25,"windowDurationMins":10080}},"codex_named":{"limitId":"codex_named","limitName":"Named","primary":{"usedPercent":20,"windowDurationMins":300},"secondary":{"usedPercent":25,"windowDurationMins":10080}},"codex_other":{"limitId":"codex_other","limitName":"Other","primary":{"usedPercent":95,"windowDurationMins":300},"secondary":{"usedPercent":95,"windowDurationMins":10080}}}}}'
+              ;;
+            exhausted)
+              printf '%s\n' '{"id":7,"result":{"rateLimits":{"limitId":"codex","primary":null,"secondary":{"usedPercent":25,"windowDurationMins":10080}},"rateLimitsByLimitId":{"codex":{"limitId":"codex","primary":{"usedPercent":95,"windowDurationMins":300},"secondary":{"usedPercent":25,"windowDurationMins":10080}}}}}'
+              ;;
+            multiple-no-best)
+              printf '%s\n' '{"id":7,"result":{"rateLimits":{"limitId":"codex","primary":null,"secondary":{"usedPercent":25,"windowDurationMins":10080}},"rateLimitsByLimitId":{"codex":{"limitId":"codex","primary":{"usedPercent":95,"windowDurationMins":300},"secondary":{"usedPercent":25,"windowDurationMins":10080}},"codex_other":{"limitId":"codex_other","limitName":"Other","primary":{"usedPercent":1,"windowDurationMins":300},"secondary":{"usedPercent":1,"windowDurationMins":10080}}}}}'
+              ;;
+            unknown-mapping)
+              printf '%s\n' '{"id":7,"result":{"rateLimits":{"limitId":"codex","primary":null,"secondary":{"usedPercent":25,"windowDurationMins":10080}},"rateLimitsByLimitId":{"codex_other":{"limitId":"codex_other","limitName":"Other","primary":{"usedPercent":20,"windowDurationMins":300},"secondary":{"usedPercent":25,"windowDurationMins":10080}},"codex_extra":{"limitId":"codex_extra","limitName":"Extra","primary":{"usedPercent":20,"windowDurationMins":300},"secondary":{"usedPercent":25,"windowDurationMins":10080}}}}}'
+              ;;
+            malformed-map)
+              printf '%s\n' '{"id":7,"result":{"rateLimits":{"limitId":"codex"},"rateLimitsByLimitId":{"codex":{"limitId":"wrong","primary":{"usedPercent":20,"windowDurationMins":300},"secondary":{"usedPercent":25,"windowDurationMins":10080}}}}}'
+              ;;
+            unsupported)
+              printf '%s\n' '{"id":7,"result":{"futureLimits":{}}}'
+              ;;
+            missing-window)
+              printf '%s\n' '{"id":7,"result":{"rateLimits":{"limitId":"codex"},"rateLimitsByLimitId":{"codex":{"limitId":"codex","primary":null,"secondary":{"usedPercent":25,"windowDurationMins":10080}}}}}'
+              ;;
+          esac
+          ;;
+      esac
+    done
     ;;
   exec:*)
     output=""
@@ -130,10 +171,49 @@ cat > "$TMP/claude-telemetry.json" <<'JSON'
 JSON
 env -u OPENROUTER_API_KEY -u OPENROUTER_API_KEY_FILE \
   PATH="$TMP/bin:$PATH" FAKE_CLAUDE_AUTH=subscription \
+  MODEL_ROUTER_CODEX_FIXTURE=legacy MODEL_ROUTER_CODEX_RPC_LOG="$TMP/codex-rpc.log" \
   MODEL_ROUTER_CLAUDE_RATE_LIMITS_FILE="$TMP/claude-telemetry.json" \
   "$PROBE" > "$TMP/probe-subscription.json"
 if [ "${MODEL_ROUTER_TEST_DEBUG:-0}" = 1 ]; then jq . "$TMP/probe-subscription.json"; fi
 assert jq -e '.codex.authMode == "subscription" and .codex.state == "ok" and .claude.authMode == "subscription" and .claude.agentSdkRateLimitsObserved == true and .claude.allowances.agent_sdk.state == "ok"' "$TMP/probe-subscription.json"
+assert test "$(sed -n '1p' "$TMP/codex-rpc.log")" = initialize
+assert test "$(sed -n '2p' "$TMP/codex-rpc.log")" = initialized
+assert test "$(sed -n '3p' "$TMP/codex-rpc.log")" = account/rateLimits/read
+
+# Codex 0.147 normalizes every structurally valid bucket. The incomplete
+# backward-compatible default window is non-applicable, and multiple buckets
+# stay unmapped unless policy has authoritative candidate metadata.
+for codex_fixture in v147 exhausted multiple-no-best unknown-mapping malformed-map unsupported missing-window; do
+  MODEL_ROUTER_CODEX_FIXTURE="$codex_fixture" MODEL_ROUTER_CODEX_RPC_TIMEOUT=2 \
+    env -u OPENROUTER_API_KEY -u OPENROUTER_API_KEY_FILE PATH="$TMP/bin:$PATH" \
+    FAKE_CLAUDE_AUTH=none "$PROBE" > "$TMP/probe-$codex_fixture.json"
+done
+if [ "${MODEL_ROUTER_TEST_DEBUG:-0}" = 1 ]; then
+  jq . "$TMP"/probe-v147.json "$TMP"/probe-exhausted.json \
+    "$TMP"/probe-unknown-mapping.json "$TMP"/probe-malformed-map.json
+fi
+assert jq -e '.codex.state == "unknown" and .codex.reason == "rate_limit_mapping_unknown" and .codex.allowances.codex.reason == "required_window_missing" and .codex.allowances.codex_named.state == "ok"' "$TMP/probe-v147.json"
+assert jq -e '.codex.state == "limited" and .codex.reason == "rate_limit_exhausted"' "$TMP/probe-exhausted.json"
+assert jq -e '.codex.state == "unknown" and .codex.reason == "rate_limit_mapping_unknown" and .codex.allowances.codex.state == "limited" and .codex.allowances.codex_other.state == "ok"' "$TMP/probe-multiple-no-best.json"
+assert jq -e '.codex.state == "unknown" and .codex.reason == "rate_limit_mapping_unknown" and (has("defaultAllowanceId") | not)' "$TMP/probe-unknown-mapping.json"
+assert jq -e '.codex.state == "unknown" and .codex.reason == "rate_limit_response_malformed"' "$TMP/probe-malformed-map.json"
+assert jq -e '.codex.state == "unknown" and .codex.reason == "rate_limit_shape_unsupported"' "$TMP/probe-unsupported.json"
+assert jq -e '.codex.state == "unknown" and .codex.reason == "required_window_missing"' "$TMP/probe-missing-window.json"
+
+for codex_fixture in init-no-response rate-no-response; do
+  started_at="$(date +%s)"
+  MODEL_ROUTER_CODEX_FIXTURE="$codex_fixture" MODEL_ROUTER_CODEX_RPC_TIMEOUT=2 \
+    env -u OPENROUTER_API_KEY -u OPENROUTER_API_KEY_FILE PATH="$TMP/bin:$PATH" \
+    FAKE_CLAUDE_AUTH=none "$PROBE" > "$TMP/probe-$codex_fixture.json"
+  elapsed=$(( $(date +%s) - started_at ))
+  assert test "$elapsed" -lt 8
+  assert jq -e '.codex.state == "unknown" and .codex.reason == "rate_limit_probe_no_response"' "$TMP/probe-$codex_fixture.json"
+done
+
+# Probe output and downstream receipts expose only normalized state/reasons,
+# never raw account payloads or exact quota balances.
+jq -c '.codex' "$TMP/probe-v147.json" > "$TMP/probe-v147-codex.json"
+assert sh -c "! grep -Eq 'usedPercent|remaining_pct|resetsAt|limitName' '$TMP/probe-v147-codex.json'"
 env -u OPENROUTER_API_KEY -u OPENROUTER_API_KEY_FILE \
   PATH="$TMP/bin:$PATH" FAKE_CLAUDE_AUTH=subscription "$PROBE" > "$TMP/probe-no-telemetry.json"
 assert jq -e '.claude.authMode == "subscription" and .claude.plan == "max" and .claude.state == "unknown" and .claude.rateLimitsObserved == false' "$TMP/probe-no-telemetry.json"
@@ -171,6 +251,59 @@ assert sh -c "! grep -Eq 'deepseek|openrouter|gpt-5|fable|kimi|qwen|grok' '$TMP/
 # Deep work prefers healthy native subscription capacity.
 run_role deep builder-deep high --capability read-repository --capability tool-use
 assert jq -e '.served.transport == "codex-cli" and .served.billingMode == "included-subscription"' "$TMP/deep.receipt"
+
+# A multi-bucket 0.147 response without an authoritative model mapping does
+# not guess. Each native attempt closes explicitly before the external tail.
+jq -s '.[0] as $base | .[1].codex as $codex | $base | .codex = $codex' "$TMP/availability.json" "$TMP/probe-v147.json" > "$TMP/availability.next"
+mv "$TMP/availability.next" "$TMP/availability.json"
+run_role mapping-unknown builder-deep high --capability read-repository --capability long-context
+assert jq -e '.served.transport == "openrouter" and ([.attempts[] | select(.transport == "codex-cli" and .reason == "rate_limit_mapping_unknown")] | length) == 2' "$TMP/mapping-unknown.receipt"
+
+# When authoritative policy metadata does name the applicable 0.147 bucket,
+# the same response becomes eligible without comparing it with other buckets.
+cp -R "$(dirname "$ROUTER")" "$TMP/mapped-router"
+jq '(.roles["builder-deep"][] | select(.transport == "codex-cli")).rateLimitId = "codex_named"' \
+  "$TMP/mapped-router/role-policy.json" > "$TMP/mapped-router/role-policy.next"
+mv "$TMP/mapped-router/role-policy.next" "$TMP/mapped-router/role-policy.json"
+MODEL_ROUTER_AVAILABILITY_FILE="$TMP/availability.json" \
+  MODEL_ROUTER_TRANSPORT_STUB="$TMP/transport-stub" \
+  "$TMP/mapped-router/role-dispatch.sh" --role builder-deep --effort high \
+    --capability read-repository --capability long-context \
+    --prompt-file "$TMP/prompt" --repository-evidence-file "$TMP/evidence" \
+    --output-file "$TMP/mapped.out" --receipt-file "$TMP/mapped.receipt" >/dev/null
+assert jq -e '.served.transport == "codex-cli" and .served.allowanceWindow == "codex_named" and (.attempts | length) == 1' "$TMP/mapped.receipt"
+
+jq '(.roles["builder-deep"][] | select(.transport == "codex-cli")).rateLimitId = "does_not_exist"' \
+  "$TMP/mapped-router/role-policy.json" > "$TMP/mapped-router/role-policy.next"
+mv "$TMP/mapped-router/role-policy.next" "$TMP/mapped-router/role-policy.json"
+MODEL_ROUTER_AVAILABILITY_FILE="$TMP/availability.json" \
+  MODEL_ROUTER_TRANSPORT_STUB="$TMP/transport-stub" \
+  "$TMP/mapped-router/role-dispatch.sh" --role builder-deep --effort high \
+    --capability read-repository --capability long-context \
+    --prompt-file "$TMP/prompt" --repository-evidence-file "$TMP/evidence" \
+    --output-file "$TMP/missing-map.out" --receipt-file "$TMP/missing-map.receipt" >/dev/null
+assert jq -e '.served.transport == "openrouter" and ([.attempts[] | select(.transport == "codex-cli" and .reason == "rate_limit_mapping_unknown")] | length) == 2' "$TMP/missing-map.receipt"
+
+# Safe availability reasons survive candidate attempts and the operator receipt
+# without carrying raw response/account/quota data.
+cp "$TMP/probe-exhausted.json" "$TMP/availability.json"
+set +e
+run_role exhausted-reason builder-deep high --capability tool-use
+exhausted_reason_rc=$?
+set -e
+assert test "$exhausted_reason_rc" -eq 76
+assert jq -e '.fallbackReason == "rate_limit_exhausted" and all(.attempts[]; .reason == "rate_limit_exhausted")' "$TMP/exhausted-reason.receipt"
+assert sh -c "! grep -Eq 'usedPercent|remaining_pct|resetsAt|limitName|account' '$TMP/exhausted-reason.receipt'"
+
+# Browser means local interactive navigation. With no runtime-proven transport,
+# the request closes explicitly and never turns on OpenRouter web search.
+fixture healthy
+set +e
+run_role browser-closed research-fast high --capability browser --capability structured-output
+browser_closed_rc=$?
+set -e
+assert test "$browser_closed_rc" -eq 76
+assert jq -e '.fallbackReason == "browser_transport_unavailable" and (.attempts | length) == 0' "$TMP/browser-closed.receipt"
 
 # Exhausted Codex descends without an approval prompt.
 fixture codex-exhausted

--- a/tools/validate-composition.sh
+++ b/tools/validate-composition.sh
@@ -646,6 +646,11 @@ run_composition_checks() {
     any_failed=1
   fi
 
+  printf "\n${BOLD}dm-review UI readiness:${RESET}\n"
+  if ! "$SCRIPT_DIR/test-dm-review-ui-readiness.sh"; then
+    any_failed=1
+  fi
+
   printf "\n${BOLD}Provider-neutral model router:${RESET}\n"
   if ! "$SCRIPT_DIR/validate-openrouter-cascade.sh"; then
     any_failed=1

--- a/tools/validate-dm-review-codex-perspective.sh
+++ b/tools/validate-dm-review-codex-perspective.sh
@@ -393,8 +393,8 @@ for zero_deferral_surface in \
   reject_text "$zero_deferral_surface" 'P3 advisories' "${zero_deferral_surface#$REPO_ROOT/} rejects deferred P3 evidence"
   reject_text "$zero_deferral_surface" 'P3 stays advisory' "${zero_deferral_surface#$REPO_ROOT/} rejects clean-with-P3 policy"
 done
-require_text "$REPO_ROOT/plugins/dm-review/.claude-plugin/plugin.json" '"version": "1.72.0"' "canonical dm-review version is 1.72.0"
-require_text "$REPO_ROOT/plugins/dm-review/.codex-plugin/plugin.json" '"version": "1.72.0"' "generated dm-review version is 1.72.0"
+require_text "$REPO_ROOT/plugins/dm-review/.claude-plugin/plugin.json" '"version": "1.73.0"' "canonical dm-review version is 1.73.0"
+require_text "$REPO_ROOT/plugins/dm-review/.codex-plugin/plugin.json" '"version": "1.73.0"' "generated dm-review version is 1.73.0"
 require_text "$REPO_ROOT/plugins/pipeline/.claude-plugin/plugin.json" '"version": "1.59.0"' "canonical Pipeline version is 1.59.0"
 require_text "$REPO_ROOT/plugins/pipeline/.codex-plugin/plugin.json" '"dm-review": ">=1.72.0"' "generated Pipeline dependency floor is current"
 

--- a/tools/validate-provider-neutral-routing.sh
+++ b/tools/validate-provider-neutral-routing.sh
@@ -10,13 +10,15 @@ trap 'rm -rf "$TMP"' EXIT
 
 fail() { printf 'provider-neutral-routing: %s\n' "$1" >&2; exit 1; }
 
-# Closed roles, capabilities, effort, no inactive GLM, and focused Kimi use.
+# Closed roles, capabilities, effort, no inactive GLM, focused Kimi use, and
+# no invented Codex candidate-to-allowance mapping.
 jq -e '
   (.roles | keys | sort) == (["architect","builder-deep","builder-fast","editorial","plan-critic","research-fast","review-deep","review-fast","security-review"] | sort) and
   (.effort.vocabulary == ["low","medium","high","max"]) and
   all(.roles[]; any(.[]; .transport == "openrouter")) and
   ([.roles[][] | .capabilities[] | select(IN("read-repository","write-repository","tool-use","browser","long-context","structured-output","independent-family") | not)] | length == 0) and
   ([.roles[][] | .model | select(test("glm";"i"))] | length == 0) and
+  all(.roles[][] | select(.transport == "codex-cli"); has("rateLimitId") | not) and
   ([.roles | to_entries[] | select(.key != "security-review") | .value[] | .model | select(test("kimi";"i"))] | length == 0)
 ' "$POLICY" >/dev/null || fail 'role policy is not closed'
 
@@ -38,19 +40,37 @@ jq -r '.roles[][] | select(.transport == "openrouter") | .model' "$POLICY" | sor
 jq -r '.models[] | .slug' "$MATRIX" | sort -u > "$TMP/matrix-models"
 missing="$(comm -23 "$TMP/router-models" "$TMP/matrix-models")"
 [ -z "$missing" ] || fail "OpenRouter candidate missing from matrix: $missing"
-jq -e '
-  (.roles["research-fast"][] | select(.model == "google/gemini-3.7-flash")
-    | .capabilities | index("browser")) != null
-' "$POLICY" >/dev/null || fail 'research-fast lacks its matrix-backed browser candidate'
-jq -e '.models[] | select(.slug == "google/gemini-3.7-flash")
-  | (.web_search_usd_per_request | type) == "number"' "$MATRIX" >/dev/null ||
-  fail 'browser candidate lacks OpenRouter web-search evidence'
-grep -Fq 'OPENROUTER_WEB_SEARCH="$web_search"' \
+# Public web search is not local interactive browser authority. No current
+# transport advertises browser, and OpenRouter invocation pins web search off.
+jq -e '([.roles[][] | select(.capabilities | index("browser") != null)] | length) == 0' \
+  "$POLICY" >/dev/null || fail 'a transport falsely advertises local browser access'
+grep -Fq 'OPENROUTER_WEB_SEARCH=0' \
   "$ROOT/plugins/model-router/skills/model-router/references/role-dispatch.sh" ||
-  fail 'browser capability is not wired to the provider adapter'
+  fail 'OpenRouter web search is not pinned off for routed local-browser semantics'
+grep -Fq 'browser_transport_unavailable' \
+  "$ROOT/plugins/model-router/skills/model-router/references/role-dispatch.sh" ||
+  fail 'browser requests lack an actionable closed reason'
 grep -Fq 'test fixture hooks require MODEL_ROUTER_TEST_MODE=1' \
   "$ROOT/plugins/model-router/skills/model-router/references/role-dispatch.sh" ||
   fail 'production role dispatch does not reject unguarded fixture hooks'
+
+ui_readiness="$ROOT/plugins/dm-review/skills/review/references/ui-review-readiness.md"
+ui_helper="$ROOT/plugins/dm-review/skills/review/references/ui-review-readiness.sh"
+full_lane="$ROOT/plugins/dm-review/skills/review/references/full-lane-dispatch.md"
+grep -Fq 'Keep browser interaction host-owned' "$full_lane" ||
+  fail 'dm-review does not keep local browser interaction host-owned'
+grep -Fq 'OpenRouter web search is remote public-web retrieval.' "$ui_readiness" ||
+  fail 'dm-review does not distinguish web search from local browser access'
+grep -Fq '`dev_server_unavailable`' "$ui_readiness" ||
+  fail 'dm-review lacks the dev-server closed reason'
+grep -Fq '`browser_transport_unavailable`' "$ui_readiness" ||
+  fail 'dm-review lacks the browser-transport closed reason'
+grep -Fq '`model_participant_unavailable`' "$ui_readiness" ||
+  fail 'dm-review lacks the model-participant closed reason'
+grep -Fq 'confirm-browser' "$ui_readiness" &&
+  grep -Fq 'app_ready' "$ui_helper" &&
+  grep -Fq 'cleanupArgv' "$ui_helper" ||
+  fail 'dm-review lacks the two-phase browser gate or exact cleanup snapshot'
 
 # Pipeline policy may express only role intent and legacy translation.
 jq -e '


### PR DESCRIPTION
Closes #96

## Summary
- perform a bounded, initialization-ordered Codex app-server JSON-RPC rate-limit probe
- normalize legacy and multi-bucket rate-limit shapes with safe fail-closed mapping reasons
- keep local browser interaction host-owned and gate required UI analysis on declared app readiness plus real browser evidence
- track exact review-created resources through a two-phase app/browser lifecycle and clean only registered resources
- bump model-router to 0.3.0 and dm-review to 1.73.0; Pipeline remains 1.59.0

## Verification
- `./tools/test-model-router.sh` — 89 assertions
- `./tools/test-dm-review-ui-readiness.sh` — 43 assertions
- `./tools/validate-provider-neutral-routing.sh`
- `./tools/validate-routing-economics.sh`
- `./tools/validate-workflow-contracts.sh`
- `./tools/validate-workflow-kernel.py`
- `./tools/generate-codex-manifests.py --check`
- `./tools/generate-codex-command-skills.py --check`
- `./tools/check-dependencies.sh`
- `./tools/validate-dual-compat.sh`
- `./tools/validate-composition.sh --all`
- `bash -n` on changed shell scripts
- `git diff --check`

## Review
One focused live `review-deep` pass confirmed seven reachable findings (1 P1, 4 P2, 2 P3); all seven were repaired and the affected verification lanes rerun.

PR #93 was merged into the base unchanged and is not modified by this diff.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Design-Machines-Studio/codesmith/depot/pr/98"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790320488&installation_model_id=428410&pr_number=98&repository=Design-Machines-Studio%2Fdepot&return_to=https%3A%2F%2Fgithub.com%2FDesign-Machines-Studio%2Fdepot%2Fpull%2F98&signature=5be2e6b853ef310ab96b274c376206d4cf2453a138d965da061d9c6173100ac8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->