### PR TITLE
ROUTE-04: Restore practical model routing and operator recommendations

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -69,7 +69,7 @@
     {
       "name": "project-manager",
       "source": "./plugins/project-manager",
-      "version": "1.11.0",
+      "version": "1.12.0",
       "author": {
         "name": "Design Machines"
       },
@@ -283,7 +283,7 @@
     {
       "name": "dm-review",
       "source": "./plugins/dm-review",
-      "version": "1.73.0",
+      "version": "1.74.0",
       "author": {
         "name": "Design Machines",
         "url": "https://designmachines.studio"
@@ -361,7 +361,7 @@
     {
       "name": "pipeline",
       "source": "./plugins/pipeline",
-      "version": "1.59.0",
+      "version": "1.60.0",
       "author": {
         "name": "Design Machines",
         "url": "https://designmachines.studio"
@@ -388,7 +388,7 @@
     {
       "name": "model-router",
       "source": "./plugins/model-router",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "author": {
         "name": "Design Machines",
         "url": "https://designmachines.studio"

--- a/docs/dependency-graph.md
+++ b/docs/dependency-graph.md
@@ -64,7 +64,7 @@ graph LR
 | dm-review | live-wires | required | `>=1.8.0` |
 | dm-review | ghostwriter | required | `>=3.7.0` |
 | dm-review | council | required | `>=1.5.0` |
-| dm-review | model-router | required | `>=0.3.0` |
+| dm-review | model-router | required | `>=0.4.0` |
 | dm-review | workflow-kernel | required | `>=0.17.0` |
 | dm-review | ned | optional | `>=1.4.0` |
 | dm-review | superpowers | optional | `>=1.0.0` |
@@ -74,8 +74,8 @@ graph LR
 | model-router | openrouter | optional | `>=1.19.0` |
 | model-router | workflow-kernel | optional | `>=0.17.0` |
 | ned | superpowers | optional | `>=1.0.0` |
-| pipeline | dm-review | required | `>=1.72.0` |
-| pipeline | model-router | required | `>=0.2.0` |
+| pipeline | dm-review | required | `>=1.74.0` |
+| pipeline | model-router | required | `>=0.4.0` |
 | pipeline | workflow-kernel | required | `>=0.17.0` |
 | pipeline | ned | optional | `>=1.4.0` |
 | pipeline | design-machines | optional | `>=1.3.0` |
@@ -91,7 +91,7 @@ graph LR
 | project-manager | design-machines | required | `>=1.3.0` |
 | project-manager | ghostwriter | required | `>=3.7.0` |
 | project-manager | council | required | `>=1.5.0` |
-| project-manager | model-router | optional | `>=0.2.0` |
+| project-manager | model-router | optional | `>=0.4.0` |
 | project-scaffolder | live-wires | optional | `>=1.0.0` |
 | project-scaffolder | dm-review | optional | `>=1.0.0` |
 | project-scaffolder | pipeline | optional | `>=1.0.0` |

--- a/plugins/dm-review/.claude-plugin/plugin.json
+++ b/plugins/dm-review/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dm-review",
   "description": "Code review orchestrator with evidence-backed severity, minimum-adequate repairs, zero-deferral convergence, full security and browser coverage, and stable finding receipts",
-  "version": "1.73.0",
+  "version": "1.74.0",
   "author": {
     "name": "Design Machines",
     "url": "https://designmachines.io"
@@ -11,7 +11,7 @@
     "live-wires": ">=1.8.0",
     "ghostwriter": ">=3.7.0",
     "council": ">=1.5.0",
-    "model-router": ">=0.3.0",
+    "model-router": ">=0.4.0",
     "workflow-kernel": ">=0.17.0"
   },
   "optionalPluginDependencies": {

--- a/plugins/dm-review/.codex-plugin/plugin.json
+++ b/plugins/dm-review/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dm-review",
-  "version": "1.73.0",
+  "version": "1.74.0",
   "description": "Code review orchestrator with evidence-backed severity, minimum-adequate repairs, zero-deferral convergence, full security and browser coverage, and stable finding receipts",
   "author": {
     "name": "Design Machines",
@@ -316,7 +316,7 @@
     "live-wires": ">=1.8.0",
     "ghostwriter": ">=3.7.0",
     "council": ">=1.5.0",
-    "model-router": ">=0.3.0",
+    "model-router": ">=0.4.0",
     "workflow-kernel": ">=0.17.0"
   },
   "optionalPluginDependencies": {

--- a/plugins/dm-review/agents/review/ui-standards-reviewer.md
+++ b/plugins/dm-review/agents/review/ui-standards-reviewer.md
@@ -31,7 +31,7 @@ You complement the ux-quality-reviewer (which evaluates design philosophy and us
 ## Precondition
 
 The host must supply a `## Host Browser Evidence` section produced only after
-`ui-review-readiness.md` confirmed the repository-declared application and a
+`ui-review-readiness.md` confirmed the invocation-selected application and a
 real local interactive browser navigation. It contains bounded screenshots,
 accessibility snapshots, route/viewport IDs, console summaries, interaction
 observations, and computed-style results. Analyze that evidence; do not call or

--- a/plugins/dm-review/agents/review/ux-quality-reviewer.md
+++ b/plugins/dm-review/agents/review/ux-quality-reviewer.md
@@ -52,7 +52,7 @@ All design recommendations MUST use Live Wires vocabulary: `.stack` not "add mar
 ## Precondition
 
 The host must supply a `## Host Browser Evidence` section produced only after
-`ui-review-readiness.md` confirmed the declared application and real local
+`ui-review-readiness.md` confirmed the selected application target and real local
 interactive browser navigation. Analyze its bounded screenshots,
 accessibility snapshots, console summary, route/viewport IDs, interaction
 observations, and computed-style results. Do not call or search for browser

--- a/plugins/dm-review/agents/review/visual-browser-tester.md
+++ b/plugins/dm-review/agents/review/visual-browser-tester.md
@@ -28,7 +28,7 @@ accessibility. You complement static code analysis with what actually rendered.
 
 ## Precondition
 
-A `## Host Browser Evidence` section must bind the repository-declared target,
+A `## Host Browser Evidence` section must bind the invocation-selected target,
 real local interactive transport, screenshots, accessibility snapshots,
 console summary, route/viewport case IDs, interaction observations, and
 computed-style results. The host has already completed the app/browser

--- a/plugins/dm-review/commands/dm-review-visual.md
+++ b/plugins/dm-review/commands/dm-review-visual.md
@@ -19,11 +19,16 @@ the policy.
 
 1. Load the visual-test skill from `plugins/dm-review/skills/visual-test/SKILL.md`
 2. Execute with the provided argument:
-   - No argument: auto-detect dev server, test all pages
+   - No argument: use an attached automation-capable T3 preview or optional
+     tracked `.dm/ui-review.json`; never scan localhost ports
    - URL: test that specific URL
    - `--states`: focus on interactive state testing
    - `--a11y`: focus on runtime accessibility checks
 3. Output the visual testing report
+
+This command always requires rendered evidence. Run the shared readiness gate
+with `--visual-required true`; if no target can be selected, return one `REVIEW
+INCOMPLETE` coverage result and one next action.
 
 Materialize the validated standalone review request, including its explicit/defaulted `workflowClass`, at `<exact-run-root>/review/request.json`; maintain its cumulative ordered redacted receipts at `<exact-run-root>/review/authoritative-receipts.json`. Resolve `$WORKFLOW_KERNEL` -- the workflow-kernel launcher script -- once per run, following the fail-closed resolution contract in the workflow-kernel plugin's `references/runtime-resolution.md`. Initialize the run under `.workflow-kernel/runs/<run-id>`; the kernel derives and verifies the immutable repository scope from the state directory, and no caller-selected lease root is accepted. Before authoritative browser actions, seal the independent prediction:
 

--- a/plugins/dm-review/skills/dm-review-visual/SKILL.md
+++ b/plugins/dm-review/skills/dm-review-visual/SKILL.md
@@ -34,11 +34,16 @@ the policy.
 
 1. Load the visual-test skill from `plugins/dm-review/skills/visual-test/SKILL.md`
 2. Execute with the provided argument:
-   - No argument: auto-detect dev server, test all pages
+   - No argument: use an attached automation-capable T3 preview or optional
+     tracked `.dm/ui-review.json`; never scan localhost ports
    - URL: test that specific URL
    - `--states`: focus on interactive state testing
    - `--a11y`: focus on runtime accessibility checks
 3. Output the visual testing report
+
+This command always requires rendered evidence. Run the shared readiness gate
+with `--visual-required true`; if no target can be selected, return one `REVIEW
+INCOMPLETE` coverage result and one next action.
 
 Materialize the validated standalone review request, including its explicit/defaulted `workflowClass`, at `<exact-run-root>/review/request.json`; maintain its cumulative ordered redacted receipts at `<exact-run-root>/review/authoritative-receipts.json`. Resolve `$WORKFLOW_KERNEL` -- the workflow-kernel launcher script -- once per run, following the fail-closed resolution contract in the workflow-kernel plugin's `references/runtime-resolution.md`. Initialize the run under `.workflow-kernel/runs/<run-id>`; the kernel derives and verifies the immutable repository scope from the state directory, and no caller-selected lease root is accepted. Before authoritative browser actions, seal the independent prediction:
 

--- a/plugins/dm-review/skills/review/SKILL.md
+++ b/plugins/dm-review/skills/review/SKILL.md
@@ -249,6 +249,7 @@ DM_REVIEW_REQUIRED_ASSETS=(
   "agents/workflow/review-consolidator.md"
   "agents/workflow/review-memory-recorder.md"
   "skills/review/references/reviewer-output-contract.md"
+  "skills/review/references/host-verification-evidence.md"
   "skills/review/references/ui-review-readiness.md"
   "skills/review/references/ui-review-readiness.sh"
 )
@@ -404,23 +405,36 @@ Load `${CLAUDE_SKILL_DIR}/references/full-lane-dispatch.md`. It owns the closed
 lane-to-role mapping and anonymous public receipt. Do not load a provider/model
 table or print concrete routing identity.
 
-### Phase 3.9: Required UI readiness
+### Phase 3.8: Host verification
+
+Only when a deterministic tests/build lane is selected, load
+`${CLAUDE_SKILL_DIR}/references/host-verification-evidence.md`. Run the existing
+repository-owned verification profile or established command on the host before
+model analysis, capture its compact bounded evidence once, and share that
+evidence with any useful `review-fast` or `review-deep` judgment lane. The
+normal tests/build analysis requests `read-repository` and
+`structured-output`, not `tool-use`.
+
+### Phase 3.9: Proportional UI readiness
 
 When any browser/UI lane is selected, load
 `${CLAUDE_SKILL_DIR}/references/ui-review-readiness.md` and complete its
-application and local-browser gate before model dispatch. Use only the
-repository-declared target and exact start/readiness procedure. Start an exact
-declared process through its helper, or an exact declared Compose consumer
-through the existing review Docker contract. Track and clean only resources
-this invocation created.
+application and local-browser gate once before model dispatch. Select an
+explicit invocation URL first, then an already attached automation-capable T3
+preview, then optional tracked `.dm/ui-review.json`. Start only an exact
+declared process or Compose consumer and track only resources this invocation
+created. Never infer readiness from changed file extensions.
 
 Verify application reachability and actual local interactive browser
 navigation independently. OpenRouter web search and generic `tool-use` never
 satisfy local browser readiness. Current browser interaction is host-owned;
-pass bounded evidence to the mapped provider-neutral analysis role without a
-`browser` capability request. If app or browser recovery fails, dispatch no UI
-participant and keep `REVIEW INCOMPLETE` with one safe reason and one next
-action. If readiness succeeds but the role is unavailable, report
+collect bounded evidence once and pass the same packet to each mapped
+provider-neutral analysis role without a `browser` capability request. If no
+target exists in an ordinary review, dispatch no UI participant and emit one
+nonblocking visual coverage note; do not repeat it per lane. Keep `REVIEW
+INCOMPLETE` only when rendered evidence was explicitly required by
+`/dm-review-visual`, the user, acceptance criteria, or a verification profile.
+If readiness succeeds but the role is unavailable, report
 `model_participant_unavailable` distinctly.
 
 ---

--- a/plugins/dm-review/skills/review/references/full-lane-dispatch.md
+++ b/plugins/dm-review/skills/review/references/full-lane-dispatch.md
@@ -15,7 +15,7 @@ For every lane that requires separation from implementation, load
 | patterns | `review-deep` | `read-repository`, `structured-output` | `high` |
 | simplicity | `review-deep` | `read-repository`, `structured-output` | `high` |
 | documentation | `review-fast` | `read-repository`, `structured-output` | `medium` |
-| tests/build | `review-fast` | `read-repository`, `tool-use`, `structured-output` | `medium` |
+| tests/build analysis | `review-fast` | `read-repository`, `structured-output` | `medium` |
 | second perspective | `plan-critic` | `read-repository`, `long-context`, `structured-output`, `independent-family` | `high` |
 | triggered domain lane | `review-deep` | explicit required capabilities only | `high` |
 | triggered UI analysis lane | `review-deep` | `read-repository`, `long-context`, `structured-output` | `high` |
@@ -23,11 +23,18 @@ For every lane that requires separation from implementation, load
 Keep the complete selected roster. Role mapping does not drop a required lane.
 Quick mode keeps its existing smaller roster but uses the same role mapping.
 
+Before a tests/build analysis call, load `host-verification-evidence.md` and run
+the applicable existing repository verification on the host. A passing host
+result settles deterministic execution before model analysis. When judgment is
+useful, pass only its bounded evidence envelope and repository evidence to the
+prompt-only role. Do not add `tool-use`. A genuinely tool-dependent selected
+task still requests `tool-use` and therefore excludes prompt-only transports.
+
 ## Dispatch
 
 Resolve one coherent model-router bundle with Workflow Kernel and require
 `skills/model-router/references/role-dispatch.sh`, the request schema, and role
-policy at minimum version `0.3.0`. When this invocation owns terminal reporting,
+policy at minimum version `0.4.0`. When this invocation owns terminal reporting,
 require `skills/model-router/references/render-terminal-report.sh` from that
 same bundle. For each selected lane:
 
@@ -41,7 +48,9 @@ same bundle. For each selected lane:
    repository-evidence file. Pass the evidence path with
    `--repository-evidence-file`; a prompt-only candidate is ineligible without
    it.
-4. Build `role-dispatch` argv as an array from the table above.
+4. Build `role-dispatch` argv as an array from the table above and pass the
+   invocation's exact validated launcher as `--workflow-kernel
+   "$WORKFLOW_KERNEL"`.
 5. Store every live implementation and repair receipt under
    `<exact-run-root>/receipts/private/router/`, named by its opaque receipt ID.
    For independent lanes, pass that directory with
@@ -54,25 +63,28 @@ same bundle. For each selected lane:
    The two origin forms are mutually exclusive.
 6. Launch selected lanes in parallel when the host supports it.
 
-### Required UI prerequisite
+### Proportional UI prerequisite
 
 Before any selected UI lane is dispatched, load `ui-review-readiness.md` and
-run its ordered application/browser gate. The application target and start
-procedure come only from `.dm/ui-review.json`. A declared Compose consumer uses
+run its ordered application/browser gate once. Prefer an explicit invocation
+URL, then an attached automation-capable T3 preview, then optional tracked
+`.dm/ui-review.json`. A declared Compose consumer uses
 the existing review Docker creation/cleanup contracts; an exact declared
 process uses `ui-review-readiness.sh`. Verify reachability independently, then
 prove actual local browser navigation independently.
 
 Current routed transports do not receive the host's local interactive browser.
-Keep browser interaction host-owned and materialize bounded screenshots,
+Keep browser interaction host-owned and materialize one bounded set of screenshots,
 accessibility snapshots, console summaries, route/viewport case IDs,
-interaction observations, and computed-style evidence. Pass that evidence to
-the provider-neutral UI analysis role above. Never request `browser` or generic
+interaction observations, and computed-style evidence. Share that evidence
+with every applicable provider-neutral UI analysis role above. Never request `browser` or generic
 `tool-use`, and never treat OpenRouter web search as local navigation.
 
-If application or browser recovery fails, do not dispatch a participant. Keep
-the lane and review incomplete with exactly `dev_server_unavailable` or
-`browser_transport_unavailable` plus the contract's one next action. If both
+If an ordinary review has no rendered target, dispatch no UI participant and
+emit one aggregated nonblocking coverage note. Keep the review incomplete only
+when rendered evidence was explicitly required. In that case use exactly one
+`visual_target_unavailable`, `dev_server_unavailable`, or
+`browser_transport_unavailable` result plus one next action. If both
 are ready but role dispatch is unavailable, settle as
 `model_participant_unavailable`. Prerequisite failures are coverage gaps, not
 code findings. Settle and clean only resources registered by this review;

--- a/plugins/dm-review/skills/review/references/host-verification-evidence.md
+++ b/plugins/dm-review/skills/review/references/host-verification-evidence.md
@@ -1,0 +1,39 @@
+# Host-owned deterministic verification evidence
+
+Builds, tests, linters, generators, and repository verification profiles are
+host mechanics, not model judgment. When dm-review selects a deterministic
+verification lane, run it before any analysis participant.
+
+Use the repository's existing tracked verification profile through Workflow
+Kernel when one applies. Otherwise use only the exact repository-owned command
+already selected by dm-review's established build/test mapping. Do not invent a
+second command ladder, guess a mutating command, or ask a model to discover and
+run shell commands.
+
+Capture one bounded evidence envelope per executed command:
+
+```json
+{
+  "schemaVersion": 1,
+  "lane": "tests/build",
+  "commandArgv": ["./tools/verify"],
+  "exitStatus": 0,
+  "result": "passed",
+  "stdoutTail": "bounded to 8192 UTF-8 bytes",
+  "stderrTail": "bounded to 8192 UTF-8 bytes"
+}
+```
+
+Keep argv as an array. Record the exact exit status. Retain at most the final
+8,192 UTF-8 bytes from each stream, replacing invalid UTF-8 and credential-like
+values with the existing safe redaction marker before materializing evidence.
+An exit-zero host result settles deterministic execution without a model call.
+A nonzero result is authoritative failure evidence; a `review-fast` or
+`review-deep` participant may analyze the bounded envelope and relevant
+repository evidence with only `read-repository` and `structured-output` (plus
+`long-context` only when justified). The participant never receives command
+authority and cannot convert a failing command into success.
+
+Reserve routed `tool-use` for a selected task whose participant must actually
+invoke tools and for which host-produced evidence is not equivalent. The normal
+tests/build lane does not meet that condition.

--- a/plugins/dm-review/skills/review/references/output-format.md
+++ b/plugins/dm-review/skills/review/references/output-format.md
@@ -187,11 +187,14 @@ Coverage Gaps; they never support clean. This index creates no transcript.
 ### Coverage Gaps
 
 List incomplete required coverage, its evidence pointer, and one next action.
-For a required UI lane, emit exactly one of `dev_server_unavailable`,
+For explicitly required rendered coverage, emit exactly one of
+`visual_target_unavailable`, `dev_server_unavailable`,
 `browser_transport_unavailable`, `model_participant_unavailable`, or
 `resource_cleanup_failed`; never include raw tool/provider output, a private
 path, account data, or quota details. These readiness failures are not code
-findings.
+findings. In an ordinary review with no target, place one aggregated
+`visual_target_unavailable -- NOT RUN` note in the Agent Summary instead; it is
+not an incomplete required gap and is never repeated per UI analysis lane.
 If none, state `Coverage Gaps: none -- all required lanes completed.`
 
 ---

--- a/plugins/dm-review/skills/review/references/ui-review-readiness.md
+++ b/plugins/dm-review/skills/review/references/ui-review-readiness.md
@@ -1,16 +1,29 @@
 # Required UI-lane readiness
 
-This contract is consumed only by dm-review's required rendered UI lanes. It
+This contract is consumed only by dm-review's selected rendered UI lanes. It
 prevents participant dispatch when no rendered application or real local
 interactive browser exists. It replaces reviewer-owned localhost scanning,
 generic `tool-use` guesses, and OpenRouter web-search substitution. It is not a
 browser broker, capability negotiation framework, or workflow engine.
 
-## Repository declaration
+## Target selection
 
-Discover only `<repository>/.dm/ui-review.json`; never scan generic localhost
-ports or infer a start command from incidental files. The closed version 1
-shape is:
+Select exactly one target in this order:
+
+1. an explicit URL supplied by the current invocation;
+2. an already attached, automation-capable T3 preview and its current URL;
+3. the optional tracked `<repository>/.dm/ui-review.json` declaration;
+4. otherwise no rendered target is available.
+
+Pass invocation and T3 targets to `prepare` with `--target-url` and
+`--target-source explicit|t3-preview`. Do not scan localhost ports, infer a URL
+from file extensions, or guess a start command. The helper validates the URL;
+successful host navigation remains the readiness proof.
+
+## Optional repository declaration
+
+When present, discover only `<repository>/.dm/ui-review.json`. Its closed
+version 1 shape is:
 
 ```json
 {
@@ -44,8 +57,9 @@ consumer is sufficient.
 
 ## Ordered gate
 
-1. Check declared application readiness independently with
-   `ui-review-readiness.sh prepare`.
+1. Select the target using the order above. For an explicit URL or attached T3
+   preview, run `ui-review-readiness.sh prepare` with that exact target. For a
+   declaration, check its application readiness independently with `prepare`.
 2. If a stopped `process` consumer has an exact start procedure, start it and
    register only that created resource. `prepare` returns `app_ready` with
    `dispatchAllowed: false` and leaves that registered process available for
@@ -75,9 +89,10 @@ consumer is sufficient.
    exact state file created by `prepare`. It rechecks the registered target and
    consumes the browser proof. Only `dispatchAllowed: true` permits a
    participant call.
-7. Keep browser interaction host-owned. Give each UI analysis role the bounded
-   screenshots, accessibility snapshots, console summary, route/viewport IDs,
-   interaction observations, and computed-style results it needs. Request
+7. Keep browser interaction host-owned. Collect screenshots, accessibility
+   snapshots, console summary, route/viewport IDs, interaction observations,
+   and computed-style results once. Give the same bounded evidence packet to
+   each applicable UI analysis role. Request
    `review-deep` with `read-repository`, `long-context`, and
    `structured-output`; do not request `browser` or generic `tool-use`.
 8. Settle the public participant result through `ui-review-readiness.sh
@@ -99,11 +114,20 @@ probe that proves local navigation.
 
 | Reason | Review state | One next action |
 |---|---|---|
+| `visual_target_unavailable` | `NOT RUN` ordinarily; `REVIEW INCOMPLETE` when required | Supply an explicit URL, attach T3 preview, or add the optional declaration when coverage is required. |
 | `dev_server_unavailable` | `REVIEW INCOMPLETE` | Declare or recover the exact repository-owned consumer and rerun. |
 | `browser_transport_unavailable` | `REVIEW INCOMPLETE` | Attach a local interactive browser, navigate the target, and rerun. |
 | `model_participant_unavailable` | `REVIEW INCOMPLETE` | Restore an eligible provider-neutral analysis participant and rerun the lane. |
 | `resource_cleanup_failed` | `REVIEW INCOMPLETE` | Run only the recorded repository-owned cleanup and inspect that resource. |
 
-These are prerequisite/coverage outcomes, never code-quality findings. Emit
-one exact cause and one next action. Do not dispatch a doomed participant,
-silently omit a required lane, or convert missing evidence into approval.
+These are prerequisite/coverage outcomes, never code-quality findings. When no
+target exists during an ordinary quick or full review, dispatch no UI analysis
+participant and emit one aggregated `visual_target_unavailable` coverage note
+with `NOT RUN`; the review remains otherwise complete. Do not repeat that note
+for visual-browser, UX-quality, and UI-standards lanes.
+
+Rendered evidence is required only for `/dm-review-visual`, explicit user or
+acceptance-criteria requirements, or a repository verification profile. Call
+`prepare --visual-required true` for those cases. If no target exists, emit one
+honest `REVIEW INCOMPLETE` coverage result and one next action. File extensions
+alone do not make visual infrastructure mandatory.

--- a/plugins/dm-review/skills/review/references/ui-review-readiness.sh
+++ b/plugins/dm-review/skills/review/references/ui-review-readiness.sh
@@ -1,13 +1,15 @@
 #!/usr/bin/env bash
 # ui-review-readiness.sh -- dm-review UI-lane prerequisite and cleanup helper.
 #
-# Current consumer: dm-review required UI lanes. It prevents doomed model
+# Current consumer: dm-review selected UI lanes. It prevents doomed model
 # dispatch when the repository's rendered app or the host's local interactive
 # browser is unavailable. It replaces per-reviewer localhost scanning and
 # unowned start/stop guesses; it is not an orchestration layer or browser broker.
 #
 # Usage:
 #   ui-review-readiness.sh prepare --repository-root ROOT --state-file FILE
+#     [--target-url URL --target-source explicit|t3-preview]
+#     [--visual-required true|false]
 #   ui-review-readiness.sh confirm-browser --repository-root ROOT \
 #     --state-file FILE --browser-evidence-file FILE
 #   ui-review-readiness.sh settle --repository-root ROOT --state-file FILE \
@@ -25,6 +27,9 @@ REPOSITORY_ROOT=""
 STATE_FILE=""
 BROWSER_EVIDENCE_FILE=""
 PARTICIPANT_RESULT_FILE=""
+TARGET_URL_INPUT=""
+TARGET_SOURCE_INPUT=""
+VISUAL_REQUIRED=false
 
 usage() {
   printf '%s\n' 'ui-review-readiness: invalid invocation' >&2
@@ -37,6 +42,9 @@ while [ "$#" -gt 0 ]; do
     --state-file) [ "$#" -ge 2 ] || usage; STATE_FILE="$2"; shift 2 ;;
     --browser-evidence-file) [ "$#" -ge 2 ] || usage; BROWSER_EVIDENCE_FILE="$2"; shift 2 ;;
     --participant-result-file) [ "$#" -ge 2 ] || usage; PARTICIPANT_RESULT_FILE="$2"; shift 2 ;;
+    --target-url) [ "$#" -ge 2 ] || usage; TARGET_URL_INPUT="$2"; shift 2 ;;
+    --target-source) [ "$#" -ge 2 ] || usage; TARGET_SOURCE_INPUT="$2"; shift 2 ;;
+    --visual-required) [ "$#" -ge 2 ] || usage; VISUAL_REQUIRED="$2"; shift 2 ;;
     *) usage ;;
   esac
 done
@@ -47,12 +55,19 @@ command -v jq >/dev/null 2>&1 || { printf '%s\n' 'ui-review-readiness: unavailab
 REPOSITORY_ROOT="$(cd "$REPOSITORY_ROOT" && pwd -P)" || usage
 git -C "$REPOSITORY_ROOT" rev-parse --show-toplevel >/dev/null 2>&1 || usage
 [ -n "$STATE_FILE" ] && [ -d "$(dirname "$STATE_FILE")" ] || usage
+case "$VISUAL_REQUIRED" in true|false) ;; *) usage ;; esac
+[ -z "$TARGET_URL_INPUT" ] || [ "$ACTION" = prepare ] || usage
+[ -z "$TARGET_SOURCE_INPUT" ] || [ "$ACTION" = prepare ] || usage
 
 emit_closed() {
   local reason="$1" next_action="$2"
   jq -cn --arg reason "$reason" --arg next_action "$next_action" \
     '{state:"closed",dispatchAllowed:false,reason:$reason,nextAction:$next_action,
       reviewDisposition:"REVIEW INCOMPLETE"}'
+}
+
+valid_target_url() {
+  printf '%s' "$1" | jq -eR 'test("^https?://(localhost|127\\.0\\.0\\.1|[a-z0-9.-]+\\.(test|site)|[a-z0-9.-]+\\.ddev\\.site)(:[0-9]{1,5})?(/[^[:space:]]*)?$")' >/dev/null 2>&1
 }
 
 load_argv() {
@@ -128,14 +143,16 @@ validate_declaration() {
 write_state() {
   local target_url="$1" stage="$2" dispatch_allowed="$3" created="$4" cleanup_pending="$5"
   local readiness_argv="$6" readiness_attempts="$7" readiness_timeout="$8"
-  local cleanup_argv="$9" cleanup_timeout="${10}" tmp
+  local cleanup_argv="$9" cleanup_timeout="${10}" target_source="${11:-declaration}" visual_required="${12:-false}" tmp
   tmp="$(mktemp "$(dirname "$STATE_FILE")/.ui-review-state.XXXXXX")" || return 1
   jq -cn --arg target_url "$target_url" --arg stage "$stage" \
     --argjson dispatch_allowed "$dispatch_allowed" --argjson created "$created" \
     --argjson cleanup_pending "$cleanup_pending" --argjson readiness_argv "$readiness_argv" \
     --argjson readiness_attempts "$readiness_attempts" --argjson readiness_timeout "$readiness_timeout" \
     --argjson cleanup_argv "$cleanup_argv" --argjson cleanup_timeout "$cleanup_timeout" \
+    --arg target_source "$target_source" --argjson visual_required "$visual_required" \
     '{schemaVersion:1,targetUrl:$target_url,stage:$stage,dispatchAllowed:$dispatch_allowed,
+      targetSource:$target_source,visualRequired:$visual_required,
       createdByReview:$created,cleanupPending:$cleanup_pending,
       readinessArgv:$readiness_argv,readinessAttempts:$readiness_attempts,
       readinessTimeoutSeconds:$readiness_timeout,cleanupArgv:$cleanup_argv,
@@ -147,12 +164,15 @@ validate_state() {
   [ -f "$STATE_FILE" ] && [ ! -L "$STATE_FILE" ] || return 1
   jq -e '
     type == "object" and
-    (keys | sort) == (["cleanupArgv","cleanupPending","cleanupTimeoutSeconds","createdByReview","dispatchAllowed","readinessArgv","readinessAttempts","readinessTimeoutSeconds","schemaVersion","stage","targetUrl"] | sort) and
+    (keys | sort) == (["cleanupArgv","cleanupPending","cleanupTimeoutSeconds","createdByReview","dispatchAllowed","readinessArgv","readinessAttempts","readinessTimeoutSeconds","schemaVersion","stage","targetSource","targetUrl","visualRequired"] | sort) and
     .schemaVersion == 1 and (.targetUrl | type) == "string" and
+    (.targetSource == "explicit" or .targetSource == "t3-preview" or .targetSource == "declaration") and
+    (.visualRequired | type) == "boolean" and
     (.stage == "app_ready" or .stage == "ready" or .stage == "closed" or .stage == "settled") and
     (.dispatchAllowed | type) == "boolean" and (.createdByReview | type) == "boolean" and
     (.cleanupPending | type) == "boolean" and
-    (.readinessArgv | type) == "array" and (.readinessArgv | length) > 0 and
+    (.readinessArgv | type) == "array" and
+    (if .targetSource == "declaration" then (.readinessArgv | length) > 0 else (.readinessArgv | length) == 0 end) and
     all(.readinessArgv[]; type == "string" and length > 0 and length <= 4096) and
     (.readinessAttempts | type) == "number" and (.readinessAttempts | floor) == .readinessAttempts and .readinessAttempts >= 1 and .readinessAttempts <= 30 and
     (.readinessTimeoutSeconds | type) == "number" and (.readinessTimeoutSeconds | floor) == .readinessTimeoutSeconds and .readinessTimeoutSeconds >= 1 and .readinessTimeoutSeconds <= 60 and
@@ -263,9 +283,31 @@ cleanup_on_unexpected_exit() {
 }
 
 if [ "$ACTION" = prepare ]; then
+  if [ -n "$TARGET_URL_INPUT" ]; then
+    case "$TARGET_SOURCE_INPUT" in explicit|t3-preview) ;; *) usage ;; esac
+    valid_target_url "$TARGET_URL_INPUT" || usage
+    [ ! -e "$STATE_FILE" ] || usage
+    write_state "$TARGET_URL_INPUT" app_ready false false false '[]' 1 1 '[]' 0 \
+      "$TARGET_SOURCE_INPUT" "$VISUAL_REQUIRED" || exit 76
+    jq -cn --arg target_url "$TARGET_URL_INPUT" --arg source "$TARGET_SOURCE_INPUT" \
+      '{state:"app_ready",dispatchAllowed:false,reason:"browser_evidence_required",
+        targetUrl:$target_url,targetSource:$source,createdResources:0,
+        nextAction:"navigate the invocation-selected target with the host local browser, then run confirm-browser"}'
+    exit 0
+  fi
   if ! validate_declaration "$DECLARATION"; then
-    emit_closed dev_server_unavailable 'declare .dm/ui-review.json with exact repository-owned readiness/start/cleanup argv and rerun'
-    exit 76
+    if [ -e "$DECLARATION" ]; then
+      emit_closed dev_server_unavailable 'repair the optional tracked .dm/ui-review.json declaration or supply an explicit target'
+      exit 76
+    fi
+    if [ "$VISUAL_REQUIRED" = true ]; then
+      emit_closed visual_target_unavailable 'supply an explicit URL, attach an automation-capable T3 preview, or add the optional tracked declaration'
+      exit 76
+    fi
+    jq -cn '{state:"not_available",dispatchAllowed:false,reason:"visual_target_unavailable",
+      coverageDisposition:"NOT RUN",reviewDisposition:"completed",createdResources:0,
+      nextAction:"none; configure a visual target only when rendered coverage is needed"}'
+    exit 0
   fi
   TARGET_URL="$(jq -r '.targetUrl' "$DECLARATION")"
   load_argv "$DECLARATION" '.readiness.argv' || usage
@@ -288,7 +330,7 @@ if [ "$ACTION" = prepare ]; then
     CREATED="$(jq -r '.createdByReview' "$STATE_FILE")"
   elif run_bounded_argv "$READINESS_TIMEOUT" "${READINESS_ARGV[@]}"; then
     write_state "$TARGET_URL" app_ready false false false "$READINESS_ARGV_JSON" \
-      "$READINESS_ATTEMPTS" "$READINESS_TIMEOUT" '[]' 0 || exit 76
+      "$READINESS_ATTEMPTS" "$READINESS_TIMEOUT" '[]' 0 declaration "$VISUAL_REQUIRED" || exit 76
   else
     if [ "$(jq -r '.start == null' "$DECLARATION")" = true ]; then
       emit_closed dev_server_unavailable 'run the repository-declared application consumer and rerun'
@@ -312,7 +354,7 @@ if [ "$ACTION" = prepare ]; then
     }
     CREATED=true
     write_state "$TARGET_URL" app_ready false true true "$READINESS_ARGV_JSON" \
-      "$READINESS_ATTEMPTS" "$READINESS_TIMEOUT" "$CLEANUP_ARGV_JSON" "$START_TIMEOUT" || exit 76
+      "$READINESS_ATTEMPTS" "$READINESS_TIMEOUT" "$CLEANUP_ARGV_JSON" "$START_TIMEOUT" declaration "$VISUAL_REQUIRED" || exit 76
     trap cleanup_on_unexpected_exit EXIT
     trap 'exit 130' HUP INT TERM
     if ! run_bounded_argv "$START_TIMEOUT" "${UI_ARGV[@]}"; then
@@ -341,16 +383,18 @@ fi
 validate_state &&
   jq -e '.stage == "app_ready" and .dispatchAllowed == false' "$STATE_FILE" >/dev/null 2>&1 || usage
 TARGET_URL="$(jq -r '.targetUrl' "$STATE_FILE")"
-load_argv "$STATE_FILE" '.readinessArgv' || usage
-validate_repo_executable "${UI_ARGV[0]}" || close_registered_state dev_server_unavailable 'repair the registered readiness command and rerun'
-READINESS_ARGV=("${UI_ARGV[@]}")
 READINESS_TIMEOUT="$(jq -r '.readinessTimeoutSeconds' "$STATE_FILE")"
 if [ "$(jq -r '.createdByReview and .cleanupPending' "$STATE_FILE")" = true ]; then
   trap cleanup_on_unexpected_exit EXIT
   trap 'exit 130' HUP INT TERM
 fi
-if ! run_bounded_argv "$READINESS_TIMEOUT" "${READINESS_ARGV[@]}"; then
-  close_registered_state dev_server_unavailable 'inspect the registered application readiness command and rerun'
+if [ "$(jq -r '.targetSource' "$STATE_FILE")" = declaration ]; then
+  load_argv "$STATE_FILE" '.readinessArgv' || usage
+  validate_repo_executable "${UI_ARGV[0]}" || close_registered_state dev_server_unavailable 'repair the registered readiness command and rerun'
+  READINESS_ARGV=("${UI_ARGV[@]}")
+  if ! run_bounded_argv "$READINESS_TIMEOUT" "${READINESS_ARGV[@]}"; then
+    close_registered_state dev_server_unavailable 'inspect the registered application readiness command and rerun'
+  fi
 fi
 if [ ! -f "$BROWSER_EVIDENCE_FILE" ] || [ -L "$BROWSER_EVIDENCE_FILE" ] ||
    ! jq -e --arg target_url "$TARGET_URL" '
@@ -361,7 +405,7 @@ if [ ! -f "$BROWSER_EVIDENCE_FILE" ] || [ -L "$BROWSER_EVIDENCE_FILE" ] ||
      .targetUrl == $target_url and
      (.evidenceRef | type) == "string" and (.evidenceRef | test("^[a-z0-9][a-z0-9._/-]{0,255}$"))
    ' "$BROWSER_EVIDENCE_FILE" >/dev/null 2>&1; then
-  close_registered_state browser_transport_unavailable 'attach a local interactive browser, navigate the declared target, and rerun'
+  close_registered_state browser_transport_unavailable 'attach a local interactive browser, navigate the selected target, and rerun'
 fi
 update_state ready true || exit 76
 trap - EXIT HUP INT TERM

--- a/plugins/dm-review/skills/review/references/ui-review-readiness.sh
+++ b/plugins/dm-review/skills/review/references/ui-review-readiness.sh
@@ -66,8 +66,10 @@ emit_closed() {
       reviewDisposition:"REVIEW INCOMPLETE"}'
 }
 
-valid_target_url() {
-  printf '%s' "$1" | jq -eR 'test("^https?://(localhost|127\\.0\\.0\\.1|[a-z0-9.-]+\\.(test|site)|[a-z0-9.-]+\\.ddev\\.site)(:[0-9]{1,5})?(/[^[:space:]]*)?$")' >/dev/null 2>&1
+valid_selected_target_url() {
+  printf '%s' "$1" | jq -eR '
+    test("^https?://[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?(?:\\.[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?)*(:[0-9]{1,5})?([/?#][^[:space:]]*)?$")
+  ' >/dev/null 2>&1
 }
 
 load_argv() {
@@ -285,7 +287,7 @@ cleanup_on_unexpected_exit() {
 if [ "$ACTION" = prepare ]; then
   if [ -n "$TARGET_URL_INPUT" ]; then
     case "$TARGET_SOURCE_INPUT" in explicit|t3-preview) ;; *) usage ;; esac
-    valid_target_url "$TARGET_URL_INPUT" || usage
+    valid_selected_target_url "$TARGET_URL_INPUT" || usage
     [ ! -e "$STATE_FILE" ] || usage
     write_state "$TARGET_URL_INPUT" app_ready false false false '[]' 1 1 '[]' 0 \
       "$TARGET_SOURCE_INPUT" "$VISUAL_REQUIRED" || exit 76

--- a/plugins/dm-review/skills/visual-test/SKILL.md
+++ b/plugins/dm-review/skills/visual-test/SKILL.md
@@ -25,7 +25,8 @@ Standalone visual testing that loads pages in a real browser, screenshots at mul
 
 ## Usage
 
-- `/dm-review-visual` -- auto-detect dev server, test all discoverable pages
+- `/dm-review-visual` -- use an attached T3 preview or optional tracked
+  `.dm/ui-review.json`, then test all discoverable pages
 - `/dm-review-visual <url>` -- test a specific URL
 - `/dm-review-visual --states` -- focus on interactive state testing only
 - `/dm-review-visual --a11y` -- focus on runtime accessibility checks only
@@ -36,17 +37,18 @@ Standalone visual testing that loads pages in a real browser, screenshots at mul
 
 **If a URL argument was provided:** use it directly.
 
-**If no URL provided:** detect the dev server by trying these URLs in order with `browser_navigate`:
+**If no URL provided:** first use an already attached, automation-capable T3
+preview and its exact current URL. Otherwise use optional tracked
+`.dm/ui-review.json` through the shared `ui-review-readiness.md` start/readiness
+contract. Do not scan localhost ports, infer a target from the project type, or
+guess a mutating start command.
 
-1. `http://localhost:8080` (Go+Templ+Datastar)
-2. `http://localhost:3000` (Node/general)
-3. `https://[project-name].ddev.site` (Craft CMS DDEV)
-4. `http://localhost:5173` (Vite)
-
-Use the first URL that loads successfully. If none respond, record `target unavailable`
-and emit a blocked `human_help_required` receipt naming the exact
-missing persona/scenario/route/engine/viewport cases, then ask the user for the
-authoritative URL. Never return a bare stop, skip, approval, or pass.
+This command explicitly requires rendered evidence. Run the shared helper with
+`--visual-required true`. If neither source exists or navigation cannot be
+proved, record `target unavailable` and emit one `REVIEW INCOMPLETE` coverage
+result with the exact missing
+persona/scenario/route/engine/viewport cases and one next action. Never return a
+bare stop, skip, approval, or pass.
 
 If Playwright tools fail, follow
 `plugins/workflow-kernel/skills/workflow-kernel/references/verification-contract.md`
@@ -56,7 +58,8 @@ process/session quit plus fresh relaunch, then try a genuinely different engine.
 Exhaustion returns blocked `human_help_required` with exact missing cases. Never
 silently skip required browser testing, and never treat curl as browser proof.
 
-**Local domain preference:** For Assembly projects, prefer local `.site`/`.test` TLD domains (e.g., `http://assembly.coop.site`) over `localhost:PORT`. These are configured via Caddy/DDEV and match the visual-browser-tester's URL discovery order.
+**Local target:** Use the exact selected URL. Do not substitute a preferred
+domain or guessed port.
 
 **Page discovery:** After connecting to the dev server, discover testable pages:
 

--- a/plugins/model-router/.claude-plugin/plugin.json
+++ b/plugins/model-router/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "model-router",
   "description": "Internal deterministic role resolver and one-shot dispatcher for provider-neutral model work",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "author": {
     "name": "Design Machines",
     "url": "https://designmachines.studio"

--- a/plugins/model-router/.codex-plugin/plugin.json
+++ b/plugins/model-router/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "model-router",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Internal deterministic role resolver and one-shot dispatcher for provider-neutral model work",
   "author": {
     "name": "Design Machines",

--- a/plugins/model-router/skills/model-router/SKILL.md
+++ b/plugins/model-router/skills/model-router/SKILL.md
@@ -9,8 +9,9 @@ disable-model-invocation: true
 This internal skill owns cross-transport role resolution. It is a local policy
 bundle and one-shot dispatcher, not a service.
 
-Callers provide only a role, required capabilities, normalized effort, prompt
-file, output destination, private receipt destination, an explicit complete
+Callers provide only a role, required capabilities, normalized effort, the
+exact validated Workflow Kernel launcher for that invocation, prompt file,
+output destination, private receipt destination, an explicit complete
 repository-evidence file for prompt-only repository readers, and opaque prior
 receipt IDs plus their run-private registry when family independence is
 required. Human-authored work uses the explicit `--human-authored` origin flag
@@ -42,11 +43,21 @@ snapshot `limitId`, and evaluates only the mapped bucket's five-hour and weekly
 windows at the existing 8% threshold. It never selects the best bucket. The
 legacy 0.146 `rateLimits.primary`/`secondary` snapshot and a single 0.147 bucket
 are unambiguous defaults. Multiple 0.147 buckets without an authoritative
-candidate mapping close as `rate_limit_mapping_unknown`; the current Codex
-app-server schema does not expose that mapping, so the policy does not invent
-one for current candidates. Missing, malformed, unsupported, exhausted, or
-unmappable evidence fails closed with a content-safe reason; unknown never
-means exhausted.
+candidate mapping remain unattributed. If every normalized allowance is
+exhausted, Codex is skipped as `rate_limit_exhausted`. If at least one allowance
+is healthy, the requested candidate is attemptable once and its actual
+invocation is authoritative; no bucket is selected or claimed. Missing,
+malformed, unsupported, or window-incomplete evidence remains unavailable with
+a content-safe reason. `rate_limit_mapping_unknown` alone never means exhausted
+or blocks an authenticated candidate.
+
+Before availability probing, the dispatcher uses the supplied launcher to
+resolve one coherent OpenRouter bundle. That exact binding supplies credential
+loading, availability, the disclosure boundary, and wrapper invocation; it is
+never re-resolved during an attempt. Closed public diagnostics distinguish the
+Kernel launcher, provider bundle, credential, availability, boundary,
+transport, and model-unavailable causes without exposing stderr or private
+paths.
 
 The `browser` request capability means access to the caller's local interactive
 browser, not public web search. No current one-shot transport advertises that
@@ -76,6 +87,15 @@ preference schema is
 `${CLAUDE_SKILL_DIR}/references/operator-profile-schema.json`; an actual
 preference belongs in ignored `.dm/model-router.local.json` in the common
 checkout and must never contain operator identity.
+
+For a coordinator preparing a human copy-paste execution prompt, use
+`${CLAUDE_SKILL_DIR}/references/operator-recommendation.sh`. This read-only
+projection filters the current role policy by requested capabilities and
+availability, reads prices only from the caller-bound model matrix, and returns
+one concrete primary plus one fallback. It never invokes a model. Its identity
+and cost projection is human-only and must not enter any participant prompt,
+planning-opinion packet, reviewer prompt, participant output, or synthesis
+input.
 
 When a Pipeline, dm-review, or Assembly opinion invocation has reached a closed
 terminal state and no later model dispatch is possible, load

--- a/plugins/model-router/skills/model-router/references/availability-probe.sh
+++ b/plugins/model-router/skills/model-router/references/availability-probe.sh
@@ -320,7 +320,16 @@ EOF
           state="$(printf '%s' "$allowances" | jq -r --arg key "$default_allowance_id" '.[$key].state')"
           reason="$(printf '%s' "$allowances" | jq -r --arg key "$default_allowance_id" '.[$key].reason')"
         else
-          reason="rate_limit_mapping_unknown"
+          if printf '%s' "$allowances" | jq -e 'all(.[]; .state == "limited")' >/dev/null; then
+            state="limited"
+            reason="rate_limit_exhausted"
+          else
+            # Bucket ownership remains unknown, but a healthy allowance makes
+            # an authenticated candidate attemptable at dispatch time. Do not
+            # select or attribute a bucket here.
+            state="unknown"
+            reason="rate_limit_mapping_unknown"
+          fi
         fi
       fi
     elif [ "$map_type" != absent ] && [ "$map_type" != null ]; then
@@ -344,7 +353,7 @@ EOF
 }
 
 openrouter_json() {
-  local response="" rc=0 balance="" credential_loader="" active_host="" bundle_json="" bundle_ref="" header_file="" probe_key=""
+  local response="" rc=0 balance="" credential_loader="" active_host="" bundle_json="" bundle_ref="" header_file="" probe_key="" credential_state="missing"
   if [ -n "${OPENROUTER_API_KEY_FILE:-}" ] && [ -z "${OPENROUTER_API_KEY:-}" ]; then
     case "${OPENROUTER_BUNDLE_RESOLVED:-0}:${OPENROUTER_BUNDLE_REF:-}" in
       "1:~/"*) credential_loader="$HOME/${OPENROUTER_BUNDLE_REF#\~/}/skills/openrouter-delegate/references/openrouter-credential.sh" ;;
@@ -380,7 +389,10 @@ openrouter_json() {
       load_openrouter_api_key || OPENROUTER_API_KEY=""
     fi
   fi
-  if [ -n "${OPENROUTER_API_KEY:-}" ] && command -v curl >/dev/null 2>&1; then
+  if [ -n "${OPENROUTER_API_KEY:-}" ]; then
+    credential_state="available"
+  fi
+  if [ "$credential_state" = available ] && command -v curl >/dev/null 2>&1; then
     header_file="$(mktemp "${TMPDIR:-/tmp}/openrouter-probe.header.XXXXXX")" || header_file=""
     [ -z "$header_file" ] || chmod 600 "$header_file"
     if [ -n "$header_file" ]; then
@@ -412,12 +424,13 @@ openrouter_json() {
   # availability boundary. A finite non-negative balance is positive evidence
   # that the API balance probe worked; missing, malformed, or negative values
   # remain unknown and fail closed at role dispatch.
-  local state="unknown"
+  local state="unknown" reason="provider_availability_unknown"
   if [ -n "$balance" ]; then
-    if awk -v b="$balance" 'BEGIN{exit !(b >= 0)}'; then state="ok"; fi
+    if awk -v b="$balance" 'BEGIN{exit !(b >= 0)}'; then state="ok"; reason="available"; fi
   fi
-  jq -cn --arg balance "$balance" --arg state "$state" \
-    '{state:$state,
+  [ "$credential_state" = available ] || reason="provider_credential_unavailable"
+  jq -cn --arg balance "$balance" --arg state "$state" --arg reason "$reason" \
+    '{state:$state,reason:$reason,
       balance_usd:(if $balance == "" then null else ($balance | tonumber) end)}'
 }
 

--- a/plugins/model-router/skills/model-router/references/openrouter-write-adapter.sh
+++ b/plugins/model-router/skills/model-router/references/openrouter-write-adapter.sh
@@ -100,51 +100,27 @@ if [ -z "${OPENROUTER_API_KEY:-}" ] && [ -z "${OPENROUTER_API_KEY_FILE:-}" ]; th
   exit 77
 fi
 
-resolve_openrouter_bundle() {
-  local active_host=""
-  [ -n "${WORKFLOW_KERNEL:-}" ] && [ -x "$WORKFLOW_KERNEL" ] || return 1
-  [ -n "${CLAUDE_CODE:-}${CLAUDECODE:-}" ] && active_host="claude"
-  [ -n "${CODEX_SANDBOX:-}${CODEX_HOME:-}" ] && active_host="codex"
-  if [ -n "$active_host" ]; then
-    "$WORKFLOW_KERNEL" resolve-plugin-bundle --plugin openrouter \
-      --minimum-version 1.19.0 --active-host "$active_host" \
-      --required-executable skills/openrouter-delegate/references/openrouter-wrapper.sh \
-      --required-asset skills/openrouter-delegate/references/openrouter-credential.sh \
-      --required-asset skills/openrouter-delegate/references/delegation-security-policy.json \
-      --required-executable skills/openrouter-delegate/references/delegation-boundary.sh
-  else
-    "$WORKFLOW_KERNEL" resolve-plugin-bundle --plugin openrouter \
-      --minimum-version 1.19.0 \
-      --required-executable skills/openrouter-delegate/references/openrouter-wrapper.sh \
-      --required-asset skills/openrouter-delegate/references/openrouter-credential.sh \
-      --required-asset skills/openrouter-delegate/references/delegation-security-policy.json \
-      --required-executable skills/openrouter-delegate/references/delegation-boundary.sh
-  fi
-}
-
-RESOLVED_BUNDLE_JSON="$(resolve_openrouter_bundle)" || {
+if [ "${OPENROUTER_BUNDLE_RESOLVED:-0}" != 1 ]; then
   echo "openrouter-exec: coherent OpenRouter bundle unavailable; return to Codex" >&2
   exit 77
-}
-RESOLVED_BUNDLE_REF="$(printf '%s' "$RESOLVED_BUNDLE_JSON" | jq -r '.selected_root // empty')"
-RESOLVED_BUNDLE_VERSION="$(printf '%s' "$RESOLVED_BUNDLE_JSON" | jq -r '.version // empty')"
-RESOLVED_BUNDLE_CACHE_CLASS="$(printf '%s' "$RESOLVED_BUNDLE_JSON" | jq -r '.cache_class // empty')"
-RESOLVED_BUNDLE_REASON="$(printf '%s' "$RESOLVED_BUNDLE_JSON" | jq -r '.reason // empty')"
-if [ -n "${OPENROUTER_BUNDLE_REF:-}" ] &&
-   { [ "$RESOLVED_BUNDLE_REF" != "$OPENROUTER_BUNDLE_REF" ] ||
-     [ "$RESOLVED_BUNDLE_VERSION" != "${OPENROUTER_BUNDLE_VERSION:-}" ] ||
-     [ "$RESOLVED_BUNDLE_CACHE_CLASS" != "${OPENROUTER_BUNDLE_CACHE_CLASS:-}" ] ||
-     [ "$RESOLVED_BUNDLE_REASON" != "${OPENROUTER_BUNDLE_REASON:-}" ]; }; then
-  echo "openrouter-exec: OpenRouter bundle binding changed before transport; return to Codex" >&2
-  exit 77
 fi
-case "$RESOLVED_BUNDLE_REF" in
-  "~/"*) OPENROUTER_ROOT="$HOME/${RESOLVED_BUNDLE_REF#\~/}" ;;
+[ -n "${OPENROUTER_BUNDLE_VERSION:-}" ] &&
+  [ -n "${OPENROUTER_BUNDLE_CACHE_CLASS:-}" ] &&
+  [ -n "${OPENROUTER_BUNDLE_REASON:-}" ] || {
+  echo "openrouter-exec: incomplete OpenRouter bundle binding; return to Codex" >&2
+  exit 77
+}
+case "${OPENROUTER_BUNDLE_REF:-}" in
+  "~/"*) OPENROUTER_ROOT="$HOME/${OPENROUTER_BUNDLE_REF#\~/}" ;;
   *) echo "openrouter-exec: invalid OpenRouter bundle binding; return to Codex" >&2; exit 77 ;;
 esac
 WRAPPER="$OPENROUTER_ROOT/skills/openrouter-delegate/references/openrouter-wrapper.sh"
 POLICY="$OPENROUTER_ROOT/skills/openrouter-delegate/references/delegation-security-policy.json"
 BOUNDARY="$OPENROUTER_ROOT/skills/openrouter-delegate/references/delegation-boundary.sh"
+[ -x "$WRAPPER" ] && [ -r "$POLICY" ] && [ -x "$BOUNDARY" ] || {
+  echo "openrouter-exec: bound OpenRouter assets unavailable; return to Codex" >&2
+  exit 77
+}
 
 TASK_TMP_ROOT="${TMPDIR:-/tmp}"
 SYSTEM="You are a bounded patch generator. You have no filesystem, shell, command, tool, or repository access beyond the task and untrusted file contents in the user prompt. Return only a Git unified diff. No prose. No markdown fences."
@@ -525,9 +501,9 @@ jq -n --arg commit "$(git rev-parse --short HEAD)" --arg files "$FILES_CHANGED" 
   --arg provider "$(jq -r '.servingProvider // ""' "$RECEIPT_FILE")" \
   --arg provider_provenance "$(jq -r '.servingProviderProvenance' "$RECEIPT_FILE")" \
   --arg generation_id "$(jq -r '.generationId' "$RECEIPT_FILE")" \
-  --arg bundle_version "$RESOLVED_BUNDLE_VERSION" \
-  --arg bundle_cache_class "$RESOLVED_BUNDLE_CACHE_CLASS" \
-  --arg bundle_reason "$RESOLVED_BUNDLE_REASON" \
+  --arg bundle_version "$OPENROUTER_BUNDLE_VERSION" \
+  --arg bundle_cache_class "$OPENROUTER_BUNDLE_CACHE_CLASS" \
+  --arg bundle_reason "$OPENROUTER_BUNDLE_REASON" \
   --arg contract_digest "${MODEL_ROUTER_CONTRACT_DIGEST:-}" \
   --argjson contract_revision "${MODEL_ROUTER_CONTRACT_REVISION:-0}" \
   --arg request_digest "$(jq -r '.authorization.requestEnvelopeSha256' "$RECEIPT_FILE")" \

--- a/plugins/model-router/skills/model-router/references/operator-recommendation.sh
+++ b/plugins/model-router/skills/model-router/references/operator-recommendation.sh
@@ -1,0 +1,191 @@
+#!/usr/bin/env bash
+# Read-only human-facing recommendation projection. Never dispatches a model.
+set -euo pipefail
+
+PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
+export PATH
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+POLICY="$DIR/role-policy.json"
+MATRIX=""
+AVAILABILITY_FILE=""
+WORKFLOW_KERNEL_LAUNCHER=""
+ROLE=""
+EFFORT=""
+FORMAT=markdown
+CAPABILITIES=()
+
+usage() {
+  printf '%s\n' 'usage: operator-recommendation --role ROLE --capability CAP [--capability CAP ...] --effort EFFORT --matrix-file PATH [--availability-file PATH | --workflow-kernel PATH] [--format markdown|json]' >&2
+  exit 2
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --role) [ "$#" -ge 2 ] || usage; ROLE="$2"; shift 2 ;;
+    --capability) [ "$#" -ge 2 ] || usage; CAPABILITIES+=("$2"); shift 2 ;;
+    --effort) [ "$#" -ge 2 ] || usage; EFFORT="$2"; shift 2 ;;
+    --matrix-file) [ "$#" -ge 2 ] || usage; MATRIX="$2"; shift 2 ;;
+    --availability-file) [ "$#" -ge 2 ] || usage; AVAILABILITY_FILE="$2"; shift 2 ;;
+    --workflow-kernel) [ "$#" -ge 2 ] || usage; WORKFLOW_KERNEL_LAUNCHER="$2"; shift 2 ;;
+    --policy-file)
+      [ "${MODEL_ROUTER_TEST_MODE:-0}" = 1 ] && [ "$#" -ge 2 ] || usage
+      POLICY="$2"; shift 2 ;;
+    --format) [ "$#" -ge 2 ] || usage; FORMAT="$2"; shift 2 ;;
+    *) usage ;;
+  esac
+done
+
+case "$ROLE" in architect|plan-critic|builder-fast|builder-deep|review-fast|review-deep|security-review|research-fast|editorial) ;; *) usage ;; esac
+case "$EFFORT" in low|medium|high|max) ;; *) usage ;; esac
+case "$FORMAT" in markdown|json) ;; *) usage ;; esac
+[ -r "$POLICY" ] && [ ! -L "$POLICY" ] && jq -e '.schemaVersion == 1' "$POLICY" >/dev/null || usage
+[ -r "$MATRIX" ] && [ ! -L "$MATRIX" ] && jq -e '.schema_version == 1 and (.snapshot_date | type) == "string"' "$MATRIX" >/dev/null || usage
+[ -z "$AVAILABILITY_FILE" ] || [ -z "$WORKFLOW_KERNEL_LAUNCHER" ] || usage
+
+CAPABILITIES_JSON='[]'
+for capability in "${CAPABILITIES[@]}"; do
+  case "$capability" in read-repository|write-repository|tool-use|browser|long-context|structured-output|independent-family) ;; *) usage ;; esac
+  CAPABILITIES_JSON="$(printf '%s' "$CAPABILITIES_JSON" | jq -c --arg value "$capability" '. + [$value] | unique | sort')"
+done
+
+if [ -n "$AVAILABILITY_FILE" ]; then
+  [ -r "$AVAILABILITY_FILE" ] && [ ! -L "$AVAILABILITY_FILE" ] || usage
+  AVAILABILITY="$(jq -c . "$AVAILABILITY_FILE")" || usage
+else
+  case "$WORKFLOW_KERNEL_LAUNCHER" in /*/workflow-kernel-launcher.sh) ;; *) usage ;; esac
+  [ -f "$WORKFLOW_KERNEL_LAUNCHER" ] && [ -x "$WORKFLOW_KERNEL_LAUNCHER" ] && [ ! -L "$WORKFLOW_KERNEL_LAUNCHER" ] || usage
+  AVAILABILITY="$(WORKFLOW_KERNEL="$WORKFLOW_KERNEL_LAUNCHER" "$DIR/availability-probe.sh")" || AVAILABILITY='{}'
+fi
+
+candidate_status() {
+  local candidate="$1" transport model rate_limit_id auth state
+  transport="$(printf '%s' "$candidate" | jq -r '.transport')"
+  model="$(printf '%s' "$candidate" | jq -r '.model')"
+  case "$transport" in
+    codex-cli)
+      auth="$(printf '%s' "$AVAILABILITY" | jq -r '.codex.authMode // .codex.auth_mode // "unknown"')"
+      [ "$auth" = subscription ] || { printf unavailable; return; }
+      rate_limit_id="$(printf '%s' "$candidate" | jq -r '.rateLimitId // empty')"
+      if [ -n "$rate_limit_id" ]; then
+        state="$(printf '%s' "$AVAILABILITY" | jq -r --arg id "$rate_limit_id" '.codex.allowances[$id].state // "unknown"')"
+        case "$state" in ok) printf available ;; limited) printf unavailable ;; *) printf unknown ;; esac
+      elif [ "$(printf '%s' "$AVAILABILITY" | jq -r '.codex.allowances? | type')" = object ] &&
+           [ "$(printf '%s' "$AVAILABILITY" | jq -r '.codex.allowances | length')" -gt 0 ]; then
+        if printf '%s' "$AVAILABILITY" | jq -e 'any(.codex.allowances[]; .state == "ok")' >/dev/null; then printf attemptable
+        elif printf '%s' "$AVAILABILITY" | jq -e 'all(.codex.allowances[]; .state == "limited")' >/dev/null; then printf unavailable
+        else printf unknown
+        fi
+      else
+        state="$(printf '%s' "$AVAILABILITY" | jq -r '.codex.state // "unknown"')"
+        case "$state" in ok) printf available ;; limited|unavailable) printf unavailable ;; *) printf unknown ;; esac
+      fi
+      ;;
+    claude-cli)
+      auth="$(printf '%s' "$AVAILABILITY" | jq -r '.claude.authMode // .claude.auth_mode // "unknown"')"
+      state="$(printf '%s' "$AVAILABILITY" | jq -r '.claude.state // "unknown"')"
+      [ "$auth" = subscription ] || { printf unavailable; return; }
+      if [ "$model" = fable ] && [ "$(printf '%s' "$AVAILABILITY" | jq -r '.claude.fable // "unknown"')" = exhausted ]; then
+        printf unavailable
+      else
+        case "$state" in ok) printf available ;; unavailable) printf unavailable ;; *) printf unknown ;; esac
+      fi
+      ;;
+    openrouter)
+      state="$(printf '%s' "$AVAILABILITY" | jq -r '.openrouter.state // "unknown"')"
+      case "$state" in ok) printf available ;; unavailable|limited) printf unavailable ;; *) printf unknown ;; esac
+      ;;
+  esac
+}
+
+CANDIDATES='[]'
+while IFS= read -r candidate; do
+  [ -n "$candidate" ] || continue
+  if jq -en --argjson requested "$CAPABILITIES_JSON" --argjson candidate "$candidate" '
+    ($requested - ["independent-family"]) as $needed
+    | all($needed[]; . as $cap | $candidate.capabilities | index($cap) != null)
+  ' >/dev/null; then
+    status="$(candidate_status "$candidate")"
+    CANDIDATES="$(printf '%s' "$CANDIDATES" | jq -c --argjson candidate "$candidate" --arg status "$status" '. + [$candidate + {availability:$status}]')"
+  fi
+done < <(jq -c --arg role "$ROLE" '.roles[$role][]' "$POLICY")
+
+PRIMARY="$(printf '%s' "$CANDIDATES" | jq -c '([.[] | select(.availability == "available" or .availability == "attemptable")][0] // [.[] | select(.availability == "unknown")][0]) // empty')"
+[ -n "$PRIMARY" ] && [ "$PRIMARY" != null ] || {
+  jq -cn --arg role "$ROLE" '{recommendedStart:null,reason:"no_capability_compatible_candidate",role:$role}'
+  exit 76
+}
+PRIMARY_MODEL="$(printf '%s' "$PRIMARY" | jq -r '.model')"
+FALLBACK="$(printf '%s' "$CANDIDATES" | jq -c --arg model "$PRIMARY_MODEL" '([.[] | select(.model != $model and (.availability == "available" or .availability == "attemptable"))][0] // [.[] | select(.model != $model and .availability == "unknown")][0] // [.[] | select(.model != $model and .availability == "unavailable")][0]) // empty')"
+[ -n "$FALLBACK" ] && [ "$FALLBACK" != null ] || {
+  jq -cn --arg role "$ROLE" '{recommendedStart:null,reason:"no_concrete_fallback",role:$role}'
+  exit 76
+}
+
+harness_for() {
+  case "$1" in codex-cli) printf Codex ;; claude-cli) printf 'Claude Code' ;; openrouter) printf OpenRouter ;; esac
+}
+cost_for() {
+  local candidate="$1" transport model alias price
+  transport="$(printf '%s' "$candidate" | jq -r '.transport')"
+  model="$(printf '%s' "$candidate" | jq -r '.model')"
+  if [ "$transport" = openrouter ]; then
+    price="$(jq -c --arg model "$model" --arg snapshot "$(jq -r '.snapshot_date' "$MATRIX")" '
+      [.models[] | select(.slug == $model and .catalog_status == "available" and .snapshot_date == $snapshot)][0]
+      | if . == null then null else {inputUsdPerM:.input_usd_per_m,outputUsdPerM:.output_usd_per_m,snapshotDate:.snapshot_date} end
+    ' "$MATRIX")"
+    jq -cn --argjson price "$price" '{label:"metered API",apiPrice:$price,apiEquivalent:null}'
+  else
+    alias="$(jq -r --arg model "$model" '.native_api_equivalent_cost.aliases[$model] // empty' "$MATRIX")"
+    price="$(jq -c --arg alias "$alias" '[.native_api_equivalent_cost.models[] | select(.slug == $alias)][0] // null | if . == null then null else {inputUsdPerM:.input_usd_per_m,outputUsdPerM:.output_usd_per_m,snapshotDate:.snapshot_date,basis:.pricing_basis} end' "$MATRIX")"
+    jq -cn --argjson price "$price" '{label:"included subscription",apiPrice:null,apiEquivalent:$price}'
+  fi
+}
+
+PRIMARY_TRANSPORT="$(printf '%s' "$PRIMARY" | jq -r '.transport')"
+FALLBACK_TRANSPORT="$(printf '%s' "$FALLBACK" | jq -r '.transport')"
+PRIMARY_HARNESS="$(harness_for "$PRIMARY_TRANSPORT")"
+FALLBACK_HARNESS="$(harness_for "$FALLBACK_TRANSPORT")"
+PRIMARY_AVAILABILITY="$(printf '%s' "$PRIMARY" | jq -r '.availability')"
+FALLBACK_AVAILABILITY="$(printf '%s' "$FALLBACK" | jq -r '.availability')"
+EFFECTIVE_EFFORT="$(jq -r --arg transport "$PRIMARY_TRANSPORT" --arg effort "$EFFORT" '.effort.transports[$transport][$effort]' "$POLICY")"
+CAPABILITY_TEXT="$(printf '%s' "$CAPABILITIES_JSON" | jq -r 'join(", ")')"
+if [ "$PRIMARY_AVAILABILITY" = unknown ]; then
+  WHY="Availability is unknown; this is the first current policy candidate for $ROLE matching $CAPABILITY_TEXT."
+elif [ "$PRIMARY_AVAILABILITY" = attemptable ]; then
+  WHY="Current subscription evidence makes this $ROLE candidate attemptable without attributing an allowance bucket; invocation will settle availability."
+else
+  WHY="This is the first currently available policy candidate for $ROLE matching $CAPABILITY_TEXT."
+fi
+PRIMARY_COST="$(cost_for "$PRIMARY")"
+SNAPSHOT="$(jq -r '.snapshot_date' "$MATRIX")"
+
+RESULT="$(jq -cn --arg model "$PRIMARY_MODEL" --arg harness "$PRIMARY_HARNESS" \
+  --arg effort "$EFFECTIVE_EFFORT" --arg why "$WHY" --arg availability "$PRIMARY_AVAILABILITY" \
+  --arg fallback_model "$(printf '%s' "$FALLBACK" | jq -r '.model')" \
+  --arg fallback_harness "$FALLBACK_HARNESS" --arg fallback_availability "$FALLBACK_AVAILABILITY" \
+  --arg snapshot "$SNAPSHOT" --argjson cost "$PRIMARY_COST" \
+  '{recommendedStart:{model:$model,harness:$harness,effort:$effort,availability:$availability,why:$why,cost:$cost,
+    fallback:{model:$fallback_model,harness:$fallback_harness,availability:$fallback_availability},matrixEvidence:$snapshot}}')"
+
+if [ "$FORMAT" = json ]; then
+  printf '%s\n' "$RESULT"
+  exit 0
+fi
+
+cost_label="$(printf '%s' "$RESULT" | jq -r '.recommendedStart.cost.label')"
+if [ "$cost_label" = 'metered API' ]; then
+  price_text="$(printf '%s' "$RESULT" | jq -r 'if .recommendedStart.cost.apiPrice == null then "price unavailable in current matrix" else "$" + (.recommendedStart.cost.apiPrice.inputUsdPerM|tostring) + "/M input, $" + (.recommendedStart.cost.apiPrice.outputUsdPerM|tostring) + "/M output" end')"
+  COST_TEXT="metered API; $price_text"
+else
+  equivalent_text="$(printf '%s' "$RESULT" | jq -r 'if .recommendedStart.cost.apiEquivalent == null then "API-equivalent unavailable in current matrix" else "API-equivalent $" + (.recommendedStart.cost.apiEquivalent.inputUsdPerM|tostring) + "/M input, $" + (.recommendedStart.cost.apiEquivalent.outputUsdPerM|tostring) + "/M output (" + .recommendedStart.cost.apiEquivalent.snapshotDate + ")" end')"
+  COST_TEXT="included subscription; $equivalent_text"
+fi
+printf 'Recommended start\n\n'
+printf -- '- Model: %s\n' "$PRIMARY_MODEL"
+printf -- '- Harness/rail: %s\n' "$PRIMARY_HARNESS"
+printf -- '- Effort: %s\n' "$EFFECTIVE_EFFORT"
+printf -- '- Why: %s\n' "$WHY"
+printf -- '- Cost: %s\n' "$COST_TEXT"
+printf -- '- Fallback: %s via %s (availability: %s)\n' "$(printf '%s' "$FALLBACK" | jq -r '.model')" "$FALLBACK_HARNESS" "$FALLBACK_AVAILABILITY"
+printf -- '- Matrix evidence: %s\n' "$SNAPSHOT"

--- a/plugins/model-router/skills/model-router/references/receipt-contract.md
+++ b/plugins/model-router/skills/model-router/references/receipt-contract.md
@@ -9,7 +9,11 @@ Availability/fallback reasons are limited to router-authored content-safe codes,
 including `rate_limit_probe_no_response`, `rate_limit_response_malformed`,
 `rate_limit_shape_unsupported`, `rate_limit_mapping_unknown`,
 `required_window_missing`, `rate_limit_exhausted`,
-`browser_transport_unavailable`, and `model_participant_unavailable`. They
+`workflow_kernel_unavailable`, `provider_bundle_unavailable`,
+`provider_credential_unavailable`, `provider_availability_unknown`,
+`provider_boundary_declined`, `provider_transport_failed`,
+`provider_model_unavailable`, `browser_transport_unavailable`, and
+`model_participant_unavailable`. They
 never contain raw CLI/provider output, account identity, quota balances,
 credentials, prompts, or private paths.
 

--- a/plugins/model-router/skills/model-router/references/role-dispatch.sh
+++ b/plugins/model-router/skills/model-router/references/role-dispatch.sh
@@ -21,13 +21,14 @@ HUMAN_AUTHORED=0
 CONTRACT_DIGEST=""
 CONTRACT_REVISION=""
 CONTRACT_REVISION_JSON=null
+WORKFLOW_KERNEL_LAUNCHER=""
 CAPABILITIES=()
 INDEPENDENCE_RECEIPT_IDS=()
 CAPABILITY_COUNT=0
 INDEPENDENCE_RECEIPT_COUNT=0
 
 usage() {
-  printf '%s\n' 'usage: role-dispatch --role ROLE --capability CAP [--capability CAP ...] --effort EFFORT --prompt-file PATH --output-file PATH --receipt-file PATH [--repository-evidence-file PATH] [--independence-receipt-dir DIR --independence-receipt-id ID ... | --human-authored] [--contract-digest SHA256 --contract-revision N]' >&2
+  printf '%s\n' 'usage: role-dispatch --role ROLE --capability CAP [--capability CAP ...] --effort EFFORT --workflow-kernel PATH --prompt-file PATH --output-file PATH --receipt-file PATH [--repository-evidence-file PATH] [--independence-receipt-dir DIR --independence-receipt-id ID ... | --human-authored] [--contract-digest SHA256 --contract-revision N]' >&2
   exit 2
 }
 
@@ -45,6 +46,7 @@ while [ "$#" -gt 0 ]; do
     --human-authored) HUMAN_AUTHORED=1; shift ;;
     --contract-digest) [ "$#" -ge 2 ] || usage; CONTRACT_DIGEST="$2"; shift 2 ;;
     --contract-revision) [ "$#" -ge 2 ] || usage; CONTRACT_REVISION="$2"; shift 2 ;;
+    --workflow-kernel) [ "$#" -ge 2 ] || usage; WORKFLOW_KERNEL_LAUNCHER="$2"; shift 2 ;;
     *) usage ;;
   esac
 done
@@ -179,11 +181,52 @@ if [ -n "$PROFILE" ]; then
   PAID_CLAUDE_CREDITS="$(jq -r '.allowPaidClaudeCredits // false' "$PROFILE")"
 fi
 
+OPENROUTER_BUNDLE_STATE="workflow_kernel_unavailable"
+OPENROUTER_BUNDLE_REF=""
+OPENROUTER_BUNDLE_ROOT=""
+OPENROUTER_BUNDLE_VERSION=""
+OPENROUTER_BUNDLE_CACHE_CLASS=""
+OPENROUTER_BUNDLE_REASON=""
+resolve_openrouter_bundle() {
+  local active_host="" bundle_json bundle_ref
+  case "$WORKFLOW_KERNEL_LAUNCHER" in /*/workflow-kernel-launcher.sh) ;; *) return 1 ;; esac
+  [ -f "$WORKFLOW_KERNEL_LAUNCHER" ] && [ -x "$WORKFLOW_KERNEL_LAUNCHER" ] &&
+    [ ! -L "$WORKFLOW_KERNEL_LAUNCHER" ] || return 1
+  OPENROUTER_BUNDLE_STATE="provider_bundle_unavailable"
+  [ -n "${CLAUDE_CODE:-}${CLAUDECODE:-}" ] && active_host=claude
+  [ -n "${CODEX_SANDBOX:-}${CODEX_HOME:-}" ] && active_host=codex
+  args=(resolve-plugin-bundle --plugin openrouter --minimum-version 1.19.0
+    --required-executable skills/openrouter-delegate/references/openrouter-wrapper.sh
+    --required-asset skills/openrouter-delegate/references/openrouter-credential.sh
+    --required-asset skills/openrouter-delegate/references/delegation-security-policy.json
+    --required-executable skills/openrouter-delegate/references/delegation-boundary.sh)
+  [ -n "$active_host" ] && args+=(--active-host "$active_host")
+  bundle_json="$("$WORKFLOW_KERNEL_LAUNCHER" "${args[@]}" 2>/dev/null)" || return 1
+  bundle_ref="$(printf '%s' "$bundle_json" | jq -r '.selected_root // empty')"
+  case "$bundle_ref" in '~/'*) ;; *) return 1 ;; esac
+  OPENROUTER_BUNDLE_REF="$bundle_ref"
+  OPENROUTER_BUNDLE_ROOT="$HOME/${bundle_ref#\~/}"
+  OPENROUTER_BUNDLE_VERSION="$(printf '%s' "$bundle_json" | jq -r '.version // empty')"
+  OPENROUTER_BUNDLE_CACHE_CLASS="$(printf '%s' "$bundle_json" | jq -r '.cache_class // empty')"
+  OPENROUTER_BUNDLE_REASON="$(printf '%s' "$bundle_json" | jq -r '.reason // empty')"
+  [ -x "$OPENROUTER_BUNDLE_ROOT/skills/openrouter-delegate/references/openrouter-wrapper.sh" ] &&
+    [ -r "$OPENROUTER_BUNDLE_ROOT/skills/openrouter-delegate/references/openrouter-credential.sh" ] &&
+    [ -r "$OPENROUTER_BUNDLE_ROOT/skills/openrouter-delegate/references/delegation-security-policy.json" ] &&
+    [ -x "$OPENROUTER_BUNDLE_ROOT/skills/openrouter-delegate/references/delegation-boundary.sh" ] || return 1
+  OPENROUTER_BUNDLE_STATE="resolved"
+}
+resolve_openrouter_bundle || true
+
 if [ -n "${MODEL_ROUTER_AVAILABILITY_FILE:-}" ]; then
   [ -r "$MODEL_ROUTER_AVAILABILITY_FILE" ] && [ ! -L "$MODEL_ROUTER_AVAILABILITY_FILE" ] || usage
   AVAILABILITY="$(jq -c '. + {probeSource:"fixture"}' "$MODEL_ROUTER_AVAILABILITY_FILE")" || usage
 else
-  AVAILABILITY="$("$DIR/availability-probe.sh" | jq -c '. + {probeSource:"live"}')" || AVAILABILITY='{"probeSource":"live"}'
+  AVAILABILITY="$(OPENROUTER_BUNDLE_RESOLVED="$([ "$OPENROUTER_BUNDLE_STATE" = resolved ] && printf 1 || printf 0)" \
+    OPENROUTER_BUNDLE_REF="$OPENROUTER_BUNDLE_REF" \
+    OPENROUTER_BUNDLE_VERSION="$OPENROUTER_BUNDLE_VERSION" \
+    OPENROUTER_BUNDLE_CACHE_CLASS="$OPENROUTER_BUNDLE_CACHE_CLASS" \
+    OPENROUTER_BUNDLE_REASON="$OPENROUTER_BUNDLE_REASON" \
+    "$DIR/availability-probe.sh" | jq -c '. + {probeSource:"live"}')" || AVAILABILITY='{"probeSource":"live"}'
 fi
 PROBE_SOURCE="$(printf '%s' "$AVAILABILITY" | jq -r '.probeSource')"
 TRANSPORT_STUB=false
@@ -232,7 +275,7 @@ candidate_has_capabilities() {
 }
 
 transport_eligibility() {
-  local transport="$1" model="$2" rate_limit_id="${3:-}" state auth_mode plan fable_state observed sdk_observed five weekly paid allowance_reason
+  local transport="$1" model="$2" rate_limit_id="${3:-}" state auth_mode plan fable_state observed sdk_observed five weekly paid allowance_reason healthy_count allowance_count
   BILLING_MODE="unavailable"
   ALLOWANCE_WINDOW="unavailable"
   ELIGIBILITY_REASON="model_participant_unavailable"
@@ -248,10 +291,30 @@ transport_eligibility() {
           rate_limit_id="codex"
         fi
       fi
-      [ -n "$rate_limit_id" ] || {
+      if [ -z "$rate_limit_id" ] &&
+         [ "$(printf '%s' "$AVAILABILITY" | jq -r '.codex.allowances? | type')" = object ]; then
+        allowance_count="$(printf '%s' "$AVAILABILITY" | jq -r '.codex.allowances | length')"
+        healthy_count="$(printf '%s' "$AVAILABILITY" | jq -r '[.codex.allowances[] | select(.state == "ok")] | length')"
+        if [ "$allowance_count" -gt 0 ] && [ "$healthy_count" -gt 0 ]; then
+          auth_mode="$(printf '%s' "$AVAILABILITY" | jq -r '.codex.authMode // .codex.auth_mode // "unknown"')"
+          [ "$auth_mode" = subscription ] || {
+            ELIGIBILITY_REASON="model_participant_unavailable"
+            return 1
+          }
+          BILLING_MODE="included-subscription"
+          ALLOWANCE_WINDOW="mapping-unknown"
+          ELIGIBILITY_REASON="attemptable"
+          return 0
+        fi
+        if [ "$allowance_count" -gt 0 ] &&
+           printf '%s' "$AVAILABILITY" | jq -e 'all(.codex.allowances[]; .state == "limited")' >/dev/null; then
+          ELIGIBILITY_REASON="rate_limit_exhausted"
+          return 1
+        fi
         ELIGIBILITY_REASON="rate_limit_mapping_unknown"
         return 1
-      }
+      fi
+      [ -n "$rate_limit_id" ] || { ELIGIBILITY_REASON="rate_limit_mapping_unknown"; return 1; }
       if [ "$(printf '%s' "$AVAILABILITY" | jq -r '.codex.allowances? | type')" = object ]; then
         if ! printf '%s' "$AVAILABILITY" | jq -e --arg limit_id "$rate_limit_id" \
           '.codex.allowances | has($limit_id)' >/dev/null 2>&1; then
@@ -323,8 +386,19 @@ transport_eligibility() {
       esac
       ;;
     openrouter)
+      if [ "$OPENROUTER_BUNDLE_STATE" != resolved ]; then
+        ELIGIBILITY_REASON="$OPENROUTER_BUNDLE_STATE"
+        return 1
+      fi
       state="$(printf '%s' "$AVAILABILITY" | jq -r '.openrouter.state // "unknown"')"
-      [ "$state" = ok ] || return 1
+      if [ "$state" != ok ]; then
+        allowance_reason="$(printf '%s' "$AVAILABILITY" | jq -r '.openrouter.reason // "provider_availability_unknown"')"
+        case "$allowance_reason" in
+          provider_credential_unavailable|provider_availability_unknown) ELIGIBILITY_REASON="$allowance_reason" ;;
+          *) ELIGIBILITY_REASON="provider_availability_unknown" ;;
+        esac
+        return 1
+      fi
       BILLING_MODE="api"
       ALLOWANCE_WINDOW="api"
       ;;
@@ -332,24 +406,9 @@ transport_eligibility() {
   esac
 }
 
-resolve_openrouter_root() {
-  local active_host="" bundle_json bundle_ref
-  [ -n "${WORKFLOW_KERNEL:-}" ] && [ -x "$WORKFLOW_KERNEL" ] || return 1
-  [ -n "${CLAUDE_CODE:-}${CLAUDECODE:-}" ] && active_host=claude
-  [ -n "${CODEX_SANDBOX:-}${CODEX_HOME:-}" ] && active_host=codex
-  args=(resolve-plugin-bundle --plugin openrouter --minimum-version 1.19.0
-    --required-executable skills/openrouter-delegate/references/openrouter-wrapper.sh
-    --required-asset skills/openrouter-delegate/references/openrouter-credential.sh
-    --required-asset skills/openrouter-delegate/references/delegation-security-policy.json
-    --required-executable skills/openrouter-delegate/references/delegation-boundary.sh)
-  [ -n "$active_host" ] && args+=(--active-host "$active_host")
-  bundle_json="$("$WORKFLOW_KERNEL" "${args[@]}" 2>>"$PRIVATE_LOG")" || return 1
-  bundle_ref="$(printf '%s' "$bundle_json" | jq -r '.selected_root // empty')"
-  case "$bundle_ref" in '~/'*) printf '%s\n' "$HOME/${bundle_ref#\~/}" ;; *) return 1 ;; esac
-}
-
 invoke_candidate() {
   local transport="$1" model="$2" effective="$3" rc=0 root system_file prompt_copy result_json sandbox
+  INVOKE_REASON=""
   : > "$TRANSPORT_OUTPUT"
   : > "$PROVIDER_RECEIPT"
   if [ -n "${MODEL_ROUTER_TRANSPORT_STUB:-}" ]; then
@@ -394,16 +453,21 @@ invoke_candidate() {
       printf '%s' "$result_json" > "$PROVIDER_RECEIPT"
       ;;
     openrouter)
+      root="$OPENROUTER_BUNDLE_ROOT"
+      [ "$OPENROUTER_BUNDLE_STATE" = resolved ] || { INVOKE_REASON="$OPENROUTER_BUNDLE_STATE"; return 77; }
       if printf '%s' "$CAPABILITIES_JSON" | jq -e 'index("write-repository") != null' >/dev/null; then
         [ -n "${OPENROUTER_EXEC_ALLOWED_PATHS:-}" ] || return 77
         argv=("$DIR/openrouter-write-adapter.sh" --model "$model")
         MODEL_ROUTER_CONTRACT_DIGEST="$CONTRACT_DIGEST" \
           MODEL_ROUTER_CONTRACT_REVISION="$CONTRACT_REVISION" \
+          OPENROUTER_BUNDLE_RESOLVED=1 OPENROUTER_BUNDLE_REF="$OPENROUTER_BUNDLE_REF" \
+          OPENROUTER_BUNDLE_VERSION="$OPENROUTER_BUNDLE_VERSION" \
+          OPENROUTER_BUNDLE_CACHE_CLASS="$OPENROUTER_BUNDLE_CACHE_CLASS" \
+          OPENROUTER_BUNDLE_REASON="$OPENROUTER_BUNDLE_REASON" \
           "${argv[@]}" < "$PROMPT_FILE" > "$PROVIDER_RECEIPT" 2>>"$PRIVATE_LOG" || return $?
         jq -n --arg digest "$CONTRACT_DIGEST" --argjson revision "$CONTRACT_REVISION" \
           '{status:"committed",verification:"required",contract_digest:$digest,revision:$revision}' > "$TRANSPORT_OUTPUT"
       else
-        root="$(resolve_openrouter_root)" || return 77
         system_file="$(mktemp "${TMPDIR:-/tmp}/model-router.system.XXXXXX")" || return 1
         prompt_copy="$(mktemp "${TMPDIR:-/tmp}/model-router.prompt.XXXXXX")" || { rm -f "$system_file"; return 1; }
         printf '%s' 'Return only the requested analysis. You have no command authority.' > "$system_file"
@@ -413,13 +477,20 @@ invoke_candidate() {
           cat "$REPOSITORY_EVIDENCE_FILE" >> "$prompt_copy"
         fi
         argv=("$root/skills/openrouter-delegate/references/delegation-boundary.sh" --mode artifact-delegation --policy "$root/skills/openrouter-delegate/references/delegation-security-policy.json" --content-file "$system_file" --content-file "$prompt_copy")
-        "${argv[@]}" >>"$PRIVATE_LOG" 2>&1 || { rm -f "$system_file" "$prompt_copy"; return 77; }
+        "${argv[@]}" >>"$PRIVATE_LOG" 2>&1 || { INVOKE_REASON="provider_boundary_declined"; rm -f "$system_file" "$prompt_copy"; return 77; }
         argv=(bash "$root/skills/openrouter-delegate/references/openrouter-wrapper.sh" "$model" - 3600)
         env -u OPENROUTER_SYSTEM OPENROUTER_SYSTEM_FILE="$system_file" \
           OPENROUTER_WORKLOAD=mechanical OPENROUTER_WEB_SEARCH=0 \
           OPENROUTER_RECEIPT_FILE="$PROVIDER_RECEIPT" "${argv[@]}" \
           < "$prompt_copy" > "$TRANSPORT_OUTPUT" 2>>"$PRIVATE_LOG"
         rc=$?
+        if [ "$rc" -ne 0 ]; then
+          if jq -e '.httpStatus == 404 or .failureReason == "model_not_found" or .failureReason == "no_available_provider"' "$PROVIDER_RECEIPT" >/dev/null 2>&1; then
+            INVOKE_REASON="provider_model_unavailable"
+          else
+            INVOKE_REASON="provider_transport_failed"
+          fi
+        fi
         rm -f "$system_file" "$prompt_copy"
         return "$rc"
       fi
@@ -530,10 +601,12 @@ while IFS= read -r candidate; do
     jq -n --arg role "$ROLE" --arg participant "$PARTICIPANT_ID" --arg requested_effort "$EFFORT" --arg effective_effort "$EFFECTIVE_EFFORT" --arg output "$OUTPUT_FILE" --arg probe_source "$PROBE_SOURCE" --argjson transport_stub "$TRANSPORT_STUB" --argjson capabilities "$CAPABILITIES_JSON" --argjson fallback "$fallback" --argjson human_authored "$([ "$HUMAN_AUTHORED" -eq 1 ] && printf true || printf false)" --argjson excluded_family_count "$(printf '%s' "$EXCLUDED_FAMILIES" | jq 'length')" '{role:$role,capabilities:$capabilities,requestedEffort:$requested_effort,effectiveEffort:$effective_effort,participantId:$participant,disposition:"completed",fallback:$fallback,evidenceSource:$probe_source,transportStub:$transport_stub,familyIndependence:{humanAuthored:$human_authored,excludedFamilyCount:$excluded_family_count},output:$output}'
     exit 0
   fi
-  if grep -Fqi 'repository-not-clean' "$PRIVATE_LOG"; then reason=repository-not-clean
+  if [ -n "${INVOKE_REASON:-}" ]; then reason="$INVOKE_REASON"
+  elif grep -Fqi 'repository-not-clean' "$PRIVATE_LOG"; then reason=repository-not-clean
   elif grep -Fqi 'write-completion-without-commit' "$PRIVATE_LOG"; then reason=write-completion-without-commit
   elif grep -Fqi 'write-completion-dirty' "$PRIVATE_LOG"; then reason=write-completion-dirty
-  elif grep -qiE 'usage.?limit|rate.?limit|quota|exhausted' "$PRIVATE_LOG"; then reason=quota-exhausted
+  elif grep -qiE 'usage.?limit|rate.?limit|quota|exhausted' "$PRIVATE_LOG"; then
+    if [ "$transport" = codex-cli ]; then reason=rate_limit_exhausted; else reason=quota-exhausted; fi
   elif grep -qiE 'declin|refus' "$PRIVATE_LOG"; then reason=content-refusal
   else reason=transport-unavailable
   fi
@@ -548,7 +621,7 @@ while IFS= read -r candidate; do
       break
     fi
   fi
-  if [ "$reason" = quota-exhausted ]; then
+  if [ "$reason" = quota-exhausted ] || [ "$reason" = rate_limit_exhausted ]; then
     if [ "$transport" = codex-cli ]; then
       EXHAUSTED_TRANSPORTS="$(printf '%s' "$EXHAUSTED_TRANSPORTS" | jq -c --arg value "$transport" '. + [$value] | unique')"
     else

--- a/plugins/model-router/skills/model-router/references/role-request-schema.json
+++ b/plugins/model-router/skills/model-router/references/role-request-schema.json
@@ -4,7 +4,7 @@
   "title": "Model router role request",
   "type": "object",
   "additionalProperties": false,
-  "required": ["role", "capabilities", "effort", "promptFile", "outputFile", "receiptFile"],
+  "required": ["role", "capabilities", "effort", "workflowKernel", "promptFile", "outputFile", "receiptFile"],
   "properties": {
     "role": {
       "enum": ["architect", "plan-critic", "builder-fast", "builder-deep", "review-fast", "review-deep", "security-review", "research-fast", "editorial"]
@@ -17,6 +17,7 @@
       }
     },
     "effort": {"enum": ["low", "medium", "high", "max"]},
+    "workflowKernel": {"type": "string", "minLength": 1},
     "independenceReceiptIds": {
       "type": "array",
       "uniqueItems": true,

--- a/plugins/pipeline/.claude-plugin/plugin.json
+++ b/plugins/pipeline/.claude-plugin/plugin.json
@@ -1,14 +1,14 @@
 {
   "name": "pipeline",
   "description": "Autonomous feature development pipeline with approved-scope intake, minimum-adequate planning, bounded adversarial review, fresh tiered verification, browser recovery, and isolated execution",
-  "version": "1.59.0",
+  "version": "1.60.0",
   "author": {
     "name": "Design Machines",
     "url": "https://designmachines.io"
   },
   "pluginDependencies": {
-    "dm-review": ">=1.72.0",
-    "model-router": ">=0.2.0",
+    "dm-review": ">=1.74.0",
+    "model-router": ">=0.4.0",
     "workflow-kernel": ">=0.17.0"
   },
   "optionalPluginDependencies": {

--- a/plugins/pipeline/.codex-plugin/plugin.json
+++ b/plugins/pipeline/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pipeline",
-  "version": "1.59.0",
+  "version": "1.60.0",
   "description": "Autonomous feature development pipeline with approved-scope intake, minimum-adequate planning, bounded adversarial review, fresh tiered verification, browser recovery, and isolated execution",
   "author": {
     "name": "Design Machines",
@@ -163,8 +163,8 @@
     ]
   },
   "pluginDependencies": {
-    "dm-review": ">=1.72.0",
-    "model-router": ">=0.2.0",
+    "dm-review": ">=1.74.0",
+    "model-router": ">=0.4.0",
     "workflow-kernel": ">=0.17.0"
   },
   "optionalPluginDependencies": {

--- a/plugins/pipeline/agents/workflow/execution-orchestrator.md
+++ b/plugins/pipeline/agents/workflow/execution-orchestrator.md
@@ -475,7 +475,7 @@ model-router bundle:
 ```bash
 : "${WORKFLOW_KERNEL:?resolve workflow-kernel-launcher.sh first}"
 MODEL_ROUTER_BUNDLE_JSON=$("$WORKFLOW_KERNEL" resolve-plugin-bundle \
-  --plugin model-router --minimum-version 0.2.0 \
+  --plugin model-router --minimum-version 0.4.0 \
   --required-executable skills/model-router/references/role-dispatch.sh \
   --required-executable skills/model-router/references/render-terminal-report.sh \
   --required-asset skills/model-router/references/role-request-schema.json \
@@ -514,6 +514,7 @@ argv as an array:
 
 ```bash
 ROLE_ARGS=(--role "$EXECUTOR_ROLE" --effort "$EXECUTOR_EFFORT"
+  --workflow-kernel "$WORKFLOW_KERNEL"
   --prompt-file "$WORKER_PROMPT" --output-file "$WORKER_OUTPUT"
   --receipt-file "$PRIVATE_ROUTER_RECEIPT"
   --repository-evidence-file "$COMPLETE_REPOSITORY_EVIDENCE"

--- a/plugins/pipeline/references/cascade-dispatch.sh
+++ b/plugins/pipeline/references/cascade-dispatch.sh
@@ -15,10 +15,11 @@ OUTPUT=""
 ATTEMPT_RECEIPT_TEMPLATE=""
 CONTRACT_DIGEST=""
 CONTRACT_REVISION=""
+WORKFLOW_KERNEL_LAUNCHER=""
 DRY_RUN=0
 
 usage() {
-  printf '%s\n' 'usage: cascade-dispatch.sh --class <codex|openrouter|claude>|--kind <ui|logic|integration|config|docs|mechanical-logic> --prompt <text|-> [--receipt-file PATH] [--output-file PATH] [--contract-digest SHA256 --contract-revision N] [legacy options]' >&2
+  printf '%s\n' 'usage: cascade-dispatch.sh --class <codex|openrouter|claude>|--kind <ui|logic|integration|config|docs|mechanical-logic> --prompt <text|-> --workflow-kernel PATH [--receipt-file PATH] [--output-file PATH] [--contract-digest SHA256 --contract-revision N] [legacy options]' >&2
   exit 2
 }
 
@@ -32,6 +33,7 @@ while [ "$#" -gt 0 ]; do
     --attempt-receipt-template) [ "$#" -ge 2 ] || usage; ATTEMPT_RECEIPT_TEMPLATE="$2"; shift 2 ;;
     --contract-digest) [ "$#" -ge 2 ] || usage; CONTRACT_DIGEST="$2"; shift 2 ;;
     --contract-revision) [ "$#" -ge 2 ] || usage; CONTRACT_REVISION="$2"; shift 2 ;;
+    --workflow-kernel) [ "$#" -ge 2 ] || usage; WORKFLOW_KERNEL_LAUNCHER="$2"; shift 2 ;;
     --phase|--host|--timeout|--probe-file|--exhausted-rail) [ "$#" -ge 2 ] || usage; shift 2 ;;
     --dry-run) DRY_RUN=1; shift ;;
     *) usage ;;
@@ -64,6 +66,9 @@ if [ "$DRY_RUN" -eq 1 ]; then
     '{schemaVersion:1,compatibilityAdapter:true,class:$class,role:$role,disposition:"dry-run"}'
   exit 0
 fi
+case "$WORKFLOW_KERNEL_LAUNCHER" in /*/workflow-kernel-launcher.sh) ;; *) usage ;; esac
+[ -f "$WORKFLOW_KERNEL_LAUNCHER" ] && [ -x "$WORKFLOW_KERNEL_LAUNCHER" ] &&
+  [ ! -L "$WORKFLOW_KERNEL_LAUNCHER" ] || usage
 
 TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/cascade-compat.XXXXXX")"
 cleanup() { rm -rf "$TMP_ROOT"; }
@@ -80,15 +85,21 @@ fi
 
 DISPATCHER="$DIR/../../model-router/skills/model-router/references/role-dispatch.sh"
 if [ ! -x "$DISPATCHER" ]; then
-  DISPATCHER=""
-  for cache_root in "$HOME/.claude/plugins/cache/depot" "$HOME/.codex/plugins/cache/depot"; do
-    candidate="$(ls -t "$cache_root"/model-router/*/skills/model-router/references/role-dispatch.sh 2>/dev/null | head -1)"
-    if [ -n "$candidate" ] && [ -x "$candidate" ]; then DISPATCHER="$candidate"; break; fi
-  done
+  BUNDLE_JSON="$("$WORKFLOW_KERNEL_LAUNCHER" resolve-plugin-bundle \
+    --plugin model-router --minimum-version 0.4.0 \
+    --required-executable skills/model-router/references/role-dispatch.sh \
+    --required-asset skills/model-router/references/role-request-schema.json \
+    --required-asset skills/model-router/references/role-policy.json 2>/dev/null)" || BUNDLE_JSON=""
+  BUNDLE_REF="$(printf '%s' "$BUNDLE_JSON" | jq -r '.selected_root // empty')"
+  case "$BUNDLE_REF" in
+    "~/"*) DISPATCHER="$HOME/${BUNDLE_REF#\~/}/skills/model-router/references/role-dispatch.sh" ;;
+    *) DISPATCHER="" ;;
+  esac
 fi
 [ -n "$DISPATCHER" ] || { printf '%s\n' 'cascade-dispatch: role router unavailable' >&2; exit 76; }
 
 ROLE_ARGS=(--role "$ROLE" --capability structured-output --effort medium
+  --workflow-kernel "$WORKFLOW_KERNEL_LAUNCHER"
   --prompt-file "$PROMPT_FILE"
   --output-file "$OUTPUT" --receipt-file "$RECEIPT")
 if [ -n "$CONTRACT_DIGEST" ]; then

--- a/plugins/pipeline/references/codex-native-execution-adapter.md
+++ b/plugins/pipeline/references/codex-native-execution-adapter.md
@@ -37,7 +37,8 @@ materialize the complete prompt. Invoke model-router's `role-dispatch.sh` from
 that worktree with the manifest's `executorRole`, repeated
 `executorCapabilities`, and `executorEffort`, plus fresh output and private
 receipt destinations, the complete repository-evidence file, and the current
-behavioral contract digest/revision. Build argv as an array. Never call a host
+behavioral contract digest/revision. Pass the exact invocation-local validated
+Kernel launcher as `--workflow-kernel "$WORKFLOW_KERNEL"`. Build argv as an array. Never call a host
 worker/model transport directly. The materialized prompt MUST include:
 
 - The worktree path as the only allowed write scope.

--- a/plugins/project-manager/.claude-plugin/plugin.json
+++ b/plugins/project-manager/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-manager",
   "description": "Project management: LT10 methodology, Notion-integrated sprint planning, and GitHub-native cross-repository Assembly coordination",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "author": {
     "name": "Design Machines"
   },
@@ -12,7 +12,7 @@
     "council": ">=1.5.0"
   },
   "optionalPluginDependencies": {
-    "model-router": ">=0.2.0"
+    "model-router": ">=0.4.0"
   },
   "capabilities": {
     "skills": [

--- a/plugins/project-manager/.codex-plugin/plugin.json
+++ b/plugins/project-manager/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "project-manager",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "description": "Project management: LT10 methodology, Notion-integrated sprint planning, and GitHub-native cross-repository Assembly coordination",
   "author": {
     "name": "Design Machines"
@@ -105,7 +105,7 @@
     "council": ">=1.5.0"
   },
   "optionalPluginDependencies": {
-    "model-router": ">=0.2.0"
+    "model-router": ">=0.4.0"
   },
   "interface": {
     "displayName": "Project Manager",

--- a/plugins/project-manager/skills/assembly-coordinator/SKILL.md
+++ b/plugins/project-manager/skills/assembly-coordinator/SKILL.md
@@ -14,9 +14,10 @@ Recover the live Assembly development picture and choose the next safe chunk. Ac
 - Recommend exactly one next chunk first. Spare agents, time, or model capacity do not make later work safe.
 - Do not use Notion, personal sprint state, or ai-memory for this workflow.
 - Do not copy Baseplate roadmaps or work-path documents. Link to the owning source and retain only the evidence needed for the current decision.
-- Never assign a concrete model, provider, transport, family, subscription, or
-  billing source. Execution prompts assign only a role, required capabilities,
-  and normalized effort.
+- Execution prompts and participant packets assign only a role, required
+  capabilities, and normalized effort. Concrete routing identity appears only
+  in the human-facing `Recommended start` projection immediately before a
+  copy-paste execution prompt.
 
 ## Use planning opinions only when triggered
 
@@ -138,6 +139,51 @@ Every prompt must state:
 The prompt must not call a direct provider command or contain a concrete
 routing override. Its role request is resolved later by model-router.
 
+### Recommended start
+
+Whenever this coordinator produces an implementation or review copy-paste
+prompt, resolve one coherent model-router bundle through Workflow Kernel at
+minimum version `0.4.0`, requiring
+`skills/model-router/references/operator-recommendation.sh`, `role-policy.json`,
+and `availability-probe.sh`. Resolve the current OpenRouter
+`model-matrix.json` through Workflow Kernel without changing it. Invoke the
+read-only recommendation renderer with the prompt's `executorRole`, each
+`executorCapabilities` value, `executorEffort`, the exact matrix asset, and the
+current availability probe. Preparing this projection never invokes a model.
+
+Place its output immediately before the copy-paste prompt in exactly this
+shape:
+
+```text
+Recommended start
+
+- Model: concrete recommended model
+- Harness/rail: Codex, Claude Code, or OpenRouter
+- Effort: low, medium, high, or max
+- Why: one sentence tied to the requested role and task
+- Cost: included subscription, metered API price, or unavailable
+- Fallback: exactly one concrete fallback
+- Matrix evidence: snapshot date
+```
+
+Use the renderer's current role-policy order, capability fit, availability, and
+matrix prices. Never hardcode a favourite or prose price here. Preserve an
+explicit unknown availability label. Native marginal cost is `included
+subscription`; its separately labeled API-equivalent estimate remains planning
+evidence, never billed subscription spend. OpenRouter prices come from the
+fresh checked-in matrix. Return one primary and one fallback, not a menu.
+
+The block is for the human operator and primary executor only. Never copy it,
+concrete model identities, candidate order, availability comparison, or costs
+into participant prompts, Plan A/Plan B evidence, reviewer prompts,
+participant outputs, or synthesis inputs. Those surfaces remain anonymous and
+provider-neutral. Routine status-only coordination emits no empty block.
+
+This pre-run recommendation is an estimate. Preserve the existing terminal
+model/cost report exactly once after routed work settles; that report owns the
+actual provider, model, tokens, latency, and billed cost and is never replaced
+or relabeled by the recommendation.
+
 ## Report the planning pass
 
 Return a compact, outcome-first report containing:
@@ -152,9 +198,11 @@ Return a compact, outcome-first report containing:
 8. planning commits or PRs created, or `None`;
 9. when the opinion path ran, `Plan A`, `Plan B` or its unavailable state, and
    one bounded synthesis;
-10. one complete copy-paste execution prompt when requested, with role,
-    capabilities, and effort.
-11. only when the opinion path actually dispatched a role, the already-
+10. immediately before each requested copy-paste execution prompt, one
+    concrete `Recommended start` projection and exactly one fallback;
+11. one complete copy-paste execution prompt when requested, with
+    provider-neutral role, capabilities, and effort;
+12. only when the opinion path actually dispatched a role, the already-
     generated terminal model/cost Markdown after the recommendation and
     execution prompt; routine sessions emit no empty report.
 

--- a/plugins/project-manager/skills/assembly-coordinator/references/planning-opinions.md
+++ b/plugins/project-manager/skills/assembly-coordinator/references/planning-opinions.md
@@ -27,14 +27,15 @@ output. Do not run debate, rebuttal, convergence, or a third opinion.
 
 Resolve one coherent installed model-router bundle through Workflow Kernel and
 bind its `role-dispatch.sh`, request schema, policy, and terminal renderer at
-minimum model-router version `0.2.0`. Materialize Plan A and Plan B prompts
+minimum model-router version `0.4.0`. Materialize Plan A and Plan B prompts
 separately, use the same immutable evidence packet as each request's
 `--repository-evidence-file`, and allocate fresh private output and receipt
 paths in one mode-`0700` run-private directory. Create
 `terminal-receipt-index.json` there and record Plan A then Plan B when each was
 actually requested.
 
-Dispatch Plan A with `--role architect`, the three capabilities above, and
+Pass the invocation's exact validated launcher to both calls with
+`--workflow-kernel "$WORKFLOW_KERNEL"`. Dispatch Plan A with `--role architect`, the three capabilities above, and
 `--effort high`. Dispatch Plan B with `--role plan-critic`, the four
 capabilities above, `--effort high`, `--independence-receipt-dir` set to that
 private directory, and Plan A's opaque `--independence-receipt-id`. Preserve

--- a/tests/test_openrouter_noninteractive.py
+++ b/tests/test_openrouter_noninteractive.py
@@ -397,6 +397,11 @@ class OpenRouterNonInteractiveTest(unittest.TestCase):
         env = os.environ.copy()
         env.update({"HOME": str(self.home), "OPENROUTER_API_KEY": self.api_key,
                     "OPENROUTER_BASE": self.base, "WORKFLOW_KERNEL": str(self.kernel),
+                    "OPENROUTER_BUNDLE_RESOLVED": "1",
+                    "OPENROUTER_BUNDLE_REF": "~/.codex/plugins/cache/depot/openrouter/1.14.0",
+                    "OPENROUTER_BUNDLE_VERSION": "1.14.0",
+                    "OPENROUTER_BUNDLE_CACHE_CLASS": "codex",
+                    "OPENROUTER_BUNDLE_REASON": "available",
                     "MODEL_ROUTER_CONTRACT_DIGEST": "sha256:" + "a" * 64,
                     "MODEL_ROUTER_CONTRACT_REVISION": "1"})
         env.pop("OPENROUTER_API_KEY_FILE", None)

--- a/tools/check-dependencies.sh
+++ b/tools/check-dependencies.sh
@@ -275,8 +275,8 @@ for consumer, expected in consumer_floors.items():
 
 pipeline = manifests.get("pipeline")
 dm_review_floor = None if pipeline is None else pipeline.get("pluginDependencies", {}).get("dm-review")
-if dm_review_floor != ">=1.72.0":
-    errors.append("pipeline must require dm-review >=1.72.0")
+if dm_review_floor != ">=1.74.0":
+    errors.append("pipeline must require dm-review >=1.74.0")
 
 if errors:
     for error in errors:

--- a/tools/test-assembly-coordinator-recommendation.sh
+++ b/tools/test-assembly-coordinator-recommendation.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+RECOMMEND="$ROOT/plugins/model-router/skills/model-router/references/operator-recommendation.sh"
+POLICY="$ROOT/plugins/model-router/skills/model-router/references/role-policy.json"
+MATRIX="$ROOT/plugins/openrouter/skills/openrouter-delegate/references/model-matrix.json"
+COORDINATOR="$ROOT/plugins/project-manager/skills/assembly-coordinator/SKILL.md"
+OPINIONS="$ROOT/plugins/project-manager/skills/assembly-coordinator/references/planning-opinions.md"
+REVIEW_PROMPT="$ROOT/plugins/dm-review/skills/review/references/reviewer-prompt-template.md"
+TERMINAL="$ROOT/plugins/model-router/skills/model-router/references/render-terminal-report.sh"
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/coordinator-recommendation.XXXXXX")"
+trap 'rm -rf "$TMP"' EXIT
+export MODEL_ROUTER_TEST_MODE=1
+
+pass=0
+assert() { "$@" >/dev/null || { printf 'FAIL: %s\n' "$*" >&2; exit 1; }; pass=$((pass + 1)); }
+
+cat > "$TMP/healthy.json" <<'JSON'
+{"codex":{"state":"ok","authMode":"subscription"},"claude":{"state":"ok","authMode":"subscription","plan":"max","fable":"available"},"openrouter":{"state":"ok"}}
+JSON
+
+"$RECOMMEND" --role builder-deep --capability read-repository \
+  --capability write-repository --capability tool-use --capability long-context \
+  --capability structured-output --effort high --matrix-file "$MATRIX" \
+  --availability-file "$TMP/healthy.json" --format json > "$TMP/builder.json"
+assert jq -e '.recommendedStart.model == "gpt-5.6-sol" and .recommendedStart.harness == "Codex" and .recommendedStart.effort == "high"' "$TMP/builder.json"
+assert jq -e '.recommendedStart.fallback.model == "gpt-5.6-terra" and (.recommendedStart.fallback | keys | length) == 3' "$TMP/builder.json"
+assert jq -e '.recommendedStart.cost.label == "included subscription" and .recommendedStart.cost.apiEquivalent.inputUsdPerM == 5 and .recommendedStart.cost.apiPrice == null' "$TMP/builder.json"
+
+"$RECOMMEND" --role review-fast --capability read-repository \
+  --capability structured-output --effort medium --matrix-file "$MATRIX" \
+  --availability-file "$TMP/healthy.json" --format json > "$TMP/review.json"
+assert jq -e '.recommendedStart.model == "deepseek/deepseek-v4-flash-0731" and .recommendedStart.harness == "OpenRouter" and .recommendedStart.cost.label == "metered API"' "$TMP/review.json"
+
+jq '.openrouter.state="unavailable"' "$TMP/healthy.json" > "$TMP/no-openrouter.json"
+"$RECOMMEND" --role review-fast --capability read-repository \
+  --capability structured-output --effort medium --matrix-file "$MATRIX" \
+  --availability-file "$TMP/no-openrouter.json" --format json > "$TMP/review-native.json"
+assert jq -e '.recommendedStart.model == "gpt-5.6-luna" and .recommendedStart.harness == "Codex"' "$TMP/review-native.json"
+
+jq '.roles["review-fast"] += [
+  {model:"qwen/qwen3.8-max",provider:"openrouter",transport:"openrouter",family:"qwen",billing:"api",capabilities:["read-repository","long-context","structured-output"]},
+  {model:"deepseek/deepseek-v4-pro-0813",provider:"openrouter",transport:"openrouter",family:"deepseek",billing:"api",capabilities:["read-repository","long-context","structured-output"]}
+]' "$POLICY" > "$TMP/capability-policy.json"
+"$RECOMMEND" --policy-file "$TMP/capability-policy.json" --role review-fast \
+  --capability read-repository --capability long-context \
+  --capability structured-output --effort medium --matrix-file "$MATRIX" \
+  --availability-file "$TMP/healthy.json" --format json > "$TMP/review-long-context.json"
+assert jq -e '.recommendedStart.model == "qwen/qwen3.8-max" and .recommendedStart.fallback.model == "deepseek/deepseek-v4-pro-0813"' "$TMP/review-long-context.json"
+
+jq '.roles["review-fast"] |= reverse' "$POLICY" > "$TMP/reordered-policy.json"
+"$RECOMMEND" --policy-file "$TMP/reordered-policy.json" --role review-fast \
+  --capability read-repository --capability structured-output --effort medium \
+  --matrix-file "$MATRIX" --availability-file "$TMP/healthy.json" --format json \
+  > "$TMP/reordered.json"
+assert jq -e '.recommendedStart.model == "gpt-5.6-luna"' "$TMP/reordered.json"
+
+jq '(.models[] | select(.slug == "deepseek/deepseek-v4-flash-0731")).input_usd_per_m=9.99 | (.models[] | select(.slug == "deepseek/deepseek-v4-flash-0731")).output_usd_per_m=8.88' "$MATRIX" > "$TMP/priced-matrix.json"
+"$RECOMMEND" --role review-fast --capability read-repository \
+  --capability structured-output --effort medium --matrix-file "$TMP/priced-matrix.json" \
+  --availability-file "$TMP/healthy.json" --format json > "$TMP/priced.json"
+assert jq -e '.recommendedStart.cost.apiPrice.inputUsdPerM == 9.99 and .recommendedStart.cost.apiPrice.outputUsdPerM == 8.88' "$TMP/priced.json"
+
+jq '.codex={state:"unknown",authMode:"subscription",reason:"rate_limit_mapping_unknown",allowances:{a:{state:"limited"},b:{state:"ok"}}} | .openrouter.state="unavailable"' "$TMP/healthy.json" > "$TMP/unmapped.json"
+"$RECOMMEND" --role builder-deep --capability read-repository \
+  --capability write-repository --capability tool-use --capability long-context \
+  --capability structured-output --effort high --matrix-file "$MATRIX" \
+  --availability-file "$TMP/unmapped.json" --format json > "$TMP/attemptable.json"
+assert jq -e '.recommendedStart.availability == "attemptable" and (.recommendedStart.why | contains("without attributing an allowance bucket"))' "$TMP/attemptable.json"
+
+assert grep -Fq 'Routine status-only coordination emits no empty block.' "$COORDINATOR"
+assert grep -Fq 'The block is for the human operator and primary executor only.' "$COORDINATOR"
+assert sh -c "! grep -Eq 'gpt-5\\.|deepseek/|qwen/|x-ai/|moonshotai/|Recommended start' '$OPINIONS' '$REVIEW_PROMPT'"
+assert grep -Fq 'tokenProvenance' "$TERMINAL"
+assert grep -Fq 'billedCostUsd' "$TERMINAL"
+
+"$RECOMMEND" --role review-fast --capability read-repository \
+  --capability structured-output --effort medium --matrix-file "$MATRIX" \
+  --availability-file "$TMP/healthy.json" --format markdown > "$TMP/recommended.md"
+assert test "$(grep -c '^Recommended start$' "$TMP/recommended.md")" -eq 1
+assert test "$(grep -c '^- Fallback:' "$TMP/recommended.md")" -eq 1
+assert grep -Fq -- '- Matrix evidence: 2026-08-26' "$TMP/recommended.md"
+
+printf 'assembly-coordinator-recommendation: %d assertions passed\n' "$pass"

--- a/tools/test-dm-review-host-verification.sh
+++ b/tools/test-dm-review-host-verification.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+LANES="$ROOT/plugins/dm-review/skills/review/references/full-lane-dispatch.md"
+HOST_CONTRACT="$ROOT/plugins/dm-review/skills/review/references/host-verification-evidence.md"
+ROUTER="$ROOT/plugins/model-router/skills/model-router/references/role-dispatch.sh"
+KERNEL="$ROOT/plugins/workflow-kernel/skills/workflow-kernel/references/workflow-kernel-launcher.sh"
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/dm-review-host-verification.XXXXXX")"
+trap 'rm -rf "$TMP"' EXIT
+
+pass=0
+assert() { "$@" >/dev/null || { printf 'FAIL: %s\n' "$*" >&2; exit 1; }; pass=$((pass + 1)); }
+
+assert grep -Fq '| tests/build analysis | `review-fast` | `read-repository`, `structured-output` | `medium` |' "$LANES"
+assert grep -Fq 'run it before any analysis participant' "$HOST_CONTRACT"
+assert grep -Fq '8,192 UTF-8 bytes' "$HOST_CONTRACT"
+assert grep -Fq 'tests/build lane does not meet that condition.' "$HOST_CONTRACT"
+
+printf '%s\n' 'host verification completed' > "$TMP/host.log"
+printf '%s\n' 'analyze the supplied host verification evidence' > "$TMP/prompt"
+printf '%s\n' '{"schemaVersion":1,"lane":"tests/build","commandArgv":["./tools/verify"],"exitStatus":0,"result":"passed","stdoutTail":"ok","stderrTail":""}' > "$TMP/evidence"
+printf '%s\n' '{"codex":{"state":"ok","authMode":"subscription"},"claude":{"state":"unavailable","authMode":"none"},"openrouter":{"state":"ok"}}' > "$TMP/availability"
+cat > "$TMP/transport" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+[ -s "$HOST_EVIDENCE_SETTLED" ]
+transport=""; output=""; receipt=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --transport) transport="$2"; shift 2 ;;
+    --output-file) output="$2"; shift 2 ;;
+    --provider-receipt-file) receipt="$2"; shift 2 ;;
+    *) shift 2 ;;
+  esac
+done
+printf '%s\n' "$transport" > "$HOST_TRANSPORT_LOG"
+printf '%s\n' 'analysis complete' > "$output"
+: > "$receipt"
+STUB
+chmod +x "$TMP/transport"
+
+MODEL_ROUTER_TEST_MODE=1 MODEL_ROUTER_AVAILABILITY_FILE="$TMP/availability" \
+  MODEL_ROUTER_TRANSPORT_STUB="$TMP/transport" HOST_EVIDENCE_SETTLED="$TMP/host.log" \
+  HOST_TRANSPORT_LOG="$TMP/transport.log" \
+  "$ROUTER" --workflow-kernel "$KERNEL" --role review-fast --effort medium \
+    --capability read-repository --capability structured-output \
+    --prompt-file "$TMP/prompt" --repository-evidence-file "$TMP/evidence" \
+    --output-file "$TMP/out" --receipt-file "$TMP/receipt" >/dev/null
+assert grep -Fxq openrouter "$TMP/transport.log"
+assert jq -e '.requested.capabilities == ["read-repository","structured-output"]' "$TMP/receipt"
+
+rm -f "$TMP/out" "$TMP/receipt" "$TMP/transport.log"
+MODEL_ROUTER_TEST_MODE=1 MODEL_ROUTER_AVAILABILITY_FILE="$TMP/availability" \
+  MODEL_ROUTER_TRANSPORT_STUB="$TMP/transport" HOST_EVIDENCE_SETTLED="$TMP/host.log" \
+  HOST_TRANSPORT_LOG="$TMP/transport.log" \
+  "$ROUTER" --workflow-kernel "$KERNEL" --role review-fast --effort medium \
+    --capability read-repository --capability tool-use --capability structured-output \
+    --prompt-file "$TMP/prompt" --repository-evidence-file "$TMP/evidence" \
+    --output-file "$TMP/out" --receipt-file "$TMP/receipt" >/dev/null
+assert grep -Fxq codex-cli "$TMP/transport.log"
+assert jq -e '.requested.capabilities | index("tool-use") != null' "$TMP/receipt"
+
+printf 'dm-review-host-verification: %d assertions passed\n' "$pass"

--- a/tools/test-dm-review-ui-readiness.sh
+++ b/tools/test-dm-review-ui-readiness.sh
@@ -40,9 +40,10 @@ export TEST_RESOURCE_LOG="$TMP/resources.log"
 
 run_prepare() {
   local name="$1" rc=0
+  shift
   rm -f "$TMP/$name.state" "$TMP/$name.result"
   "$HELPER" prepare --repository-root "$REPO" --state-file "$TMP/$name.state" \
-    > "$TMP/$name.result" || rc=$?
+    "$@" > "$TMP/$name.result" || rc=$?
   printf '%s\n' "$rc"
 }
 
@@ -53,10 +54,33 @@ run_confirm() {
   printf '%s\n' "$rc"
 }
 
-# No declaration means no guessed localhost scan and no participant dispatch.
+# No declaration means no guessed localhost scan and one nonblocking coverage
+# note in an ordinary review.
 no_decl_rc="$(run_prepare no-declaration)"
-assert test "$no_decl_rc" -eq 76
-assert jq -e '.dispatchAllowed == false and .reason == "dev_server_unavailable" and .reviewDisposition == "REVIEW INCOMPLETE"' "$TMP/no-declaration.result"
+assert test "$no_decl_rc" -eq 0
+assert jq -e '.dispatchAllowed == false and .reason == "visual_target_unavailable" and .coverageDisposition == "NOT RUN" and .reviewDisposition == "completed"' "$TMP/no-declaration.result"
+assert test ! -e "$TMP/no-declaration.state"
+
+# Explicit visual review keeps one honest incomplete result when no target is
+# available.
+required_rc="$(run_prepare required-no-target --visual-required true)"
+assert test "$required_rc" -eq 76
+assert jq -e '.reason == "visual_target_unavailable" and .reviewDisposition == "REVIEW INCOMPLETE"' "$TMP/required-no-target.result"
+
+cat > "$TMP/browser-preview.json" <<'JSON'
+{"schemaVersion":1,"status":"ready","transportClass":"local-interactive","localNavigation":"confirmed","targetUrl":"http://localhost:9090/preview","evidenceRef":"review/browser/preview.json"}
+JSON
+
+# An attached automation-capable T3 preview precedes optional repository
+# configuration and proceeds without a declaration.
+preview_prepare_rc="$(run_prepare attached-preview --target-url http://localhost:9090/preview --target-source t3-preview)"
+assert test "$preview_prepare_rc" -eq 0
+assert jq -e '.targetSource == "t3-preview" and .createdResources == 0' "$TMP/attached-preview.result"
+preview_ready_rc="$(run_confirm attached-preview "$TMP/browser-preview.json")"
+assert test "$preview_ready_rc" -eq 0
+assert jq -e '.state == "ready" and .dispatchAllowed == true' "$TMP/attached-preview.confirmed"
+"$HELPER" cleanup --repository-root "$REPO" --state-file "$TMP/attached-preview.state" > "$TMP/attached-preview-cleanup.json"
+assert jq -e '.state == "already_clean" and .removedCount == 0' "$TMP/attached-preview-cleanup.json"
 
 cat > "$REPO/.dm/ui-review.json" <<'JSON'
 {
@@ -183,5 +207,10 @@ assert test ! -e "$TEST_SERVER_MARKER"
 "$HELPER" cleanup --repository-root "$REPO" --state-file "$TMP/completed-created.state" \
   > "$TMP/already-clean.json"
 assert jq -e '.state == "already_clean" and .removedCount == 0' "$TMP/already-clean.json"
+
+# Missing readiness is aggregated once even when three UI analysis lanes apply,
+# and remote web search never counts as local navigation.
+assert test "$(grep -c 'one aggregated `visual_target_unavailable` coverage note' "$ROOT/plugins/dm-review/skills/review/references/ui-review-readiness.md")" -eq 1
+assert grep -Fq 'OpenRouter web search is remote public-web retrieval.' "$ROOT/plugins/dm-review/skills/review/references/ui-review-readiness.md"
 
 printf 'dm-review-ui-readiness: %d assertions passed\n' "$pass"

--- a/tools/test-dm-review-ui-readiness.sh
+++ b/tools/test-dm-review-ui-readiness.sh
@@ -82,6 +82,27 @@ assert jq -e '.state == "ready" and .dispatchAllowed == true' "$TMP/attached-pre
 "$HELPER" cleanup --repository-root "$REPO" --state-file "$TMP/attached-preview.state" > "$TMP/attached-preview-cleanup.json"
 assert jq -e '.state == "already_clean" and .removedCount == 0' "$TMP/attached-preview-cleanup.json"
 
+cat > "$TMP/browser-remote.json" <<'JSON'
+{"schemaVersion":1,"status":"ready","transportClass":"local-interactive","localNavigation":"confirmed","targetUrl":"https://preview.example.com/review","evidenceRef":"review/browser/remote.json"}
+JSON
+
+# Invocation-supplied URLs may point at staging or other remote HTTP(S) hosts;
+# only tracked repository declarations are restricted to local targets.
+remote_prepare_rc="$(run_prepare remote-explicit --target-url https://preview.example.com/review --target-source explicit)"
+assert test "$remote_prepare_rc" -eq 0
+assert jq -e '.targetSource == "explicit" and .targetUrl == "https://preview.example.com/review"' "$TMP/remote-explicit.result"
+remote_ready_rc="$(run_confirm remote-explicit "$TMP/browser-remote.json")"
+assert test "$remote_ready_rc" -eq 0
+assert jq -e '.state == "ready" and .dispatchAllowed == true' "$TMP/remote-explicit.confirmed"
+"$HELPER" cleanup --repository-root "$REPO" --state-file "$TMP/remote-explicit.state" > "$TMP/remote-explicit-cleanup.json"
+assert jq -e '.state == "already_clean" and .removedCount == 0' "$TMP/remote-explicit-cleanup.json"
+
+# Invocation targets still require a real authority/hostname.
+hostless_rc="$(run_prepare hostless-explicit --target-url 'https://?' --target-source explicit 2> "$TMP/hostless-explicit.stderr")"
+assert test "$hostless_rc" -eq 2
+assert test ! -e "$TMP/hostless-explicit.state"
+assert grep -Fq 'ui-review-readiness: invalid invocation' "$TMP/hostless-explicit.stderr"
+
 cat > "$REPO/.dm/ui-review.json" <<'JSON'
 {
   "schemaVersion": 1,

--- a/tools/test-model-router.sh
+++ b/tools/test-model-router.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 ROUTER="$ROOT/plugins/model-router/skills/model-router/references/role-dispatch.sh"
 PROBE="$ROOT/plugins/model-router/skills/model-router/references/availability-probe.sh"
+KERNEL="$ROOT/plugins/workflow-kernel/skills/workflow-kernel/references/workflow-kernel-launcher.sh"
 FIXTURES="$ROOT/plugins/model-router/skills/model-router/tests/availability-fixtures.json"
 TMP="$(mktemp -d "${TMPDIR:-/tmp}/model-router-tests.XXXXXX")"
 trap 'rm -rf "$TMP"' EXIT
@@ -78,7 +79,7 @@ for fixture_hook in MODEL_ROUTER_AVAILABILITY_FILE MODEL_ROUTER_TRANSPORT_STUB M
   esac
   set +e
   env -u MODEL_ROUTER_TEST_MODE "$fixture_hook=$fixture_value" \
-    "$ROUTER" --role review-fast --effort low --capability structured-output \
+    "$ROUTER" --workflow-kernel "$KERNEL" --role review-fast --effort low --capability structured-output \
       --prompt-file "$TMP/prompt" --output-file "$TMP/no-test-mode.out" \
       --receipt-file "$TMP/no-test-mode.receipt" >/dev/null 2>&1
   no_test_mode_rc=$?
@@ -119,6 +120,9 @@ case "${1:-}:${2:-}" in
               ;;
             multiple-no-best)
               printf '%s\n' '{"id":7,"result":{"rateLimits":{"limitId":"codex","primary":null,"secondary":{"usedPercent":25,"windowDurationMins":10080}},"rateLimitsByLimitId":{"codex":{"limitId":"codex","primary":{"usedPercent":95,"windowDurationMins":300},"secondary":{"usedPercent":25,"windowDurationMins":10080}},"codex_other":{"limitId":"codex_other","limitName":"Other","primary":{"usedPercent":1,"windowDurationMins":300},"secondary":{"usedPercent":1,"windowDurationMins":10080}}}}}'
+              ;;
+            all-exhausted)
+              printf '%s\n' '{"id":7,"result":{"rateLimits":{"limitId":"codex"},"rateLimitsByLimitId":{"codex":{"limitId":"codex","primary":{"usedPercent":95,"windowDurationMins":300},"secondary":{"usedPercent":95,"windowDurationMins":10080}},"codex_other":{"limitId":"codex_other","primary":{"usedPercent":96,"windowDurationMins":300},"secondary":{"usedPercent":97,"windowDurationMins":10080}}}}}'
               ;;
             unknown-mapping)
               printf '%s\n' '{"id":7,"result":{"rateLimits":{"limitId":"codex","primary":null,"secondary":{"usedPercent":25,"windowDurationMins":10080}},"rateLimitsByLimitId":{"codex_other":{"limitId":"codex_other","limitName":"Other","primary":{"usedPercent":20,"windowDurationMins":300},"secondary":{"usedPercent":25,"windowDurationMins":10080}},"codex_extra":{"limitId":"codex_extra","limitName":"Extra","primary":{"usedPercent":20,"windowDurationMins":300},"secondary":{"usedPercent":25,"windowDurationMins":10080}}}}}'
@@ -183,7 +187,7 @@ assert test "$(sed -n '3p' "$TMP/codex-rpc.log")" = account/rateLimits/read
 # Codex 0.147 normalizes every structurally valid bucket. The incomplete
 # backward-compatible default window is non-applicable, and multiple buckets
 # stay unmapped unless policy has authoritative candidate metadata.
-for codex_fixture in v147 exhausted multiple-no-best unknown-mapping malformed-map unsupported missing-window; do
+for codex_fixture in v147 exhausted multiple-no-best all-exhausted unknown-mapping malformed-map unsupported missing-window; do
   MODEL_ROUTER_CODEX_FIXTURE="$codex_fixture" MODEL_ROUTER_CODEX_RPC_TIMEOUT=2 \
     env -u OPENROUTER_API_KEY -u OPENROUTER_API_KEY_FILE PATH="$TMP/bin:$PATH" \
     FAKE_CLAUDE_AUTH=none "$PROBE" > "$TMP/probe-$codex_fixture.json"
@@ -195,6 +199,7 @@ fi
 assert jq -e '.codex.state == "unknown" and .codex.reason == "rate_limit_mapping_unknown" and .codex.allowances.codex.reason == "required_window_missing" and .codex.allowances.codex_named.state == "ok"' "$TMP/probe-v147.json"
 assert jq -e '.codex.state == "limited" and .codex.reason == "rate_limit_exhausted"' "$TMP/probe-exhausted.json"
 assert jq -e '.codex.state == "unknown" and .codex.reason == "rate_limit_mapping_unknown" and .codex.allowances.codex.state == "limited" and .codex.allowances.codex_other.state == "ok"' "$TMP/probe-multiple-no-best.json"
+assert jq -e '.codex.state == "limited" and .codex.reason == "rate_limit_exhausted" and all(.codex.allowances[]; .state == "limited")' "$TMP/probe-all-exhausted.json"
 assert jq -e '.codex.state == "unknown" and .codex.reason == "rate_limit_mapping_unknown" and (has("defaultAllowanceId") | not)' "$TMP/probe-unknown-mapping.json"
 assert jq -e '.codex.state == "unknown" and .codex.reason == "rate_limit_response_malformed"' "$TMP/probe-malformed-map.json"
 assert jq -e '.codex.state == "unknown" and .codex.reason == "rate_limit_shape_unsupported"' "$TMP/probe-unsupported.json"
@@ -235,12 +240,151 @@ run_role() {
   rm -f "$TMP/$name.out" "$TMP/$name.receipt" "$TMP/$name.public"
   MODEL_ROUTER_AVAILABILITY_FILE="$TMP/availability.json" \
     MODEL_ROUTER_TRANSPORT_STUB="$TMP/transport-stub" \
-    "$ROUTER" --role "$role" --effort "$effort" \
+    "$ROUTER" --workflow-kernel "$KERNEL" --role "$role" --effort "$effort" \
       --prompt-file "$TMP/prompt" --repository-evidence-file "$TMP/evidence" \
       --output-file "$TMP/$name.out" --receipt-file "$TMP/$name.receipt" \
       --contract-digest "sha256:$(printf 'a%.0s' {1..64})" --contract-revision 1 \
       "$@" > "$TMP/$name.public"
 }
+
+# The dispatcher owns one invocation-local Kernel and OpenRouter binding. A
+# fake coherent bundle proves the no-inherited-variable path and closed causes
+# without contacting a paid provider.
+FAKE_HOME="$TMP/fake-home"
+FAKE_BUNDLE="$FAKE_HOME/.codex/plugins/cache/depot/openrouter/1.19.1"
+FAKE_REFS="$FAKE_BUNDLE/skills/openrouter-delegate/references"
+mkdir -p "$FAKE_REFS" "$TMP/fake-kernel"
+cat > "$TMP/fake-kernel/workflow-kernel-launcher.sh" <<'STUB'
+#!/usr/bin/env bash
+if [ "${FAKE_KERNEL_OUTCOME:-ok}" = unavailable ]; then exit 4; fi
+printf '%s\n' '{"selected_root":"~/.codex/plugins/cache/depot/openrouter/1.19.1","version":"1.19.1","cache_class":"codex","reason":"active-host"}'
+STUB
+cat > "$FAKE_REFS/delegation-boundary.sh" <<'STUB'
+#!/usr/bin/env bash
+dirname "${BASH_SOURCE[0]}" >> "$FAKE_BUNDLE_LOG"
+[ "${FAKE_BOUNDARY_OUTCOME:-allow}" = allow ]
+STUB
+cat > "$FAKE_REFS/openrouter-credential.sh" <<'STUB'
+#!/usr/bin/env bash
+load_openrouter_api_key() {
+  dirname "${BASH_SOURCE[0]}" >> "$FAKE_BUNDLE_LOG"
+  OPENROUTER_API_KEY=test
+  export OPENROUTER_API_KEY
+}
+STUB
+cat > "$FAKE_REFS/openrouter-wrapper.sh" <<'STUB'
+#!/usr/bin/env bash
+set -u
+refs="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+printf '%s\n' "$refs" >> "$FAKE_BUNDLE_LOG"
+. "$refs/openrouter-credential.sh"
+load_openrouter_api_key
+cat >/dev/null
+case "${FAKE_PROVIDER_OUTCOME:-success}" in
+  success)
+    printf '%s\n' '{"outcome":"success","usage":{"prompt_tokens":1,"completion_tokens":1},"costUsd":0.000001}' > "$OPENROUTER_RECEIPT_FILE"
+    printf '%s\n' 'bounded provider output'
+    ;;
+  model)
+    printf '%s\n' '{"outcome":"error","failureKind":"http_error","failureReason":"model_not_found"}' > "$OPENROUTER_RECEIPT_FILE"
+    exit 1
+    ;;
+  *)
+    printf '%s\n' '{"outcome":"error","failureKind":"transport_error","failureReason":null}' > "$OPENROUTER_RECEIPT_FILE"
+    exit 1
+    ;;
+esac
+STUB
+printf '%s\n' '{"schemaVersion":2,"disclosureControls":{"providerInputParity":true},"executionControls":{},"delegationModes":{},"reviewControls":{}}' > "$FAKE_REFS/delegation-security-policy.json"
+chmod +x "$TMP/fake-kernel/workflow-kernel-launcher.sh" "$FAKE_REFS/delegation-boundary.sh" "$FAKE_REFS/openrouter-wrapper.sh"
+
+# A strict key-file load leaves OPENROUTER_API_KEY_FILE set. The successfully
+# loaded key is nevertheless available to the probe and must not be reported as
+# a missing credential.
+printf '%s\n' test > "$TMP/key-file"
+chmod 600 "$TMP/key-file"
+curl() { printf '%s\n' '{"data":{"total_credits":10,"total_usage":1}}'; }
+export -f curl
+key_file_probe="$(env PATH=/usr/bin:/bin HOME="$FAKE_HOME" \
+  OPENROUTER_API_KEY_FILE="$TMP/key-file" OPENROUTER_BUNDLE_RESOLVED=1 \
+  OPENROUTER_BUNDLE_REF='~/.codex/plugins/cache/depot/openrouter/1.19.1' \
+  "$PROBE")"
+unset -f curl
+assert test "$(printf '%s' "$key_file_probe" | jq -r '.openrouter.state')" = ok
+assert test "$(printf '%s' "$key_file_probe" | jq -r '.openrouter.reason')" = available
+
+fixture codex-exhausted
+rm -f "$TMP/fake-bundle.log"
+env -u WORKFLOW_KERNEL HOME="$FAKE_HOME" FAKE_BUNDLE_LOG="$TMP/fake-bundle.log" \
+  MODEL_ROUTER_AVAILABILITY_FILE="$TMP/availability.json" \
+  MODEL_ROUTER_INVOKE_FIXTURE_TRANSPORTS=1 \
+  "$ROUTER" --workflow-kernel "$TMP/fake-kernel/workflow-kernel-launcher.sh" \
+    --role review-deep --effort high --capability read-repository \
+    --capability long-context --capability structured-output \
+    --prompt-file "$TMP/prompt" --repository-evidence-file "$TMP/evidence" \
+    --output-file "$TMP/self-contained.out" --receipt-file "$TMP/self-contained.receipt" >/dev/null
+assert jq -e '.served.transport == "openrouter" and .served.tokens.prompt_tokens == 1' "$TMP/self-contained.receipt"
+assert test "$(sort -u "$TMP/fake-bundle.log" | wc -l | tr -d ' ')" -eq 1
+
+set +e
+HOME="$FAKE_HOME" MODEL_ROUTER_AVAILABILITY_FILE="$TMP/availability.json" \
+  "$ROUTER" --workflow-kernel "$TMP/missing/workflow-kernel-launcher.sh" \
+    --role review-deep --effort high --capability read-repository --capability long-context \
+    --prompt-file "$TMP/prompt" --repository-evidence-file "$TMP/evidence" \
+    --output-file "$TMP/missing-kernel.out" --receipt-file "$TMP/missing-kernel.receipt" >/dev/null
+missing_kernel_rc=$?
+HOME="$FAKE_HOME" FAKE_KERNEL_OUTCOME=unavailable \
+  MODEL_ROUTER_AVAILABILITY_FILE="$TMP/availability.json" \
+  "$ROUTER" --workflow-kernel "$TMP/fake-kernel/workflow-kernel-launcher.sh" \
+    --role review-deep --effort high --capability read-repository --capability long-context \
+    --prompt-file "$TMP/prompt" --repository-evidence-file "$TMP/evidence" \
+    --output-file "$TMP/missing-bundle.out" --receipt-file "$TMP/missing-bundle.receipt" >/dev/null
+missing_bundle_rc=$?
+set -e
+assert test "$missing_kernel_rc" -eq 76
+assert jq -e '[.attempts[] | select(.transport == "openrouter")] | all(.[]; .reason == "workflow_kernel_unavailable")' "$TMP/missing-kernel.receipt"
+assert test "$missing_bundle_rc" -eq 76
+assert jq -e '[.attempts[] | select(.transport == "openrouter")] | all(.[]; .reason == "provider_bundle_unavailable")' "$TMP/missing-bundle.receipt"
+
+for provider_case in credential availability; do
+  if [ "$provider_case" = credential ]; then provider_reason=provider_credential_unavailable
+  else provider_reason=provider_availability_unknown
+  fi
+  jq --arg reason "$provider_reason" '.openrouter={state:"unknown",reason:$reason}' \
+    "$TMP/availability.json" > "$TMP/provider-$provider_case.json"
+  set +e
+  HOME="$FAKE_HOME" MODEL_ROUTER_AVAILABILITY_FILE="$TMP/provider-$provider_case.json" \
+    "$ROUTER" --workflow-kernel "$TMP/fake-kernel/workflow-kernel-launcher.sh" \
+      --role review-deep --effort high --capability read-repository --capability long-context \
+      --prompt-file "$TMP/prompt" --repository-evidence-file "$TMP/evidence" \
+      --output-file "$TMP/provider-$provider_case.out" --receipt-file "$TMP/provider-$provider_case.receipt" >/dev/null
+  provider_case_rc=$?
+  set -e
+  assert test "$provider_case_rc" -eq 76
+  assert jq -e --arg reason "$provider_reason" \
+    '[.attempts[] | select(.transport == "openrouter")] | all(.[]; .reason == $reason)' \
+    "$TMP/provider-$provider_case.receipt"
+done
+
+for failure_case in boundary transport model; do
+  rm -f "$TMP/failure-$failure_case.out" "$TMP/failure-$failure_case.receipt"
+  set +e
+  HOME="$FAKE_HOME" FAKE_BUNDLE_LOG="$TMP/fake-bundle.log" \
+    FAKE_BOUNDARY_OUTCOME="$([ "$failure_case" = boundary ] && printf decline || printf allow)" \
+    FAKE_PROVIDER_OUTCOME="$failure_case" MODEL_ROUTER_AVAILABILITY_FILE="$TMP/availability.json" \
+    MODEL_ROUTER_INVOKE_FIXTURE_TRANSPORTS=1 \
+    "$ROUTER" --workflow-kernel "$TMP/fake-kernel/workflow-kernel-launcher.sh" \
+      --role review-deep --effort high --capability read-repository --capability long-context \
+      --prompt-file "$TMP/prompt" --repository-evidence-file "$TMP/evidence" \
+      --output-file "$TMP/failure-$failure_case.out" --receipt-file "$TMP/failure-$failure_case.receipt" >/dev/null
+  failure_case_rc=$?
+  set -e
+  assert test "$failure_case_rc" -eq 76
+done
+assert jq -e '[.attempts[] | select(.transport == "openrouter")] | all(.[]; .reason == "provider_boundary_declined")' "$TMP/failure-boundary.receipt"
+assert jq -e '[.attempts[] | select(.transport == "openrouter")] | all(.[]; .reason == "provider_transport_failed")' "$TMP/failure-transport.receipt"
+assert jq -e '[.attempts[] | select(.transport == "openrouter")] | all(.[]; .reason == "provider_model_unavailable")' "$TMP/failure-model.receipt"
+assert sh -c "! grep -Eq 'fake-home|OPENROUTER_API_KEY|transport_error|model_not_found' '$TMP/failure-transport.receipt' '$TMP/failure-model.receipt'"
 
 # Fast work resolves externally while the public surface stays anonymous.
 fixture healthy
@@ -253,21 +397,46 @@ run_role deep builder-deep high --capability read-repository --capability tool-u
 assert jq -e '.served.transport == "codex-cli" and .served.billingMode == "included-subscription"' "$TMP/deep.receipt"
 
 # A multi-bucket 0.147 response without an authoritative model mapping does
-# not guess. Each native attempt closes explicitly before the external tail.
+# not guess ownership. Any healthy bucket makes the requested candidate
+# attemptable, and the invocation itself settles candidate availability.
 jq -s '.[0] as $base | .[1].codex as $codex | $base | .codex = $codex' "$TMP/availability.json" "$TMP/probe-v147.json" > "$TMP/availability.next"
 mv "$TMP/availability.next" "$TMP/availability.json"
 run_role mapping-unknown builder-deep high --capability read-repository --capability long-context
-assert jq -e '.served.transport == "openrouter" and ([.attempts[] | select(.transport == "codex-cli" and .reason == "rate_limit_mapping_unknown")] | length) == 2' "$TMP/mapping-unknown.receipt"
+assert jq -e '.served.transport == "codex-cli" and .served.allowanceWindow == "mapping-unknown" and (.attempts | length) == 1' "$TMP/mapping-unknown.receipt"
+
+for attemptable_fixture in multiple-no-best unknown-mapping; do
+  fixture healthy
+  jq -s '.[0] as $base | .[1].codex as $codex | $base | .codex = $codex' \
+    "$TMP/availability.json" "$TMP/probe-$attemptable_fixture.json" > "$TMP/availability.next"
+  mv "$TMP/availability.next" "$TMP/availability.json"
+  run_role "attemptable-$attemptable_fixture" builder-deep high \
+    --capability read-repository --capability long-context
+  assert jq -e '.served.transport == "codex-cli" and .served.allowanceWindow == "mapping-unknown" and (.attempts | length) == 1' \
+    "$TMP/attemptable-$attemptable_fixture.receipt"
+done
+
+fixture healthy
+jq -s '.[0] as $base | .[1].codex as $codex | $base | .codex = $codex' \
+  "$TMP/availability.json" "$TMP/probe-all-exhausted.json" > "$TMP/availability.next"
+mv "$TMP/availability.next" "$TMP/availability.json"
+run_role all-buckets-exhausted builder-deep high \
+  --capability read-repository --capability long-context
+assert jq -e '.served.transport == "openrouter" and ([.attempts[] | select(.transport == "codex-cli" and .reason == "rate_limit_exhausted")] | length) == 2' \
+  "$TMP/all-buckets-exhausted.receipt"
 
 # When authoritative policy metadata does name the applicable 0.147 bucket,
 # the same response becomes eligible without comparing it with other buckets.
+fixture healthy
+jq -s '.[0] as $base | .[1].codex as $codex | $base | .codex = $codex' \
+  "$TMP/availability.json" "$TMP/probe-v147.json" > "$TMP/availability.next"
+mv "$TMP/availability.next" "$TMP/availability.json"
 cp -R "$(dirname "$ROUTER")" "$TMP/mapped-router"
 jq '(.roles["builder-deep"][] | select(.transport == "codex-cli")).rateLimitId = "codex_named"' \
   "$TMP/mapped-router/role-policy.json" > "$TMP/mapped-router/role-policy.next"
 mv "$TMP/mapped-router/role-policy.next" "$TMP/mapped-router/role-policy.json"
 MODEL_ROUTER_AVAILABILITY_FILE="$TMP/availability.json" \
   MODEL_ROUTER_TRANSPORT_STUB="$TMP/transport-stub" \
-  "$TMP/mapped-router/role-dispatch.sh" --role builder-deep --effort high \
+  "$TMP/mapped-router/role-dispatch.sh" --workflow-kernel "$KERNEL" --role builder-deep --effort high \
     --capability read-repository --capability long-context \
     --prompt-file "$TMP/prompt" --repository-evidence-file "$TMP/evidence" \
     --output-file "$TMP/mapped.out" --receipt-file "$TMP/mapped.receipt" >/dev/null
@@ -278,7 +447,7 @@ jq '(.roles["builder-deep"][] | select(.transport == "codex-cli")).rateLimitId =
 mv "$TMP/mapped-router/role-policy.next" "$TMP/mapped-router/role-policy.json"
 MODEL_ROUTER_AVAILABILITY_FILE="$TMP/availability.json" \
   MODEL_ROUTER_TRANSPORT_STUB="$TMP/transport-stub" \
-  "$TMP/mapped-router/role-dispatch.sh" --role builder-deep --effort high \
+  "$TMP/mapped-router/role-dispatch.sh" --workflow-kernel "$KERNEL" --role builder-deep --effort high \
     --capability read-repository --capability long-context \
     --prompt-file "$TMP/prompt" --repository-evidence-file "$TMP/evidence" \
     --output-file "$TMP/missing-map.out" --receipt-file "$TMP/missing-map.receipt" >/dev/null
@@ -316,7 +485,7 @@ fixture healthy
 jq '.candidateResults["gpt-5.6-sol"].outcome="quota"' "$TMP/availability.json" > "$TMP/availability.next"
 mv "$TMP/availability.next" "$TMP/availability.json"
 run_role quota-fallback builder-deep high --capability read-repository --capability long-context
-assert jq -e '.served.transport == "openrouter" and ([.attempts[].model] | index("gpt-5.6-terra") == null)' "$TMP/quota-fallback.receipt"
+assert jq -e '.served.transport == "openrouter" and .attempts[0].reason == "rate_limit_exhausted" and ([.attempts[].model] | index("gpt-5.6-terra") == null)' "$TMP/quota-fallback.receipt"
 
 # Failure reasons are attempt-local; an earlier quota cannot relabel a later transport failure.
 fixture healthy
@@ -407,7 +576,7 @@ cp "$TMP/implementer.receipt" "$TMP/simulated-registry/implementer.receipt"
 set +e
 MODEL_ROUTER_AVAILABILITY_FILE="$TMP/availability.json" \
   MODEL_ROUTER_TRANSPORT_STUB="$TMP/transport-stub" \
-  "$ROUTER" --role plan-critic --effort high --capability read-repository \
+  "$ROUTER" --workflow-kernel "$KERNEL" --role plan-critic --effort high --capability read-repository \
     --capability independent-family --independence-receipt-dir "$TMP/simulated-registry" \
     --independence-receipt-id "$implementer_id" --prompt-file "$TMP/prompt" \
     --repository-evidence-file "$TMP/evidence" --output-file "$TMP/simulated.out" \
@@ -420,7 +589,7 @@ assert test "$simulated_rc" -eq 2
 fixture healthy
 MODEL_ROUTER_AVAILABILITY_FILE="$TMP/availability.json" \
   MODEL_ROUTER_TRANSPORT_STUB="$TMP/transport-stub" \
-  "$ROUTER" --role review-fast --effort medium --capability read-repository \
+  "$ROUTER" --workflow-kernel "$KERNEL" --role review-fast --effort medium --capability read-repository \
     --prompt-file "$TMP/prompt" --output-file "$TMP/evidence-gate.out" \
     --receipt-file "$TMP/evidence-gate.receipt" >/dev/null
 assert jq -e '.served.transport == "codex-cli"' "$TMP/evidence-gate.receipt"
@@ -428,7 +597,7 @@ assert jq -e '.served.transport == "codex-cli"' "$TMP/evidence-gate.receipt"
 # A prompt cannot masquerade as complete repository evidence, including via a hardlink.
 set +e
 MODEL_ROUTER_AVAILABILITY_FILE="$TMP/availability.json" \
-  "$ROUTER" --role review-fast --effort medium --capability read-repository \
+  "$ROUTER" --workflow-kernel "$KERNEL" --role review-fast --effort medium --capability read-repository \
     --prompt-file "$TMP/prompt" --repository-evidence-file "$TMP/prompt" \
     --output-file "$TMP/same-evidence.out" --receipt-file "$TMP/same-evidence.receipt" >/dev/null 2>&1
 same_evidence_rc=$?
@@ -437,7 +606,7 @@ assert test "$same_evidence_rc" -eq 2
 ln "$TMP/prompt" "$TMP/evidence-hardlink"
 set +e
 MODEL_ROUTER_AVAILABILITY_FILE="$TMP/availability.json" \
-  "$ROUTER" --role review-fast --effort medium --capability read-repository \
+  "$ROUTER" --workflow-kernel "$KERNEL" --role review-fast --effort medium --capability read-repository \
     --prompt-file "$TMP/prompt" --repository-evidence-file "$TMP/evidence-hardlink" \
     --output-file "$TMP/hardlink-evidence.out" --receipt-file "$TMP/hardlink-evidence.receipt" >/dev/null 2>&1
 hardlink_evidence_rc=$?
@@ -450,7 +619,7 @@ assert jq -e '.familyIndependence.required == true and .familyIndependence.human
 set +e
 MODEL_ROUTER_AVAILABILITY_FILE="$TMP/availability.json" \
   MODEL_ROUTER_TRANSPORT_STUB="$TMP/transport-stub" \
-  "$ROUTER" --role review-fast --effort medium --capability structured-output \
+  "$ROUTER" --workflow-kernel "$KERNEL" --role review-fast --effort medium --capability structured-output \
     --human-authored --prompt-file "$TMP/prompt" --output-file "$TMP/invalid-human.out" \
     --receipt-file "$TMP/invalid-human.receipt" >/dev/null 2>&1
 invalid_human_rc=$?
@@ -472,7 +641,7 @@ env PATH="$TMP/bin:$PATH" OPENROUTER_API_KEY=secret-marker \
   MODEL_ROUTER_NATIVE_PROMPT_CAPTURE="$TMP/native-prompt" \
   MODEL_ROUTER_INVOKE_FIXTURE_TRANSPORTS=1 \
   MODEL_ROUTER_AVAILABILITY_FILE="$TMP/availability.json" \
-  "$ROUTER" --role builder-deep --effort high --capability read-repository --capability write-repository \
+  "$ROUTER" --workflow-kernel "$KERNEL" --role builder-deep --effort high --capability read-repository --capability write-repository \
     --prompt-file "$TMP/prompt" --repository-evidence-file "$TMP/evidence" \
     --output-file "$TMP/native-codex.out" --receipt-file "$TMP/native-codex.receipt" \
     --contract-digest "sha256:$(printf 'a%.0s' {1..64})" --contract-revision 1 >/dev/null
@@ -494,7 +663,7 @@ set +e
     MODEL_ROUTER_TRANSPORT_STUB="$TMP/transport-stub" \
     MODEL_ROUTER_STUB_MUTATE_PATH="$TMP/write-repo/tracked.txt" \
     MODEL_ROUTER_STUB_CALL_LOG="$TMP/write-calls" \
-    "$ROUTER" --role builder-deep --effort high --capability write-repository \
+    "$ROUTER" --workflow-kernel "$KERNEL" --role builder-deep --effort high --capability write-repository \
       --capability structured-output --prompt-file "$TMP/prompt" \
       --output-file "$TMP/mutating-write.out" --receipt-file "$TMP/mutating-write.receipt" \
       --contract-digest "sha256:$(printf 'b%.0s' {1..64})" --contract-revision 2 >/dev/null
@@ -512,7 +681,7 @@ env PATH="$TMP/bin:$PATH" OPENROUTER_API_KEY=secret-marker \
   OPENROUTER_API_KEY_FILE="$TMP/key-file" MODEL_ROUTER_NATIVE_ENV_CAPTURE="$TMP/native-env" \
   MODEL_ROUTER_INVOKE_FIXTURE_TRANSPORTS=1 \
   MODEL_ROUTER_AVAILABILITY_FILE="$TMP/availability.json" \
-  "$ROUTER" --role architect --effort high --capability read-repository \
+  "$ROUTER" --workflow-kernel "$KERNEL" --role architect --effort high --capability read-repository \
     --prompt-file "$TMP/prompt" --repository-evidence-file "$TMP/evidence" \
     --output-file "$TMP/native-claude.out" --receipt-file "$TMP/native-claude.receipt" >/dev/null
 assert grep -Fxq 'api=unset,file=unset' "$TMP/native-env"
@@ -522,7 +691,7 @@ mkdir "$TMP/reservation"
 MODEL_ROUTER_EXPECT_PUBLICATION_DIR="$TMP/reservation" \
   MODEL_ROUTER_AVAILABILITY_FILE="$TMP/availability.json" \
   MODEL_ROUTER_TRANSPORT_STUB="$TMP/transport-stub" \
-  "$ROUTER" --role review-fast --effort medium --capability structured-output \
+  "$ROUTER" --workflow-kernel "$KERNEL" --role review-fast --effort medium --capability structured-output \
     --prompt-file "$TMP/prompt" --output-file "$TMP/reservation/out" \
     --receipt-file "$TMP/reservation/receipt" >/dev/null
 assert test -s "$TMP/reservation/out"
@@ -533,7 +702,7 @@ set +e
 MODEL_ROUTER_REMOVE_PUBLICATION_DIR="$TMP/publication" \
   MODEL_ROUTER_AVAILABILITY_FILE="$TMP/availability.json" \
   MODEL_ROUTER_TRANSPORT_STUB="$TMP/transport-stub" \
-  "$ROUTER" --role review-fast --effort medium --capability structured-output \
+  "$ROUTER" --workflow-kernel "$KERNEL" --role review-fast --effort medium --capability structured-output \
     --prompt-file "$TMP/prompt" --output-file "$TMP/publication/out" \
     --receipt-file "$TMP/publication/receipt" > "$TMP/publication-public"
 publication_rc=$?
@@ -563,7 +732,7 @@ set +e
     MODEL_ROUTER_AVAILABILITY_FILE="$TMP/availability.json" \
     MODEL_ROUTER_TRANSPORT_STUB="$TMP/transport-stub" \
     MODEL_ROUTER_STUB_MUTATE_PATH="$TMP/publication-write-repo/tracked.txt" \
-    "$ROUTER" --role builder-deep --effort high --capability write-repository \
+    "$ROUTER" --workflow-kernel "$KERNEL" --role builder-deep --effort high --capability write-repository \
       --capability structured-output --prompt-file "$TMP/prompt" \
       --output-file "$TMP/publication-write/out" \
       --receipt-file "$TMP/publication-write/receipt" \
@@ -590,7 +759,7 @@ assert jq -e '.fallback == true and .fallbackReason == "content-refusal" and .se
 # Empty capability lists remain safe under nounset (including Bash 3.2).
 fixture healthy
 MODEL_ROUTER_AVAILABILITY_FILE="$TMP/availability.json" \
-  "$ROUTER" --role review-fast --effort low --prompt-file "$TMP/prompt" \
+  "$ROUTER" --workflow-kernel "$KERNEL" --role review-fast --effort low --prompt-file "$TMP/prompt" \
     --output-file "$TMP/no-capabilities.out" --receipt-file "$TMP/no-capabilities.receipt" >/dev/null
 assert jq -e '.requested.capabilities == []' "$TMP/no-capabilities.receipt"
 

--- a/tools/test-pipeline-role-dispatch.sh
+++ b/tools/test-pipeline-role-dispatch.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CASCADE="$ROOT/plugins/pipeline/references/cascade-dispatch.sh"
+KERNEL="$ROOT/plugins/workflow-kernel/skills/workflow-kernel/references/workflow-kernel-launcher.sh"
+ORCHESTRATOR="$ROOT/plugins/pipeline/agents/workflow/execution-orchestrator.md"
+ADAPTER="$ROOT/plugins/pipeline/references/codex-native-execution-adapter.md"
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/pipeline-role-dispatch.XXXXXX")"
+trap 'rm -rf "$TMP"' EXIT
+
+pass=0
+assert() { "$@" >/dev/null || { printf 'FAIL: %s\n' "$*" >&2; exit 1; }; pass=$((pass + 1)); }
+
+printf '%s\n' '{"codex":{"state":"ok","authMode":"subscription"},"claude":{"state":"unavailable"},"openrouter":{"state":"ok"}}' > "$TMP/availability"
+cat > "$TMP/transport" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+output=""; receipt=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --output-file) output="$2"; shift 2 ;;
+    --provider-receipt-file) receipt="$2"; shift 2 ;;
+    *) shift 2 ;;
+  esac
+done
+printf '%s\n' contact >> "$PIPELINE_CONTACT_LOG"
+printf '%s\n' 'pipeline dispatch output' > "$output"
+: > "$receipt"
+STUB
+chmod +x "$TMP/transport"
+: > "$TMP/contact.log"
+
+env -u WORKFLOW_KERNEL MODEL_ROUTER_TEST_MODE=1 \
+  MODEL_ROUTER_AVAILABILITY_FILE="$TMP/availability" \
+  MODEL_ROUTER_TRANSPORT_STUB="$TMP/transport" PIPELINE_CONTACT_LOG="$TMP/contact.log" \
+  "$CASCADE" --class openrouter --prompt 'bounded pipeline prompt' \
+    --workflow-kernel "$KERNEL" --output-file "$TMP/out" --receipt-file "$TMP/receipt" \
+    > "$TMP/stdout"
+assert grep -Fxq 'pipeline dispatch output' "$TMP/stdout"
+assert jq -e '.requested.role == "builder-fast" and .requested.capabilities == ["structured-output"]' "$TMP/receipt"
+assert test "$(grep -c '^contact$' "$TMP/contact.log")" -eq 1
+
+set +e
+MODEL_ROUTER_TEST_MODE=1 MODEL_ROUTER_AVAILABILITY_FILE="$TMP/availability" \
+  MODEL_ROUTER_TRANSPORT_STUB="$TMP/transport" PIPELINE_CONTACT_LOG="$TMP/contact.log" \
+  "$CASCADE" --class openrouter --prompt 'missing launcher' >/dev/null 2>&1
+missing_rc=$?
+set -e
+assert test "$missing_rc" -eq 2
+assert test "$(grep -c '^contact$' "$TMP/contact.log")" -eq 1
+
+assert grep -Fq -- '--workflow-kernel "$WORKFLOW_KERNEL"' "$ORCHESTRATOR"
+assert grep -Fq -- '--workflow-kernel "$WORKFLOW_KERNEL"' "$ADAPTER"
+
+printf 'pipeline-role-dispatch: %d assertions passed\n' "$pass"

--- a/tools/validate-dm-review-codex-perspective.sh
+++ b/tools/validate-dm-review-codex-perspective.sh
@@ -393,10 +393,10 @@ for zero_deferral_surface in \
   reject_text "$zero_deferral_surface" 'P3 advisories' "${zero_deferral_surface#$REPO_ROOT/} rejects deferred P3 evidence"
   reject_text "$zero_deferral_surface" 'P3 stays advisory' "${zero_deferral_surface#$REPO_ROOT/} rejects clean-with-P3 policy"
 done
-require_text "$REPO_ROOT/plugins/dm-review/.claude-plugin/plugin.json" '"version": "1.73.0"' "canonical dm-review version is 1.73.0"
-require_text "$REPO_ROOT/plugins/dm-review/.codex-plugin/plugin.json" '"version": "1.73.0"' "generated dm-review version is 1.73.0"
-require_text "$REPO_ROOT/plugins/pipeline/.claude-plugin/plugin.json" '"version": "1.59.0"' "canonical Pipeline version is 1.59.0"
-require_text "$REPO_ROOT/plugins/pipeline/.codex-plugin/plugin.json" '"dm-review": ">=1.72.0"' "generated Pipeline dependency floor is current"
+require_text "$REPO_ROOT/plugins/dm-review/.claude-plugin/plugin.json" '"version": "1.74.0"' "canonical dm-review version is 1.74.0"
+require_text "$REPO_ROOT/plugins/dm-review/.codex-plugin/plugin.json" '"version": "1.74.0"' "generated dm-review version is 1.74.0"
+require_text "$REPO_ROOT/plugins/pipeline/.claude-plugin/plugin.json" '"version": "1.60.0"' "canonical Pipeline version is 1.60.0"
+require_text "$REPO_ROOT/plugins/pipeline/.codex-plugin/plugin.json" '"dm-review": ">=1.74.0"' "generated Pipeline dependency floor is current"
 
 printf "Synthesis identity fixtures\n"
 base_id=$(fixture_finding_id \

--- a/tools/validate-openrouter-resolution.sh
+++ b/tools/validate-openrouter-resolution.sh
@@ -89,7 +89,7 @@ for relative in "${consumers[@]}"; do
       failures=1
     }
   fi
-  if grep -Fq 'skills/openrouter-delegate/references/openrouter-wrapper.sh' "$file"; then
+  if ! is_configured_key_script "$relative" && grep -Fq 'skills/openrouter-delegate/references/openrouter-wrapper.sh' "$file"; then
     grep -Fq -- '--required-asset skills/openrouter-delegate/references/openrouter-credential.sh' "$file" || {
       echo "  FAIL  OpenRouter credential loader is not bound into the coherent bundle: $relative"
       failures=1
@@ -255,11 +255,13 @@ for relative in \
   plugins/model-router/skills/model-router/references/openrouter-write-adapter.sh
 do
   file="$ROOT/$relative"
-  grep -Fq 'resolve-plugin-bundle --plugin openrouter' "$file" &&
-  grep -Fq -- '--minimum-version 1.19.0' "$file" &&
-  grep -Fq 'WORKFLOW_KERNEL' "$file" &&
+  grep -Fq 'OPENROUTER_BUNDLE_RESOLVED' "$file" &&
+  grep -Fq 'OPENROUTER_BUNDLE_REF' "$file" &&
+  grep -Fq 'OPENROUTER_BUNDLE_VERSION' "$file" &&
+  ! grep -Fq 'resolve-plugin-bundle --plugin openrouter' "$file" &&
+  ! grep -Fq 'WORKFLOW_KERNEL' "$file" &&
   ! grep -Eq 'ls -t[d]? .*openrouter' "$file" || {
-    echo "  FAIL  configured-key consumer bypasses coherent semver OpenRouter resolution: $relative"
+    echo "  FAIL  configured-key consumer does not consume the invocation-bound OpenRouter bundle: $relative"
     failures=1
   }
 done
@@ -371,13 +373,13 @@ grep -Fq '"--required-executable"' \
   }
 grep -Fq 'OPENROUTER_BUNDLE_REF' \
   "$ROOT/plugins/model-router/skills/model-router/references/openrouter-write-adapter.sh" &&
-grep -Fq '[ "$RESOLVED_BUNDLE_REF" != "$OPENROUTER_BUNDLE_REF" ]' \
+grep -Fq '[ "${OPENROUTER_BUNDLE_RESOLVED:-0}" != 1 ]' \
   "$ROOT/plugins/model-router/skills/model-router/references/openrouter-write-adapter.sh" &&
-grep -Fq '[ "$RESOLVED_BUNDLE_VERSION" != "${OPENROUTER_BUNDLE_VERSION:-}" ]' \
+grep -Fq '[ -n "${OPENROUTER_BUNDLE_VERSION:-}" ]' \
   "$ROOT/plugins/model-router/skills/model-router/references/openrouter-write-adapter.sh" &&
-grep -Fq '[ "$RESOLVED_BUNDLE_CACHE_CLASS" != "${OPENROUTER_BUNDLE_CACHE_CLASS:-}" ]' \
+grep -Fq '[ -n "${OPENROUTER_BUNDLE_CACHE_CLASS:-}" ]' \
   "$ROOT/plugins/model-router/skills/model-router/references/openrouter-write-adapter.sh" || {
-    echo "  FAIL  model-router OpenRouter adapter is not identity-bound across re-resolution"
+    echo "  FAIL  model-router OpenRouter adapter does not retain the invocation binding"
     failures=1
   }
 grep -Fq 'if type == "boolean" then tostring else error("invalid fallbackUsed") end' \

--- a/tools/validate-provider-neutral-routing.sh
+++ b/tools/validate-provider-neutral-routing.sh
@@ -5,6 +5,7 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 POLICY="$ROOT/plugins/model-router/skills/model-router/references/role-policy.json"
 MATRIX="$ROOT/plugins/openrouter/skills/openrouter-delegate/references/model-matrix.json"
 PIPELINE_POLICY="$ROOT/plugins/pipeline/references/routing-policy.json"
+KERNEL="$ROOT/plugins/workflow-kernel/skills/workflow-kernel/references/workflow-kernel-launcher.sh"
 TMP="$(mktemp -d "${TMPDIR:-/tmp}/provider-neutral-routing.XXXXXX")"
 trap 'rm -rf "$TMP"' EXIT
 
@@ -71,6 +72,10 @@ grep -Fq 'confirm-browser' "$ui_readiness" &&
   grep -Fq 'app_ready' "$ui_helper" &&
   grep -Fq 'cleanupArgv' "$ui_helper" ||
   fail 'dm-review lacks the two-phase browser gate or exact cleanup snapshot'
+grep -Fq 'optional tracked `<repository>/.dm/ui-review.json`' "$ui_readiness" ||
+  fail 'dm-review still treats UI configuration as mandatory'
+grep -Fq 'one aggregated `visual_target_unavailable` coverage note' "$ui_readiness" ||
+  fail 'dm-review duplicates missing visual readiness per lane'
 
 # Pipeline policy may express only role intent and legacy translation.
 jq -e '
@@ -185,18 +190,18 @@ printf '%s\n' '#!/usr/bin/env bash' 'while [ "$#" -gt 0 ]; do case "$1" in --out
 chmod +x "$TMP/cascade-transport"
 MODEL_ROUTER_TEST_MODE=1 MODEL_ROUTER_AVAILABILITY_FILE="$TMP/cascade-availability.json" \
   MODEL_ROUTER_TRANSPORT_STUB="$TMP/cascade-transport" \
-  "$CASCADE" --class openrouter --prompt 'inline prompt' --host codex --phase execute --timeout 5 > "$TMP/cascade-inline"
+  "$CASCADE" --class openrouter --prompt 'inline prompt' --workflow-kernel "$KERNEL" --host codex --phase execute --timeout 5 > "$TMP/cascade-inline"
 grep -Fxq 'compat-ok' "$TMP/cascade-inline" || fail 'legacy inline prompt/stdout contract failed'
 printf 'stdin prompt' | MODEL_ROUTER_TEST_MODE=1 MODEL_ROUTER_AVAILABILITY_FILE="$TMP/cascade-availability.json" \
   MODEL_ROUTER_TRANSPORT_STUB="$TMP/cascade-transport" \
-  "$CASCADE" --kind logic --prompt - --probe-file "$TMP/cascade-availability.json" --exhausted-rail openrouter > "$TMP/cascade-stdin"
+  "$CASCADE" --kind logic --prompt - --workflow-kernel "$KERNEL" --probe-file "$TMP/cascade-availability.json" --exhausted-rail openrouter > "$TMP/cascade-stdin"
 grep -Fxq 'compat-ok' "$TMP/cascade-stdin" || fail 'legacy stdin prompt contract failed'
 "$CASCADE" --kind docs --prompt x --host codex --dry-run > "$TMP/cascade-dry-run"
 jq -e '.compatibilityAdapter == true and .role == "builder-fast" and .disposition == "dry-run"' "$TMP/cascade-dry-run" >/dev/null || fail 'legacy dry-run compatibility failed'
 touch "$TMP/cascade-contacts"
 if CASCADE_CONTACT_FILE="$TMP/cascade-contacts" MODEL_ROUTER_TEST_MODE=1 MODEL_ROUTER_AVAILABILITY_FILE="$TMP/cascade-availability.json" \
   MODEL_ROUTER_TRANSPORT_STUB="$TMP/cascade-transport" \
-  "$CASCADE" --class openrouter --prompt x --attempt-receipt-template invalid >/dev/null 2>&1; then
+  "$CASCADE" --class openrouter --prompt x --workflow-kernel "$KERNEL" --attempt-receipt-template invalid >/dev/null 2>&1; then
   fail 'invalid legacy receipt template accepted'
 fi
 [ ! -s "$TMP/cascade-contacts" ] || fail 'invalid legacy receipt template contacted a transport'

--- a/tools/validate-workflow-contracts.sh
+++ b/tools/validate-workflow-contracts.sh
@@ -606,7 +606,7 @@ require_text "$review_skill" "references/selective-lane-allowlist.md" "review re
 require_text "$selective_allowlist" "never relax this equality check to a subset check" "allowlist contract requires exact selected_full_set equality"
 require_text "$selective_allowlist" "Any validation failure discards the entire selective input and dispatches the unfiltered recomputed selected full set. Never drop invalid members and honor the remainder." "allowlist contract fails open without partially honoring invalid input"
 require_text "$REPO_ROOT/plugins/dm-review/.claude-plugin/plugin.json" '"workflow-kernel": ">=0.17.0"' "dm-review requires the exact-owned cleanup kernel release"
-require_text "$REPO_ROOT/plugins/pipeline/.claude-plugin/plugin.json" '"dm-review": ">=1.72.0"' "pipeline requires the exact-owned dm-review release"
+require_text "$REPO_ROOT/plugins/pipeline/.claude-plugin/plugin.json" '"dm-review": ">=1.74.0"' "pipeline requires the exact-owned dm-review release"
 require_text "$REPO_ROOT/plugins/dm-review/.claude-plugin/plugin.json" '"name": "Second Perspective Reviewer"' "dm-review manifest names the provider-neutral perspective lane"
 require_text "$REPO_ROOT/plugins/dm-review/.claude-plugin/plugin.json" 'family-independent second-opinion review' "dm-review manifest describes family-independent perspective resolution"
 require_text "$REPO_ROOT/plugins/dm-review/skills/review/references/agent-registry.md" 'Full mode only.' "migration-validator registry limits the lane to full mode"


### PR DESCRIPTION
Closes #99.

## Summary

- make role dispatch self-contained with an explicit validated Workflow Kernel launcher and one coherent OpenRouter bundle binding
- keep authenticated Codex candidates attemptable when allowance ownership is unknowable but at least one bucket is healthy
- move deterministic test/build verification to the host and remove false review-lane `tool-use` requirements
- make `.dm/ui-review.json` optional and aggregate unavailable visual coverage into one proportional result
- add a read-only model-router projection for one concrete operator recommendation and one fallback
- preserve anonymous participant prompts and terminal actual model/usage/cost receipts

## Version movement

- model-router 0.3.0 → 0.4.0
- dm-review 1.73.0 → 1.74.0
- project-manager 1.11.0 → 1.12.0
- pipeline 1.59.0 → 1.60.0

The OpenRouter model matrix is unchanged.

## Live proof

- availability: OpenRouter available; Codex authenticated with three unmapped allowances and at least one healthy allowance
- cheapest read-only canary: `deepseek/deepseek-v4-flash-0731` via OpenRouter, 287 input / 156 output tokens, 13 seconds, $0.0001661 billed
- focused review: first stream closed as `provider_transport_failed`; one fallback served `deepseek/deepseek-v4-pro-0813`
- fixed the review-confirmed key-file credential classification defect and added regression coverage

## Verification

- `tools/test-model-router.sh` — 112 assertions
- `tools/test-dm-review-ui-readiness.sh` — 53 assertions
- `tools/test-dm-review-host-verification.sh` — 8 assertions
- `tools/test-pipeline-role-dispatch.sh` — 7 assertions
- `tools/test-assembly-coordinator-recommendation.sh` — 17 assertions
- provider-neutral routing, routing economics, Codex perspective, workflow contracts, dependencies, generated manifests/aliases, dual compatibility, coherent OpenRouter resolution — passed
- Workflow Kernel behavioral validation — all 13 sections passed
- `tools/validate-composition.sh --all` — all validators passed after review repair
- changed shell scripts — `bash -n` passed
- `git diff --check` — passed

## Simplicity check

No routing service, broker, capability framework, workflow engine, port scanner, start-command guessing, paid availability probe, or second verification ladder was added.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Design-Machines-Studio/codesmith/depot/pr/100"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790342933&installation_model_id=428410&pr_number=100&repository=Design-Machines-Studio%2Fdepot&return_to=https%3A%2F%2Fgithub.com%2FDesign-Machines-Studio%2Fdepot%2Fpull%2F100&signature=bc7525b1d80d5e72507882478486169244ec7ab8179545be3ccba18f0f974c06"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->