### PR TITLE
fix(models): report validated v2 benchmark evidence

### DIFF
--- a/tests/test_model_intelligence.py
+++ b/tests/test_model_intelligence.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 from pathlib import Path
@@ -28,6 +29,118 @@ class ModelIntelligenceTest(unittest.TestCase):
         return subprocess.run(
             [str(TOOL), *args], cwd=REPO, text=True, capture_output=True
         )
+
+    def v2_result(
+        self,
+        *,
+        case_id: str,
+        model: str,
+        transport: str,
+        observed_at: str,
+        endpoint_provider: str = "openai",
+        digest_suffix: str = "a",
+        success: bool = True,
+        failure_class: str = "none",
+        failure_owner: str = "none",
+        benchmark_fault: bool = False,
+        transport_status: str = "success",
+        identity_confidence: str = "confirmed",
+        quality_score: int = 100,
+        duration: int | None = 2,
+        usage: dict[str, int | float | None] | None = None,
+    ) -> dict[str, object]:
+        suite = json.loads(
+            (
+                REPO
+                / "plugins/openrouter/skills/openrouter-delegate/references/depot-role-benchmark-suite.json"
+            ).read_text()
+        )
+        case = next(item for item in suite["cases"] if item["id"] == case_id)
+        bindings = {
+            "suiteRevision": suite["suiteRevision"],
+            "suiteDigest": f"suite-{digest_suffix}",
+            "caseRevision": case["revision"],
+            "caseDigest": f"case-{digest_suffix}",
+            "promptRevision": case["promptRevision"],
+            "promptDigest": f"prompt-{digest_suffix}",
+            "scorerRevision": 2,
+            "scorerDigest": f"scorer-{digest_suffix}",
+            "normalizerRevision": 2,
+            "normalizerDigest": f"normalizer-{digest_suffix}",
+        }
+        gate = success
+        return {
+            "schemaVersion": 2,
+            "suiteId": suite["suiteId"],
+            "caseId": case_id,
+            "role": case["role"],
+            "observedAt": observed_at,
+            "behavioralContract": suite["behavioralContract"],
+            "evidenceBindings": {
+                name: {"declared": value, "actual": value, "match": True}
+                for name, value in bindings.items()
+            },
+            "transport": transport,
+            "endpointProvider": endpoint_provider,
+            "transportOutcome": {"status": transport_status, "failureKind": None},
+            "identityStatus": {"confidence": identity_confidence, "provenance": "response"},
+            "requestedIdentity": model,
+            "servedIdentity": model,
+            "fallback": {
+                "used": False,
+                "attemptedIdentity": model,
+                "attemptedIdentities": [model],
+                "provenance": "response_model",
+            },
+            "durationSeconds": duration,
+            "usage": usage
+            if usage is not None
+            else {
+                "prompt_tokens": 10,
+                "completion_tokens": 5,
+                "reasoning_tokens": 2,
+                "cache_read_tokens": 3,
+                "cache_creation_tokens": 1,
+                "cost": 0.01,
+            },
+            "strictParse": {"passed": gate},
+            "normalizedParse": {"passed": True, "normalization": "strict-raw-object"},
+            "contractPassed": gate,
+            "mandatoryPassed": gate,
+            "semanticPassed": gate,
+            "semanticScore": quality_score,
+            "validationPassed": gate,
+            "benchmarkFault": benchmark_fault,
+            "comparable": not benchmark_fault and transport_status == "success" and identity_confidence == "confirmed",
+            "overallSuccess": success,
+            "failureClass": failure_class,
+            "failureOwner": failure_owner,
+            "failureReasons": [] if success else [failure_class],
+            "modelConclusion": "success" if success else None,
+            "qualityScore": quality_score,
+            "parsed": True,
+        }
+
+    def write_attempt(
+        self,
+        benchmark_root: Path,
+        name: str,
+        result: dict[str, object],
+        *,
+        receipt: dict[str, object] | None = None,
+        output: dict[str, object] | None = None,
+        human: dict[str, object] | None = None,
+    ) -> Path:
+        directory = benchmark_root / name
+        directory.mkdir(parents=True)
+        (directory / "result.json").write_text(json.dumps(result))
+        if receipt is not None:
+            (directory / "receipt.json").write_text(json.dumps(receipt))
+        if output is not None:
+            (directory / "output.json").write_text(json.dumps(output))
+        if human is not None:
+            (directory / "human-rubric.json").write_text(json.dumps(human))
+        return directory
 
     def test_catalog_refresh_updates_existing_models_and_only_nominates_new(self) -> None:
         matrix = self.root / "matrix.json"
@@ -219,6 +332,347 @@ class ModelIntelligenceTest(unittest.TestCase):
         self.assertEqual(rows["native/model"]["input_bytes"], 400)
         self.assertEqual(rows["example/model"]["finding_contributions"], 2)
         self.assertIn("different units", markdown.read_text())
+
+    def test_v2_rollup_uses_validated_gates_grouping_and_attributable_rework(self) -> None:
+        benchmark_root = self.root / "bench-v2"
+        model = "deepseek/deepseek-v4-flash-0731"
+        benchmark_fault = self.v2_result(
+            case_id="review-zero-deferral",
+            model=model,
+            transport="openrouter",
+            observed_at="2026-08-29T01:00:00Z",
+            endpoint_provider="Baidu",
+            success=False,
+            failure_class="benchmark-prompt-contract-fault",
+            failure_owner="benchmark",
+            benchmark_fault=True,
+        )
+        partial = self.v2_result(
+            case_id="review-zero-deferral",
+            model=model,
+            transport="openrouter",
+            observed_at="2026-08-29T01:01:00Z",
+            endpoint_provider="Reka AI",
+            success=False,
+            failure_class="semantic-assertion-failure",
+            failure_owner="model",
+            quality_score=15,
+            duration=2,
+        )
+        partial["contractPassed"] = True
+        partial["mandatoryPassed"] = True
+        partial["semanticPassed"] = False
+        partial["validationPassed"] = False
+        validated = self.v2_result(
+            case_id="review-zero-deferral",
+            model=model,
+            transport="openrouter",
+            observed_at="2026-08-29T01:02:00Z",
+            endpoint_provider="DeepInfra",
+            duration=3,
+            usage={
+                "prompt_tokens": 20,
+                "completion_tokens": 7,
+                "reasoning_tokens": 4,
+                "cache_read_tokens": 6,
+                "cache_creation_tokens": 2,
+                "cost": 0.02,
+            },
+        )
+        for name, evidence in (
+            ("01-benchmark-fault", benchmark_fault),
+            ("02-partial", partial),
+            ("03-valid", validated),
+        ):
+            self.write_attempt(benchmark_root, name, evidence)
+
+        transport_failure = self.v2_result(
+            case_id="review-false-positive-control",
+            model=model,
+            transport="openrouter",
+            observed_at="2026-08-29T01:03:00Z",
+            success=False,
+            failure_class="transport-failure",
+            failure_owner="operational",
+            transport_status="failed",
+        )
+        self.write_attempt(benchmark_root, "04-transport-failure", transport_failure)
+        incompatible = self.v2_result(
+            case_id="review-zero-deferral",
+            model=model,
+            transport="openrouter",
+            observed_at="2026-08-29T01:04:00Z",
+            digest_suffix="incompatible",
+        )
+        incompatible["evidenceBindings"]["promptDigest"]["match"] = False
+        self.write_attempt(benchmark_root, "05-incompatible", incompatible)
+        incomplete_dir = benchmark_root / "06-incomplete"
+        incomplete_dir.mkdir(parents=True)
+        (incomplete_dir / "receipt.json").write_text(
+            json.dumps(
+                {
+                    "schemaVersion": 2,
+                    "requestedModel": model,
+                    "transport": "openrouter",
+                    "outcome": "failed",
+                    "failureKind": "http-error",
+                    "durationSeconds": 9,
+                    "usage": {"prompt_tokens": 11, "cache_read_tokens": 4},
+                    "benchmark": {
+                        "suiteId": "depot-role-v2",
+                        "caseId": "review-zero-deferral",
+                        "role": "review-fast",
+                    },
+                }
+            )
+        )
+
+        output = self.root / "v2.json"
+        markdown = self.root / "v2.md"
+        completed = self.run_tool(
+            "report",
+            "--run-root",
+            str(self.root / "no-runs"),
+            "--benchmark-root",
+            str(benchmark_root),
+            "--observed-at",
+            "2026-08-29T09:00:00+08:00",
+            "--json-output",
+            str(output),
+            "--markdown-output",
+            str(markdown),
+        )
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        report = json.loads(output.read_text())
+        rollup = report["benchmarks"]
+        primary = next(group for group in rollup["groups"] if group["case_id"] == "review-zero-deferral")
+        self.assertEqual(primary["attempts"], 3)
+        self.assertEqual(primary["comparable_attempts"], 2)
+        self.assertEqual(primary["validated_attempts"], 1)
+        self.assertFalse(primary["first_pass_validated"])
+        self.assertEqual(primary["model_rework_to_valid"], 1)
+        self.assertEqual(primary["time_to_first_validated_seconds"], 5)
+        self.assertEqual(primary["tokens_to_first_validated"]["prompt_tokens"], 30)
+        self.assertEqual(primary["operational_retries_before_valid"], {"prompt": 1})
+        self.assertEqual(
+            set(primary["endpoint_providers"]), {"Baidu", "Reka AI", "DeepInfra"}
+        )
+        self.assertEqual(primary["failure_counts"]["semantic"], 1)
+        self.assertNotIn(15, [group["validated_attempts"] for group in rollup["groups"]])
+        self.assertEqual(len(rollup["incompatible_v2"]), 1)
+        self.assertEqual(rollup["incompatible_v2"][0]["model_conclusion"], None)
+        self.assertEqual(rollup["incomplete_attempts"][0]["duration_seconds"], 9)
+        self.assertEqual(rollup["incomplete_attempts"][0]["prompt_tokens"], 11)
+        self.assertEqual(rollup["routing_conclusion"], "no routing change justified")
+        self.assertEqual(
+            {role["role"] for role in rollup["roles"]},
+            set(
+                json.loads(
+                    (
+                        REPO
+                        / "plugins/model-router/skills/model-router/references/role-policy.json"
+                    ).read_text()
+                )["roles"]
+            ),
+        )
+        self.assertLess(
+            markdown.read_text().index("Per-role validated quality and efficiency"),
+            markdown.read_text().index("Provider spend and access economics"),
+        )
+        self.assertIn("no model conclusion", markdown.read_text())
+
+    def test_v2_digest_compatibility_and_missing_ordering_stay_separate_and_null(self) -> None:
+        benchmark_root = self.root / "digest-v2"
+        for name, suffix in (("one", "a"), ("two", "b")):
+            evidence = self.v2_result(
+                case_id="mechanical-owned-edit",
+                model="gpt-5.6-luna",
+                transport="codex-cli",
+                observed_at="not-an-order",
+                digest_suffix=suffix,
+            )
+            evidence["durationSeconds"] = None
+            evidence["usage"] = {
+                "prompt_tokens": None,
+                "completion_tokens": None,
+                "reasoning_tokens": None,
+                "cache_read_tokens": None,
+                "cache_creation_tokens": None,
+                "cost": None,
+            }
+            self.write_attempt(benchmark_root, name, evidence)
+        output = self.root / "digest.json"
+        completed = self.run_tool(
+            "report",
+            "--run-root",
+            str(self.root / "no-runs"),
+            "--benchmark-root",
+            str(benchmark_root),
+            "--observed-at",
+            "2026-08-29T09:00:00+08:00",
+            "--json-output",
+            str(output),
+        )
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        groups = json.loads(output.read_text())["benchmarks"]["groups"]
+        self.assertEqual(len(groups), 2)
+        self.assertNotEqual(groups[0]["suite_digest"], groups[1]["suite_digest"])
+        for group in groups:
+            self.assertIsNone(group["first_pass_validated"])
+            self.assertIsNone(group["model_rework_to_valid"])
+            self.assertIsNone(group["time_to_first_validated_seconds"])
+            self.assertIsNone(group["tokens_to_first_validated"]["prompt_tokens"])
+            self.assertEqual(group["telemetry_coverage"]["tool_calls"]["recorded"], 0)
+
+    def test_v2_mandatory_validation_and_identity_failures_are_distinct(self) -> None:
+        benchmark_root = self.root / "failure-classes-v2"
+        mandatory = self.v2_result(
+            case_id="review-zero-deferral",
+            model="gpt-5.6-luna",
+            transport="codex-cli",
+            observed_at="2026-08-29T03:00:00Z",
+            digest_suffix="mandatory",
+            success=False,
+            failure_class="mandatory-assertion-failure",
+            failure_owner="model",
+            quality_score=50,
+        )
+        mandatory["contractPassed"] = True
+        validation = self.v2_result(
+            case_id="review-zero-deferral",
+            model="gpt-5.6-luna",
+            transport="codex-cli",
+            observed_at="2026-08-29T03:01:00Z",
+            digest_suffix="validation",
+            success=False,
+            failure_class="deterministic-validation-failure",
+            failure_owner="model",
+        )
+        validation["contractPassed"] = True
+        validation["mandatoryPassed"] = True
+        validation["semanticPassed"] = True
+        identity = self.v2_result(
+            case_id="review-zero-deferral",
+            model="gpt-5.6-luna",
+            transport="codex-cli",
+            observed_at="2026-08-29T03:02:00Z",
+            digest_suffix="identity",
+            success=True,
+            failure_class="unknown-served-identity",
+            failure_owner="operational",
+            identity_confidence="unknown",
+        )
+        for name, evidence in (
+            ("mandatory", mandatory),
+            ("validation", validation),
+            ("identity", identity),
+        ):
+            self.write_attempt(benchmark_root, name, evidence)
+        output = self.root / "failure-classes.json"
+        completed = self.run_tool(
+            "report",
+            "--run-root",
+            str(self.root / "no-runs"),
+            "--benchmark-root",
+            str(benchmark_root),
+            "--observed-at",
+            "2026-08-29T09:00:00+08:00",
+            "--json-output",
+            str(output),
+        )
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        groups = json.loads(output.read_text())["benchmarks"]["groups"]
+        categories = {
+            group["attempt_records"][0]["failure_category"]: group
+            for group in groups
+        }
+        self.assertEqual(set(categories), {"mandatory", "validation", "identity"})
+        self.assertEqual(categories["mandatory"]["best_deterministic_quality"], 50)
+        self.assertEqual(categories["mandatory"]["validated_attempts"], 0)
+        self.assertEqual(categories["validation"]["model_attributable_failures"], 1)
+        self.assertEqual(categories["identity"]["comparable_attempts"], 0)
+        self.assertEqual(categories["identity"]["operational_retries"], {"identity": 1})
+
+    def test_editorial_human_evidence_is_optional_blinded_and_digest_matched(self) -> None:
+        benchmark_root = self.root / "editorial-v2"
+        output_artifact = {"copy": "member update", "preservedFacts": []}
+        digest = hashlib.sha256(
+            (json.dumps(output_artifact, indent=2) + "\n").encode()
+        ).hexdigest()
+        accepted_result = self.v2_result(
+            case_id="editorial-member-update",
+            model="fable",
+            transport="claude-cli",
+            observed_at="2026-08-29T02:00:00Z",
+            endpoint_provider="anthropic",
+        )
+        accepted_human = {
+            "schemaVersion": 1,
+            "suiteId": "depot-role-v2",
+            "caseId": "editorial-member-update",
+            "caseRevision": 2,
+            "rubricRevision": 1,
+            "outputArtifactSha256": digest,
+            "observedAt": "2026-08-29T02:30:00Z",
+            "blindToCandidate": True,
+            "criterionScores": {"member-clarity": 5, "member-voice": 4},
+        }
+        self.write_attempt(
+            benchmark_root,
+            "accepted",
+            accepted_result,
+            output=output_artifact,
+            human=accepted_human,
+        )
+        missing = self.v2_result(
+            case_id="editorial-release-note",
+            model="fable",
+            transport="claude-cli",
+            observed_at="2026-08-29T02:01:00Z",
+            endpoint_provider="anthropic",
+        )
+        self.write_attempt(benchmark_root, "missing", missing, output={"headline": "release"})
+        rejected = dict(accepted_human)
+        rejected["candidate"] = "fable"
+        rejected_result = self.v2_result(
+            case_id="editorial-member-update",
+            model="fable",
+            transport="claude-cli",
+            observed_at="2026-08-29T02:02:00Z",
+            endpoint_provider="anthropic",
+            digest_suffix="rejected",
+        )
+        self.write_attempt(
+            benchmark_root,
+            "rejected",
+            rejected_result,
+            output=output_artifact,
+            human=rejected,
+        )
+        report_path = self.root / "editorial.json"
+        completed = self.run_tool(
+            "report",
+            "--run-root",
+            str(self.root / "no-runs"),
+            "--benchmark-root",
+            str(benchmark_root),
+            "--observed-at",
+            "2026-08-29T09:00:00+08:00",
+            "--json-output",
+            str(report_path),
+        )
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        rollup = json.loads(report_path.read_text())["benchmarks"]
+        editorial = next(role for role in rollup["roles"] if role["role"] == "editorial")
+        self.assertEqual(editorial["editorial_human_evidence"]["accepted_receipts"], 1)
+        self.assertEqual(editorial["editorial_human_evidence"]["median_mean_score"], 4.5)
+        missing_group = next(group for group in rollup["groups"] if group["case_id"] == "editorial-release-note")
+        self.assertIsNone(missing_group["editorial_human_evidence"])
+        rejected_group = next(group for group in rollup["groups"] if group["suite_digest"] == "suite-rejected")
+        self.assertEqual(
+            rejected_group["editorial_human_rejections"],
+            {"malformed or identity-bearing human rubric fields": 1},
+        )
 
 
 class NativeDepotBenchmarkTest(unittest.TestCase):

--- a/tests/test_model_intelligence.py
+++ b/tests/test_model_intelligence.py
@@ -833,6 +833,67 @@ class ModelIntelligenceTest(unittest.TestCase):
         self.assertIn("Median duration", markdown.read_text())
         self.assertIn("evaluator cohorts", markdown.read_text())
 
+    def test_v2_same_case_binding_conflicts_null_role_metrics_and_competition(self) -> None:
+        benchmark_root = self.root / "case-binding-cohorts-v2"
+        model = "gpt-5.6-luna"
+
+        def add_attempt(name: str, case_id: str, binding: str, attempt: int) -> None:
+            evidence = self.v2_result(
+                case_id=case_id,
+                model=model,
+                transport="codex-cli",
+                observed_at=f"2026-08-29T06:{len(list(benchmark_root.glob('*'))):02d}:00Z",
+                digest_suffix="case-binding",
+                duration=2 if binding == "a" else 10,
+            )
+            evidence["evidenceBindings"]["caseDigest"] = {
+                "declared": f"case-{binding}", "actual": f"case-{binding}", "match": True,
+            }
+            evidence["evidenceBindings"]["promptDigest"] = {
+                "declared": f"prompt-{binding}", "actual": f"prompt-{binding}", "match": True,
+            }
+            self.write_attempt(benchmark_root, name, evidence)
+
+        for attempt in range(1, 4):
+            add_attempt(f"zero-a-{attempt}", "review-zero-deferral", "a", attempt)
+            add_attempt(f"zero-b-{attempt}", "review-zero-deferral", "b", attempt)
+            add_attempt(
+                f"false-positive-a-{attempt}",
+                "review-false-positive-control",
+                "a",
+                attempt,
+            )
+
+        output = self.root / "case-binding-cohorts.json"
+        completed = self.run_tool(
+            "report", "--run-root", str(self.root / "no-runs"),
+            "--benchmark-root", str(benchmark_root),
+            "--observed-at", "2026-08-29T09:00:00+08:00",
+            "--json-output", str(output),
+        )
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        rollup = json.loads(output.read_text())["benchmarks"]
+        role = next(item for item in rollup["roles"] if item["role"] == "review-fast")
+        self.assertEqual(len(role["evaluator_cohorts"]), 1)
+        cohort = role["evaluator_cohorts"][0]
+        self.assertFalse(cohort["case_binding_consistent"])
+        self.assertIsNone(cohort["comparable_attempts"])
+        self.assertIsNone(cohort["median_duration_seconds"])
+        zero_case = next(
+            item for item in cohort["case_coverage"]
+            if item["case_id"] == "review-zero-deferral"
+        )
+        self.assertEqual(len(zero_case["case_binding_cohorts"]), 2)
+        self.assertTrue(role["case_binding_conflict"])
+        self.assertIsNone(role["best_deterministic_quality"])
+        self.assertIsNone(role["median_duration_seconds"])
+        evidence = next(
+            item for item in rollup["model_role_evidence"]
+            if item["role"] == "review-fast" and item["model"] == model
+        )
+        self.assertFalse(evidence["controlled_competitive_evidence"])
+        self.assertEqual(evidence["competitive_evidence_cohorts"], [])
+
     def test_degraded_attempts_retain_receipt_evidence_and_all_recorded_spend_once(self) -> None:
         benchmark_root = self.root / "retained-v2"
         model = "deepseek/deepseek-v4-flash-0731"

--- a/tests/test_model_intelligence.py
+++ b/tests/test_model_intelligence.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+from collections import Counter
 from pathlib import Path
 import stat
 import subprocess
@@ -452,6 +453,7 @@ class ModelIntelligenceTest(unittest.TestCase):
         self.assertFalse(primary["first_pass_validated"])
         self.assertEqual(primary["model_rework_to_valid"], 1)
         self.assertEqual(primary["time_to_first_validated_seconds"], 5)
+        self.assertEqual(primary["median_duration_seconds"], 2.5)
         self.assertEqual(primary["tokens_to_first_validated"]["prompt_tokens"], 30)
         self.assertEqual(primary["operational_retries_before_valid"], {"prompt": 1})
         self.assertEqual(
@@ -464,6 +466,14 @@ class ModelIntelligenceTest(unittest.TestCase):
         self.assertEqual(rollup["incomplete_attempts"][0]["duration_seconds"], 9)
         self.assertEqual(rollup["incomplete_attempts"][0]["prompt_tokens"], 11)
         self.assertEqual(rollup["routing_conclusion"], "no routing change justified")
+        review_role = next(role for role in rollup["roles"] if role["role"] == "review-fast")
+        self.assertEqual(review_role["median_duration_seconds"], 2.5)
+        model_row = next(
+            row for row in rollup["model_role_evidence"]
+            if row["role"] == "review-fast" and row["model"] == model
+        )
+        self.assertEqual(model_row["row_level_conclusion"], "no model conclusion")
+        self.assertEqual(model_row["routing_conclusion"], "no routing change justified")
         self.assertEqual(
             {role["role"] for role in rollup["roles"]},
             set(
@@ -480,6 +490,7 @@ class ModelIntelligenceTest(unittest.TestCase):
             markdown.read_text().index("Provider spend and access economics"),
         )
         self.assertIn("no model conclusion", markdown.read_text())
+        self.assertIn("| no model conclusion | no routing change justified |", markdown.read_text())
 
     def test_v2_digest_compatibility_and_missing_ordering_stay_separate_and_null(self) -> None:
         benchmark_root = self.root / "digest-v2"
@@ -673,6 +684,303 @@ class ModelIntelligenceTest(unittest.TestCase):
             rejected_group["editorial_human_rejections"],
             {"malformed or identity-bearing human rubric fields": 1},
         )
+
+    def test_v2_policy_authority_and_closed_fallback_identity_gate_comparability(self) -> None:
+        benchmark_root = self.root / "authority-v2"
+        model = "deepseek/deepseek-v4-flash-0731"
+        valid = self.v2_result(
+            case_id="review-zero-deferral",
+            model=model,
+            transport="openrouter",
+            observed_at="2026-08-29T04:00:00Z",
+            digest_suffix="fallback",
+        )
+        self.write_attempt(benchmark_root, "fallback-00-valid", valid)
+        fallback_variants = {
+            "true": {"used": True, "attemptedIdentity": model, "attemptedIdentities": [model], "provenance": "response_model"},
+            "unavailable": {"used": None, "attemptedIdentity": model, "attemptedIdentities": [model], "provenance": "not_available"},
+            "arbitrary": {"used": False, "attemptedIdentity": model, "attemptedIdentities": [model], "provenance": "claimed"},
+            "contradictory": {"used": False, "attemptedIdentity": "other/model", "attemptedIdentities": [model, "other/model"], "provenance": "response_model"},
+        }
+        for offset, (name, fallback) in enumerate(fallback_variants.items(), 1):
+            evidence = self.v2_result(
+                case_id="review-zero-deferral",
+                model=model,
+                transport="openrouter",
+                observed_at=f"2026-08-29T04:0{offset}:00Z",
+                digest_suffix="fallback",
+            )
+            evidence["fallback"] = fallback
+            self.write_attempt(benchmark_root, f"fallback-{offset:02d}-{name}", evidence)
+
+        authority_variants = []
+        wrong_role = self.v2_result(
+            case_id="review-zero-deferral", model=model, transport="openrouter",
+            observed_at="2026-08-29T04:10:00Z", digest_suffix="wrong-role",
+        )
+        wrong_role["role"] = "builder-fast"
+        authority_variants.append(("wrong-role", wrong_role, None))
+        wrong_candidate = self.v2_result(
+            case_id="review-zero-deferral", model="not/policy-eligible", transport="openrouter",
+            observed_at="2026-08-29T04:11:00Z", digest_suffix="wrong-candidate",
+        )
+        authority_variants.append(("wrong-candidate", wrong_candidate, None))
+        wrong_transport = self.v2_result(
+            case_id="review-zero-deferral", model=model, transport="codex-cli",
+            observed_at="2026-08-29T04:12:00Z", digest_suffix="wrong-transport",
+        )
+        authority_variants.append(("wrong-transport", wrong_transport, None))
+        missing_capability = self.v2_result(
+            case_id="research-claim-source-map", model="gpt-5.6-luna", transport="codex-cli",
+            observed_at="2026-08-29T04:13:00Z", digest_suffix="missing-capability",
+        )
+        authority_variants.append(("missing-capability", missing_capability, None))
+        receipt_mismatch = self.v2_result(
+            case_id="review-zero-deferral", model=model, transport="openrouter",
+            observed_at="2026-08-29T04:14:00Z", digest_suffix="receipt-mismatch",
+        )
+        authority_variants.append(
+            ("receipt-mismatch", receipt_mismatch, {"requestedModel": "other/model", "transport": "openrouter"})
+        )
+        for name, evidence, receipt in authority_variants:
+            self.write_attempt(benchmark_root, name, evidence, receipt=receipt)
+
+        output = self.root / "authority.json"
+        completed = self.run_tool(
+            "report", "--run-root", str(self.root / "no-runs"),
+            "--benchmark-root", str(benchmark_root), "--observed-at", "2026-08-29T09:00:00+08:00",
+            "--json-output", str(output),
+        )
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        rollup = json.loads(output.read_text())["benchmarks"]
+        fallback_group = next(group for group in rollup["groups"] if group["suite_digest"] == "suite-fallback")
+        self.assertEqual(fallback_group["attempts"], 5)
+        self.assertEqual(fallback_group["comparable_attempts"], 1)
+        self.assertEqual(fallback_group["validated_attempts"], 1)
+        self.assertEqual(fallback_group["operational_retries"], {"identity": 4})
+        self.assertEqual(len(rollup["incompatible_v2"]), 5)
+        self.assertTrue(all(item["model_conclusion"] is None for item in rollup["incompatible_v2"]))
+        wrong_role_row = next(item for item in rollup["incompatible_v2"] if item["path"].endswith("wrong-role"))
+        self.assertEqual(wrong_role_row["role"], "review-fast")
+        review_role = next(role for role in rollup["roles"] if role["role"] == "review-fast")
+        self.assertEqual(review_role["operational_retries"]["harness"], 4)
+        research_role = next(role for role in rollup["roles"] if role["role"] == "research-fast")
+        self.assertEqual(research_role["operational_retries"], {"harness": 1})
+        self.assertEqual(review_role["retained_attempts"], 9)
+        self.assertEqual(rollup["views"]["reliability"]["operational_retry_counts"]["harness"], 5)
+        self.assertEqual(rollup["views"]["reliability"]["retained_attempts"], 10)
+
+    def test_v2_role_metrics_and_competitive_evidence_never_mix_evaluator_cohorts(self) -> None:
+        benchmark_root = self.root / "cohorts-v2"
+
+        def add_attempt(name: str, case_id: str, model: str, transport: str, scorer: str, duration: int) -> None:
+            evidence = self.v2_result(
+                case_id=case_id, model=model, transport=transport,
+                observed_at=f"2026-08-29T05:{len(list(benchmark_root.glob('*'))):02d}:00Z",
+                digest_suffix="cohort", duration=duration,
+            )
+            evidence["evidenceBindings"]["scorerDigest"] = {
+                "declared": scorer, "actual": scorer, "match": True,
+            }
+            self.write_attempt(benchmark_root, name, evidence)
+
+        cases = ("review-zero-deferral", "review-false-positive-control")
+        for scorer, durations in (("scorer-a", (2, 4, 6)), ("scorer-b", (10, 12, 14))):
+            for case_id in cases:
+                for attempt, duration in enumerate(durations, 1):
+                    add_attempt(
+                        f"luna-{scorer}-{case_id}-{attempt}", case_id,
+                        "gpt-5.6-luna", "codex-cli", scorer, duration,
+                    )
+        for attempt in range(1, 4):
+            add_attempt(
+                f"deepseek-a-case-one-{attempt}", cases[0],
+                "deepseek/deepseek-v4-flash-0731", "openrouter", "scorer-a", 3,
+            )
+            add_attempt(
+                f"deepseek-b-case-two-{attempt}", cases[1],
+                "deepseek/deepseek-v4-flash-0731", "openrouter", "scorer-b", 9,
+            )
+
+        output = self.root / "cohorts.json"
+        markdown = self.root / "cohorts.md"
+        completed = self.run_tool(
+            "report", "--run-root", str(self.root / "no-runs"),
+            "--benchmark-root", str(benchmark_root), "--observed-at", "2026-08-29T09:00:00+08:00",
+            "--json-output", str(output), "--markdown-output", str(markdown),
+        )
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        rollup = json.loads(output.read_text())["benchmarks"]
+        role = next(item for item in rollup["roles"] if item["role"] == "review-fast")
+        self.assertEqual(len(role["evaluator_cohorts"]), 2)
+        self.assertEqual({item["scorer_digest"] for item in role["evaluator_cohorts"]}, {"scorer-a", "scorer-b"})
+        self.assertTrue(all(item["complete_case_coverage"] for item in role["evaluator_cohorts"]))
+        self.assertIsNone(role["first_pass_validated_rate"])
+        self.assertIsNone(role["best_deterministic_quality"])
+        self.assertIsNone(role["median_duration_seconds"])
+        luna = next(item for item in rollup["model_role_evidence"] if item["role"] == "review-fast" and item["model"] == "gpt-5.6-luna")
+        self.assertTrue(luna["controlled_competitive_evidence"])
+        self.assertEqual(len(luna["competitive_evidence_cohorts"]), 2)
+        for cohort in luna["competitive_evidence_cohorts"]:
+            self.assertIn(cohort["scorer_digest"], {"scorer-a", "scorer-b"})
+            self.assertEqual({group["case_id"] for group in cohort["case_groups"]}, set(cases))
+            self.assertTrue(all(group["prompt_digest"] == "prompt-cohort" for group in cohort["case_groups"]))
+        deepseek = next(item for item in rollup["model_role_evidence"] if item["role"] == "review-fast" and item["model"] == "deepseek/deepseek-v4-flash-0731")
+        self.assertFalse(deepseek["controlled_competitive_evidence"])
+        self.assertEqual(deepseek["competitive_evidence_cohorts"], [])
+        group_medians = {group["median_duration_seconds"] for group in rollup["groups"] if group["requested_candidate"] == "gpt-5.6-luna"}
+        self.assertEqual(group_medians, {4.0, 12.0})
+        self.assertIn("Median duration", markdown.read_text())
+        self.assertIn("evaluator cohorts", markdown.read_text())
+
+    def test_degraded_attempts_retain_receipt_evidence_and_all_recorded_spend_once(self) -> None:
+        benchmark_root = self.root / "retained-v2"
+        model = "deepseek/deepseek-v4-flash-0731"
+
+        def receipt(cost: float | None, outcome: str = "failed") -> dict[str, object]:
+            return {
+                "schemaVersion": 2, "requestedModel": model, "responseModel": model,
+                "servingProvider": "fixture-provider", "transport": "openrouter",
+                "billingMode": "api", "outcome": outcome, "failureKind": "fixture-failure",
+                "durationSeconds": 7,
+                "usage": {
+                    "prompt_tokens": 11, "completion_tokens": 5, "reasoning_tokens": 2,
+                    "cache_read_tokens": 3, "cache_creation_tokens": 1, "cost": None,
+                },
+                "providerBilledCostUsd": cost,
+                "contextTokens": 99, "toolCalls": 0,
+                "benchmark": {"suiteId": "depot-role-v2", "caseId": "review-zero-deferral", "role": "review-fast"},
+            }
+
+        historical = {
+            "schemaVersion": 1, "requestedModel": model, "servedModel": model,
+            "transport": "openrouter", "role": "review-fast", "caseId": "review-zero-deferral",
+            "usage": {"cost": 0.1},
+        }
+        self.write_attempt(benchmark_root, "historical", historical)
+        incompatible = self.v2_result(
+            case_id="review-zero-deferral", model=model, transport="openrouter",
+            observed_at="2026-08-29T06:00:00Z", digest_suffix="incompatible",
+            usage={"cost": 0.2},
+        )
+        incompatible["evidenceBindings"]["promptDigest"]["match"] = False
+        self.write_attempt(benchmark_root, "incompatible", incompatible)
+        malformed_dir = benchmark_root / "malformed"
+        malformed_dir.mkdir(parents=True)
+        (malformed_dir / "result.json").write_text("{")
+        (malformed_dir / "receipt.json").write_text(json.dumps(receipt(0.3)))
+        non_object_dir = benchmark_root / "non-object"
+        non_object_dir.mkdir(parents=True)
+        (non_object_dir / "result.json").write_text("[]")
+        (non_object_dir / "receipt.json").write_text(json.dumps(receipt(0.4)))
+        missing_dir = benchmark_root / "missing-result"
+        missing_dir.mkdir(parents=True)
+        (missing_dir / "receipt.json").write_text(json.dumps(receipt(0.5)))
+        (missing_dir / "prompt.txt").write_text("fixture prompt with receipt")
+        prompt_only = benchmark_root / "prompt-only"
+        prompt_only.mkdir(parents=True)
+        (prompt_only / "prompt.txt").write_text("fixture prompt")
+
+        output = self.root / "retained.json"
+        completed = self.run_tool(
+            "report", "--run-root", str(self.root / "no-runs"),
+            "--benchmark-root", str(benchmark_root), "--observed-at", "2026-08-29T09:00:00+08:00",
+            "--json-output", str(output),
+        )
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        rollup = json.loads(output.read_text())["benchmarks"]
+        self.assertAlmostEqual(rollup["measured_cost_usd"], 1.5)
+        self.assertEqual(
+            rollup["views"]["provider_spend"]["recorded_cost_coverage"],
+            {"recorded": 5, "attempts": 6, "rate": 5 / 6},
+        )
+        retained = {Path(item["path"]).name: item for item in rollup["incomplete_attempts"]}
+        self.assertEqual(set(retained), {"malformed", "non-object", "missing-result", "prompt-only"})
+        for name in ("malformed", "non-object", "missing-result"):
+            item = retained[name]
+            self.assertEqual(item["requested_candidate"], model)
+            self.assertEqual(item["served_identity"], model)
+            self.assertEqual(item["endpoint_provider"], "fixture-provider")
+            self.assertEqual(item["transport"], "openrouter")
+            self.assertEqual(item["role"], "review-fast")
+            self.assertEqual(item["case_id"], "review-zero-deferral")
+            self.assertEqual(item["receipt_outcome"], "failed")
+            self.assertEqual(item["duration_seconds"], 7)
+            self.assertEqual(item["prompt_tokens"], 11)
+            self.assertEqual(item["cache_read_tokens"], 3)
+            self.assertEqual(item["context_tokens"], 99)
+            self.assertEqual(item["cost_usd"], {"malformed": 0.3, "non-object": 0.4, "missing-result": 0.5}[name])
+            self.assertEqual(item["failure_reason"], "fixture-failure")
+        self.assertTrue(all(value is None for key, value in retained["prompt-only"].items() if key not in {"path", "failure_category", "failure_reason"}))
+        empty_root = self.root / "empty-spend"
+        empty_root.mkdir()
+        empty_output = self.root / "empty-spend.json"
+        completed = self.run_tool(
+            "report", "--run-root", str(self.root / "no-runs"),
+            "--benchmark-root", str(empty_root), "--observed-at", "2026-08-29T09:00:00+08:00",
+            "--json-output", str(empty_output),
+        )
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        self.assertIsNone(json.loads(empty_output.read_text())["benchmarks"]["measured_cost_usd"])
+
+    def test_human_rubric_requires_artifact_recomputation_and_valid_declared_digests(self) -> None:
+        benchmark_root = self.root / "human-digest-v2"
+        artifact = {"copy": "member update", "preservedFacts": []}
+        digest = hashlib.sha256((json.dumps(artifact, indent=2) + "\n").encode()).hexdigest()
+
+        def rubric(output_digest: str) -> dict[str, object]:
+            return {
+                "schemaVersion": 1, "suiteId": "depot-role-v2", "caseId": "editorial-member-update",
+                "caseRevision": 2, "rubricRevision": 1, "outputArtifactSha256": output_digest,
+                "observedAt": "2026-08-29T07:30:00Z", "blindToCandidate": True,
+                "criterionScores": {"member-clarity": 5, "member-voice": 4},
+            }
+
+        no_artifact = self.v2_result(
+            case_id="editorial-member-update", model="fable", transport="claude-cli",
+            observed_at="2026-08-29T07:00:00Z", digest_suffix="no-artifact",
+        )
+        no_artifact["normalizedOutputArtifactSha256"] = "a" * 64
+        self.write_attempt(benchmark_root, "no-artifact", no_artifact, human=rubric("a" * 64))
+        bad_rubric = self.v2_result(
+            case_id="editorial-member-update", model="fable", transport="claude-cli",
+            observed_at="2026-08-29T07:01:00Z", digest_suffix="bad-rubric",
+        )
+        self.write_attempt(benchmark_root, "bad-rubric", bad_rubric, output=artifact, human=rubric("SHA256:" + digest.upper()))
+        bad_result = self.v2_result(
+            case_id="editorial-member-update", model="fable", transport="claude-cli",
+            observed_at="2026-08-29T07:02:00Z", digest_suffix="bad-result",
+        )
+        bad_result["normalizedOutputArtifactSha256"] = "b" * 64
+        self.write_attempt(benchmark_root, "bad-result", bad_result, output=artifact, human=rubric(digest))
+        invalid_result = self.v2_result(
+            case_id="editorial-member-update", model="fable", transport="claude-cli",
+            observed_at="2026-08-29T07:02:30Z", digest_suffix="invalid-result",
+        )
+        invalid_result["normalizedOutputArtifactSha256"] = "SHA256:" + digest.upper()
+        self.write_attempt(benchmark_root, "invalid-result", invalid_result, output=artifact, human=rubric(digest))
+        accepted = self.v2_result(
+            case_id="editorial-member-update", model="fable", transport="claude-cli",
+            observed_at="2026-08-29T07:03:00Z", digest_suffix="accepted-declared",
+        )
+        accepted["normalizedOutputArtifactSha256"] = "sha256:" + digest
+        self.write_attempt(benchmark_root, "accepted", accepted, output=artifact, human=rubric("sha256:" + digest))
+
+        output = self.root / "human-digest.json"
+        completed = self.run_tool(
+            "report", "--run-root", str(self.root / "no-runs"),
+            "--benchmark-root", str(benchmark_root), "--observed-at", "2026-08-29T09:00:00+08:00",
+            "--json-output", str(output),
+        )
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        rollup = json.loads(output.read_text())["benchmarks"]
+        editorial = next(role for role in rollup["roles"] if role["role"] == "editorial")
+        self.assertEqual(editorial["editorial_human_evidence"]["accepted_receipts"], 1)
+        rejections = sum((Counter(group["editorial_human_rejections"]) for group in rollup["groups"]), Counter())
+        self.assertEqual(rejections["human rubric normalized output artifact unavailable"], 1)
+        self.assertEqual(rejections["human rubric output digest syntax invalid"], 1)
+        self.assertEqual(rejections["declared normalized output digest mismatch"], 1)
+        self.assertEqual(rejections["declared normalized output digest syntax invalid"], 1)
 
 
 class NativeDepotBenchmarkTest(unittest.TestCase):

--- a/tools/model-intelligence.py
+++ b/tools/model-intelligence.py
@@ -19,6 +19,7 @@ import argparse
 import hashlib
 import json
 import math
+import re
 import statistics
 import sys
 from collections import Counter, defaultdict
@@ -546,6 +547,7 @@ V2_BINDINGS = (
 )
 MODEL_FAILURE_CATEGORIES = {"contract", "mandatory", "semantic", "validation"}
 OPERATIONAL_FAILURE_CATEGORIES = {"benchmark", "prompt", "parser", "scorer", "harness", "transport", "identity"}
+DIGEST_PATTERN = re.compile(r"(?:sha256:)?[0-9a-f]{64}")
 
 
 def binding_value(result: dict[str, Any], name: str) -> Any:
@@ -555,17 +557,28 @@ def binding_value(result: dict[str, Any], name: str) -> Any:
 
 
 def result_usage(result: dict[str, Any], receipt: dict[str, Any]) -> dict[str, float | None]:
-    usage = result.get("usage")
-    usage = usage if isinstance(usage, dict) else receipt.get("usage")
-    usage = usage if isinstance(usage, dict) else {}
+    result_values = result.get("usage")
+    result_values = result_values if isinstance(result_values, dict) else {}
+    receipt_values = receipt.get("usage")
+    receipt_values = receipt_values if isinstance(receipt_values, dict) else {}
 
     def usage_number(*names: str) -> float | None:
-        for name in names:
-            parsed = number(usage.get(name))
-            if parsed is not None:
-                return parsed
+        for source in (result_values, receipt_values):
+            for name in names:
+                parsed = number(source.get(name))
+                if parsed is not None:
+                    return parsed
         return None
 
+    cost_usd = usage_number("cost", "cost_usd")
+    if cost_usd is None:
+        for source in (result, receipt):
+            for name in ("providerBilledCostUsd", "billedCostUsd", "costUsd", "cost_usd"):
+                cost_usd = number(source.get(name))
+                if cost_usd is not None:
+                    break
+            if cost_usd is not None:
+                break
     return {
         "prompt_tokens": usage_number("prompt_tokens", "input_tokens"),
         "completion_tokens": usage_number("completion_tokens", "output_tokens"),
@@ -576,13 +589,14 @@ def result_usage(result: dict[str, Any], receipt: dict[str, Any]) -> dict[str, f
         "cache_creation_tokens": usage_number(
             "cache_creation_tokens", "cache_write_tokens", "cache_creation_input_tokens"
         ),
-        "cost_usd": usage_number("cost", "cost_usd"),
+        "cost_usd": cost_usd,
     }
 
 
 def supplied_number(result: dict[str, Any], receipt: dict[str, Any], *names: str) -> float | None:
     usage = result.get("usage") if isinstance(result.get("usage"), dict) else {}
-    for source in (result, usage, receipt):
+    receipt_usage = receipt.get("usage") if isinstance(receipt.get("usage"), dict) else {}
+    for source in (result, usage, receipt, receipt_usage):
         for name in names:
             parsed = number(source.get(name))
             if parsed is not None:
@@ -608,7 +622,7 @@ def attempt_order(result: dict[str, Any], receipt: dict[str, Any]) -> tuple[str,
     return None
 
 
-def failure_category(result: dict[str, Any], compatible: bool, fallback_ok: bool) -> str | None:
+def failure_category(result: dict[str, Any], compatible: bool, identity_ok: bool) -> str | None:
     failure_class = result.get("failureClass")
     failure_class = failure_class if isinstance(failure_class, str) else ""
     if not compatible:
@@ -627,7 +641,7 @@ def failure_category(result: dict[str, Any], compatible: bool, fallback_ok: bool
     if not isinstance(transport, dict) or transport.get("status") != "success":
         return "transport"
     identity = result.get("identityStatus")
-    if not isinstance(identity, dict) or identity.get("confidence") != "confirmed" or not fallback_ok:
+    if not isinstance(identity, dict) or identity.get("confidence") != "confirmed" or not identity_ok:
         return "identity"
     if result.get("contractPassed") is not True:
         return "contract"
@@ -646,32 +660,123 @@ def safe_failure_reason(result: dict[str, Any], receipt: dict[str, Any], categor
         for reason in reasons:
             if isinstance(reason, str) and reason:
                 return reason.replace("\n", " ")[:240]
-    for source, name in ((result, "failureClass"), (receipt, "failureKind")):
+    for source, name in (
+        (result, "failureClass"), (result, "failureReason"),
+        (receipt, "failureKind"), (receipt, "failureReason"),
+    ):
         reason = source.get(name)
         if isinstance(reason, str) and reason:
             return reason.replace("\n", " ")[:240]
     return category
 
 
-def normalized_output_digest(directory: Path, result: dict[str, Any]) -> str | None:
-    for name in ("normalizedOutputArtifactSha256", "normalizedOutputDigest"):
-        digest = result.get(name)
-        if isinstance(digest, str) and digest:
-            return digest.removeprefix("sha256:")
-    normalized = result.get("normalizedOutput")
+def retained_attempt(
+    directory: Path,
+    result: dict[str, Any],
+    receipt: dict[str, Any],
+    case: dict[str, Any] | None,
+    category: str,
+) -> dict[str, Any]:
+    benchmark = receipt.get("benchmark")
+    benchmark = benchmark if isinstance(benchmark, dict) else {}
+    transport_outcome = result.get("transportOutcome")
+    transport_outcome = transport_outcome if isinstance(transport_outcome, dict) else {}
+
+    def text_value(*values: Any) -> str | None:
+        return next((value for value in values if isinstance(value, str) and value), None)
+
+    usage = result_usage(result, receipt)
+    case_id = text_value(result.get("caseId"), benchmark.get("caseId"))
+    authoritative_role = case.get("role") if isinstance(case, dict) else None
+    return {
+        "path": str(directory),
+        "requested_candidate": text_value(
+            result.get("requestedIdentity"), result.get("requestedModel"), receipt.get("requestedModel")
+        ),
+        "served_identity": text_value(
+            result.get("servedIdentity"), result.get("servedModel"), receipt.get("responseModel")
+        ),
+        "endpoint_provider": text_value(
+            result.get("endpointProvider"), result.get("provider"), receipt.get("servingProvider")
+        ),
+        "billing_mode": text_value(result.get("billingMode"), receipt.get("billingMode")),
+        "transport": text_value(result.get("transport"), receipt.get("transport")),
+        "role": text_value(authoritative_role, result.get("role"), benchmark.get("role")),
+        "reported_role": text_value(result.get("role"), benchmark.get("role")),
+        "case_id": case_id,
+        "observed_at": text_value(result.get("observedAt"), receipt.get("observedAt")),
+        "receipt_outcome": text_value(
+            result.get("outcome"), receipt.get("outcome"), transport_outcome.get("status")
+        ),
+        "duration_seconds": supplied_number(result, receipt, "durationSeconds", "duration_seconds"),
+        **usage,
+        "provider_billed_cost_usd": usage["cost_usd"],
+        "context_tokens": supplied_number(
+            result, receipt, "contextTokens", "context_tokens", "inputContextTokens"
+        ),
+        "tool_calls": supplied_number(result, receipt, "toolCalls", "tool_calls", "toolUseCount"),
+        "failure_category": category,
+        "failure_reason": safe_failure_reason(result, receipt, category),
+        "model_conclusion": None,
+    }
+
+
+def closed_identity_proof(result: dict[str, Any], receipt: dict[str, Any]) -> bool:
+    identity = result.get("identityStatus")
+    identity = identity if isinstance(identity, dict) else {}
+    fallback = result.get("fallback")
+    fallback = fallback if isinstance(fallback, dict) else {}
+    requested = result.get("requestedIdentity")
+    served = result.get("servedIdentity")
+    if not (
+        isinstance(requested, str)
+        and requested
+        and served == requested
+        and identity.get("confidence") == "confirmed"
+        and identity.get("provenance") == "response"
+        and fallback.get("used") is False
+        and fallback.get("attemptedIdentity") == requested
+        and fallback.get("attemptedIdentities") == [requested]
+        and fallback.get("provenance") == "response_model"
+    ):
+        return False
+    optional_receipt_bindings = {
+        "requestedModel": requested,
+        "responseModel": served,
+        "transport": result.get("transport"),
+        "fallbackUsed": False,
+        "attemptedModel": requested,
+        "attemptedModels": [requested],
+        "attemptProvenance": "response_model",
+        "responseModelProvenance": "response",
+    }
+    return all(
+        name not in receipt or receipt.get(name) == expected
+        for name, expected in optional_receipt_bindings.items()
+    )
+
+
+def normalized_output_digest(directory: Path, result: dict[str, Any]) -> tuple[str | None, str | None]:
+    output_path = directory / "output.json"
+    if not output_path.is_file() or output_path.is_symlink():
+        return None, "human rubric normalized output artifact unavailable"
+    try:
+        normalized = json.loads(output_path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return None, "human rubric normalized output artifact unavailable"
     if not isinstance(normalized, dict):
-        output_path = directory / "output.json"
-        if not output_path.is_file() or output_path.is_symlink():
-            return None
-        try:
-            candidate = json.loads(output_path.read_text())
-        except (OSError, json.JSONDecodeError):
-            return None
-        normalized = candidate if isinstance(candidate, dict) else None
-    if not isinstance(normalized, dict):
-        return None
+        return None, "human rubric normalized output artifact unavailable"
     artifact = json.dumps(normalized, indent=2, ensure_ascii=False) + "\n"
-    return sha256_bytes(artifact.encode())
+    recomputed = sha256_bytes(artifact.encode())
+    for name in ("normalizedOutputArtifactSha256", "normalizedOutputDigest"):
+        if name not in result:
+            continue
+        declared = result.get(name)
+        if not isinstance(declared, str) or DIGEST_PATTERN.fullmatch(declared) is None:
+            return None, "declared normalized output digest syntax invalid"
+        if declared.removeprefix("sha256:") != recomputed:
+            return None, "declared normalized output digest mismatch"
+    return recomputed, None
 
 
 def human_rubric_evidence(
@@ -701,7 +806,7 @@ def human_rubric_evidence(
         if isinstance(item, dict) and isinstance(item.get("id"), str)
     )
     scores = receipt.get("criterionScores") if isinstance(receipt, dict) else None
-    digest = normalized_output_digest(directory, result)
+    digest, digest_error = normalized_output_digest(directory, result)
     valid_scores = (
         isinstance(scores, dict)
         and sorted(scores) == criterion_ids
@@ -732,7 +837,11 @@ def human_rubric_evidence(
     ):
         return None, "human rubric case or rubric mismatch"
     receipt_digest = receipt.get("outputArtifactSha256")
-    if not isinstance(receipt_digest, str) or digest is None or receipt_digest.removeprefix("sha256:") != digest:
+    if digest_error is not None:
+        return None, digest_error
+    if not isinstance(receipt_digest, str) or DIGEST_PATTERN.fullmatch(receipt_digest) is None:
+        return None, "human rubric output digest syntax invalid"
+    if digest is None or receipt_digest.removeprefix("sha256:") != digest:
         return None, "human rubric output digest mismatch"
     if not valid_scores:
         return None, "unknown criterion IDs or invalid criterion scores"
@@ -841,6 +950,7 @@ def group_rollup(key: tuple[Any, ...], attempts: list[dict[str, Any]]) -> dict[s
         "model_rework_to_valid": model_rework,
         "attempts_to_valid": len(through_valid) if through_valid else None,
         "time_to_first_validated_seconds": sum_through_valid(through_valid, "duration_seconds"),
+        "median_duration_seconds": median(item["duration_seconds"] for item in comparable),
         "tokens_to_first_validated": {
             field: sum_through_valid(through_valid, field)
             for field in (
@@ -890,6 +1000,114 @@ def group_rollup(key: tuple[Any, ...], attempts: list[dict[str, Any]]) -> dict[s
     }
 
 
+EVALUATOR_COHORT_FIELDS = (
+    "suite_id", "suite_revision", "suite_digest", "scorer_revision", "scorer_digest",
+    "normalizer_revision", "normalizer_digest", "behavior_revision", "behavior_digest",
+)
+
+
+def evaluator_cohort_key(group: dict[str, Any]) -> tuple[Any, ...]:
+    return tuple(group[name] for name in EVALUATOR_COHORT_FIELDS)
+
+
+def evaluator_cohort_rollup(
+    key: tuple[Any, ...],
+    groups: list[dict[str, Any]],
+    role_cases: list[dict[str, Any]],
+) -> dict[str, Any]:
+    comparable_attempts = [
+        attempt for group in groups for attempt in group["attempt_records"]
+        if attempt["comparable"]
+    ]
+    first_pass = [
+        group["first_pass_validated"] for group in groups
+        if group["first_pass_validated"] is not None
+    ]
+    valid_groups = [group for group in groups if group["attempts_to_valid"] is not None]
+    case_coverage = []
+    for case in role_cases:
+        matching = [group for group in groups if group["case_id"] == case.get("id")]
+        case_coverage.append(
+            {
+                "case_id": case.get("id"),
+                "case_revision": case.get("revision"),
+                "prompt_revision": case.get("promptRevision"),
+                "groups": [
+                    {
+                        "requested_candidate": group["requested_candidate"],
+                        "transport": group["transport"],
+                        "case_revision": group["case_revision"],
+                        "case_digest": group["case_digest"],
+                        "prompt_revision": group["prompt_revision"],
+                        "prompt_digest": group["prompt_digest"],
+                        "comparable_attempts": group["comparable_attempts"],
+                        "validated_attempts": group["validated_attempts"],
+                    }
+                    for group in matching
+                ],
+                "comparable_attempts": sum(group["comparable_attempts"] for group in matching),
+                "validated_attempts": sum(group["validated_attempts"] for group in matching),
+            }
+        )
+    return {
+        **dict(zip(EVALUATOR_COHORT_FIELDS, key)),
+        "complete_case_coverage": bool(case_coverage) and all(
+            item["comparable_attempts"] > 0 for item in case_coverage
+        ),
+        "case_coverage": case_coverage,
+        "comparable_attempts": len(comparable_attempts),
+        "validated_attempts": sum(group["validated_attempts"] for group in groups),
+        "best_deterministic_quality": max(
+            (group["best_deterministic_quality"] for group in groups if group["best_deterministic_quality"] is not None),
+            default=None,
+        ),
+        "first_pass_validated_rate": sum(first_pass) / len(first_pass) if first_pass else None,
+        "median_duration_seconds": median(
+            attempt["duration_seconds"] for attempt in comparable_attempts
+        ),
+        "median_time_to_first_validated_seconds": median(
+            group["time_to_first_validated_seconds"] for group in valid_groups
+        ),
+        "median_attempts_to_valid": median(group["attempts_to_valid"] for group in valid_groups),
+        "median_model_rework_to_valid": median(
+            group["model_rework_to_valid"] for group in valid_groups
+        ),
+        "median_tokens_to_first_validated": {
+            field: median(group["tokens_to_first_validated"][field] for group in valid_groups)
+            for field in (
+                "prompt_tokens", "completion_tokens", "reasoning_tokens",
+                "cache_read_tokens", "cache_creation_tokens",
+            )
+        },
+        "median_context_to_first_validated": median(
+            group["context_to_first_validated"] for group in valid_groups
+        ),
+        "useful_finding_yield": median(group["useful_finding_yield"] for group in groups),
+        "false_positive_yield": median(group["false_positive_yield"] for group in groups),
+        "model_failure_counts": dict(sorted(sum(
+            (
+                Counter({
+                    name: count for name, count in group["failure_counts"].items()
+                    if name in MODEL_FAILURE_CATEGORIES
+                })
+                for group in groups
+            ),
+            Counter(),
+        ).items())),
+        "operational_retries": dict(sorted(sum(
+            (Counter(group["operational_retries"]) for group in groups), Counter()
+        ).items())),
+        "instrumentation": {
+            field: telemetry_coverage(comparable_attempts, field)
+            for field in (
+                "duration_seconds", "prompt_tokens", "completion_tokens", "reasoning_tokens",
+                "cache_read_tokens", "cache_creation_tokens", "context_tokens", "tool_calls",
+                "correction_count", "useful_findings", "false_positives",
+            )
+        },
+    }
+
+
 def benchmark_rollup(root: Path | None) -> dict[str, Any]:
     policy = load_json(DEFAULT_ROLE_POLICY)
     suite = load_json(DEFAULT_BENCHMARK_SUITE)
@@ -906,7 +1124,7 @@ def benchmark_rollup(root: Path | None) -> dict[str, Any]:
     incomplete: list[dict[str, Any]] = []
     historical_v1: list[dict[str, Any]] = []
     incompatible_v2: list[dict[str, Any]] = []
-    measured_cost_usd = 0.0
+    recorded_costs: list[float] = []
     expected_behavior = suite.get("behavioralContract")
     expected_behavior = expected_behavior if isinstance(expected_behavior, dict) else {}
 
@@ -919,71 +1137,54 @@ def benchmark_rollup(root: Path | None) -> dict[str, Any]:
         receipt = receipt if isinstance(receipt, dict) else {}
         result_path = directory / "result.json"
         if not result_path.is_file():
-            usage = result_usage({}, receipt)
             benchmark = receipt.get("benchmark")
             benchmark = benchmark if isinstance(benchmark, dict) else {}
             case_id = benchmark.get("caseId")
             case = case_by_id.get(case_id) if isinstance(case_id, str) else None
-            incomplete.append(
-                {
-                    "path": str(directory),
-                    "requested_candidate": receipt.get("requestedModel"),
-                    "transport": receipt.get("transport"),
-                    "role": benchmark.get("role") or (case.get("role") if isinstance(case, dict) else None),
-                    "case_id": case_id,
-                    "duration_seconds": supplied_number({}, receipt, "durationSeconds", "duration_seconds"),
-                    **usage,
-                    "receipt_outcome": receipt.get("outcome"),
-                    "failure_category": "transport" if receipt.get("outcome") == "failed" else "harness",
-                    "failure_reason": safe_failure_reason({}, receipt, "incomplete attempt"),
-                }
-            )
-            cost = usage["cost_usd"]
-            measured_cost_usd += cost if cost is not None else 0
+            category = "transport" if receipt.get("outcome") == "failed" else "harness"
+            retained = retained_attempt(directory, {}, receipt, case, category)
+            incomplete.append(retained)
+            if retained["cost_usd"] is not None:
+                recorded_costs.append(retained["cost_usd"])
             continue
         try:
             result = load_json(result_path)
-        except IntelligenceError as exc:
-            usage = result_usage({}, receipt)
+        except IntelligenceError:
             benchmark = receipt.get("benchmark")
             benchmark = benchmark if isinstance(benchmark, dict) else {}
-            incomplete.append(
-                {
-                    "path": str(directory),
-                    "requested_candidate": receipt.get("requestedModel"),
-                    "transport": receipt.get("transport"),
-                    "role": benchmark.get("role"),
-                    "case_id": benchmark.get("caseId"),
-                    "duration_seconds": supplied_number({}, receipt, "durationSeconds", "duration_seconds"),
-                    **usage,
-                    "receipt_outcome": receipt.get("outcome"),
-                    "failure_category": "parser",
-                    "failure_reason": str(exc),
-                }
-            )
+            case_id = benchmark.get("caseId")
+            case = case_by_id.get(case_id) if isinstance(case_id, str) else None
+            retained = retained_attempt(directory, {}, receipt, case, "parser")
+            incomplete.append(retained)
+            if retained["cost_usd"] is not None:
+                recorded_costs.append(retained["cost_usd"])
             continue
         if not isinstance(result, dict):
-            incomplete.append({"path": str(directory), "failure_category": "parser", "failure_reason": "result object required"})
+            benchmark = receipt.get("benchmark")
+            benchmark = benchmark if isinstance(benchmark, dict) else {}
+            case_id = benchmark.get("caseId")
+            case = case_by_id.get(case_id) if isinstance(case_id, str) else None
+            retained = retained_attempt(directory, {}, receipt, case, "parser")
+            if retained["failure_reason"] == "parser":
+                retained["failure_reason"] = "result object required"
+            incomplete.append(retained)
+            if retained["cost_usd"] is not None:
+                recorded_costs.append(retained["cost_usd"])
             continue
         if result.get("schemaVersion") != 2:
-            usage = result_usage(result, receipt)
+            result_case_id = result.get("caseId")
+            case = case_by_id.get(result_case_id) if isinstance(result_case_id, str) else None
+            retained = retained_attempt(directory, result, receipt, case, "harness")
             historical_v1.append(
-                {
-                    "path": str(directory),
+                retained | {
                     "schema_version": result.get("schemaVersion", 1),
-                    "requested_candidate": result.get("requestedModel"),
-                    "served_identity": result.get("servedModel"),
-                    "transport": result.get("transport"),
-                    "case_id": result.get("caseId"),
                     "parsed": result.get("parsed") if isinstance(result.get("parsed"), bool) else None,
                     "quality_score": number(result.get("qualityScore")),
-                    "duration_seconds": supplied_number(result, receipt, "durationSeconds", "duration_seconds"),
-                    **usage,
-                    "receipt_outcome": receipt.get("outcome"),
-                    "failure_reason": safe_failure_reason(result, receipt, None),
                     "classification": "historical/incompatible; no model conclusion",
                 }
             )
+            if retained["cost_usd"] is not None:
+                recorded_costs.append(retained["cost_usd"])
             continue
 
         case_id = result.get("caseId")
@@ -995,7 +1196,50 @@ def benchmark_rollup(root: Path | None) -> dict[str, Any]:
             isinstance(bindings.get(name), dict)
             and bindings[name].get("match") is True
             and bindings[name].get("actual") is not None
+            and bindings[name].get("declared") == bindings[name].get("actual")
             for name in V2_BINDINGS
+        )
+        authoritative_role = case.get("role") if isinstance(case, dict) else None
+        requested_candidate = result.get("requestedIdentity")
+        transport = result.get("transport")
+        role_candidates = policy_roles.get(authoritative_role)
+        role_candidates = role_candidates if isinstance(role_candidates, list) else []
+        policy_candidate = next(
+            (
+                candidate for candidate in role_candidates
+                if isinstance(candidate, dict)
+                and candidate.get("model") == requested_candidate
+                and candidate.get("transport") == transport
+            ),
+            None,
+        )
+        required_capabilities = case.get("requiredCapabilities") if isinstance(case, dict) else None
+        required_capabilities = required_capabilities if isinstance(required_capabilities, list) else []
+        candidate_capabilities = policy_candidate.get("capabilities") if isinstance(policy_candidate, dict) else None
+        candidate_capabilities = candidate_capabilities if isinstance(candidate_capabilities, list) else []
+        policy_ok = bool(
+            isinstance(policy_candidate, dict)
+            and result.get("role") == authoritative_role
+            and all(
+                isinstance(capability, str) and capability in candidate_capabilities
+                for capability in required_capabilities
+            )
+        )
+        receipt_benchmark = receipt.get("benchmark")
+        receipt_benchmark = receipt_benchmark if isinstance(receipt_benchmark, dict) else {}
+        receipt_binding_ok = all(
+            name not in receipt or receipt.get(name) == expected
+            for name, expected in (
+                ("requestedModel", requested_candidate),
+                ("transport", transport),
+            )
+        ) and all(
+            name not in receipt_benchmark or receipt_benchmark.get(name) == expected
+            for name, expected in (
+                ("suiteId", result.get("suiteId")),
+                ("caseId", case_id),
+                ("role", authoritative_role),
+            )
         )
         authority_ok = bool(
             isinstance(case, dict)
@@ -1006,29 +1250,17 @@ def benchmark_rollup(root: Path | None) -> dict[str, Any]:
             and behavior.get("revision") == expected_behavior.get("revision")
             and behavior.get("digest") == expected_behavior.get("digest")
         )
-        compatible = bindings_ok and authority_ok
+        compatible = bindings_ok and authority_ok and policy_ok and receipt_binding_ok
         fallback = result.get("fallback")
-        fallback_ok = bool(
-            isinstance(fallback, dict)
-            and isinstance(fallback.get("used"), bool)
-            and isinstance(fallback.get("provenance"), str)
-            and fallback.get("provenance")
-        )
-        category = failure_category(result, compatible, fallback_ok)
+        identity_ok = closed_identity_proof(result, receipt)
+        category = failure_category(result, compatible, identity_ok)
         transport_outcome = result.get("transportOutcome")
         transport_outcome = transport_outcome if isinstance(transport_outcome, dict) else {}
-        identity_status = result.get("identityStatus")
-        identity_status = identity_status if isinstance(identity_status, dict) else {}
         comparable = bool(
             compatible
             and result.get("benchmarkFault") is False
             and transport_outcome.get("status") == "success"
-            and identity_status.get("confidence") == "confirmed"
-            and fallback_ok
-            and isinstance(result.get("requestedIdentity"), str)
-            and bool(result.get("requestedIdentity"))
-            and isinstance(result.get("servedIdentity"), str)
-            and bool(result.get("servedIdentity"))
+            and identity_ok
         )
         validated = bool(
             comparable
@@ -1039,16 +1271,18 @@ def benchmark_rollup(root: Path | None) -> dict[str, Any]:
         )
         usage = result_usage(result, receipt)
         cost = usage["cost_usd"]
-        measured_cost_usd += cost if cost is not None else 0
+        if cost is not None:
+            recorded_costs.append(cost)
         human, human_rejection = human_rubric_evidence(directory, result, case)
         attempt = {
             "path": str(directory),
-            "requested_candidate": result.get("requestedIdentity"),
+            "requested_candidate": requested_candidate,
             "served_identity": result.get("servedIdentity"),
             "endpoint_provider": result.get("endpointProvider"),
             "billing_mode": result.get("billingMode") or receipt.get("billingMode"),
-            "transport": result.get("transport"),
-            "role": result.get("role"),
+            "transport": transport,
+            "role": authoritative_role,
+            "reported_role": result.get("role"),
             "case_id": case_id,
             "case_revision": binding_value(result, "caseRevision"),
             "observed_at": result.get("observedAt") if isinstance(result.get("observedAt"), str) else None,
@@ -1064,6 +1298,7 @@ def benchmark_rollup(root: Path | None) -> dict[str, Any]:
             "failure_reason": safe_failure_reason(result, receipt, category),
             "duration_seconds": supplied_number(result, receipt, "durationSeconds", "duration_seconds"),
             **usage,
+            "provider_billed_cost_usd": usage["cost_usd"],
             "context_tokens": supplied_number(result, receipt, "contextTokens", "context_tokens", "inputContextTokens"),
             "tool_calls": supplied_number(result, receipt, "toolCalls", "tool_calls", "toolUseCount"),
             "correction_count": supplied_number(result, receipt, "correctionCount", "correction_count"),
@@ -1096,11 +1331,29 @@ def benchmark_rollup(root: Path | None) -> dict[str, Any]:
     for role, candidates in policy_roles.items():
         role_cases = [case for case in cases if isinstance(case, dict) and case.get("role") == role]
         role_groups = [group for group in groups if group["role"] == role]
-        role_attempts = [
-            attempt for group in role_groups for attempt in group["attempt_records"]
-            if attempt["comparable"]
+        cohort_groups: dict[tuple[Any, ...], list[dict[str, Any]]] = defaultdict(list)
+        for group in role_groups:
+            cohort_groups[evaluator_cohort_key(group)].append(group)
+        evaluator_cohorts = [
+            evaluator_cohort_rollup(key, matching, role_cases)
+            for key, matching in sorted(
+                cohort_groups.items(), key=lambda item: tuple(str(part) for part in item[0])
+            )
+        ]
+        metric_cohorts = [
+            cohort for cohort in evaluator_cohorts if cohort["comparable_attempts"] > 0
+        ]
+        selected_cohort = metric_cohorts[0] if len(metric_cohorts) == 1 else None
+        selected_key = (
+            tuple(selected_cohort[name] for name in EVALUATOR_COHORT_FIELDS)
+            if selected_cohort is not None else None
+        )
+        selected_groups = [
+            group for group in role_groups
+            if selected_key is not None and evaluator_cohort_key(group) == selected_key
         ]
         incomplete_for_role = [item for item in incomplete if item.get("role") == role]
+        incompatible_for_role = [item for item in incompatible_v2 if item.get("role") == role]
         role_operational_retries = sum(
             (Counter(group["operational_retries"]) for group in role_groups), Counter()
         )
@@ -1108,9 +1361,27 @@ def benchmark_rollup(root: Path | None) -> dict[str, Any]:
             item["failure_category"] for item in incomplete_for_role
             if item.get("failure_category") in OPERATIONAL_FAILURE_CATEGORIES
         )
+        role_operational_retries.update(
+            item["failure_category"] for item in incompatible_for_role
+            if item.get("failure_category") in OPERATIONAL_FAILURE_CATEGORIES
+        )
         case_coverage = []
         for case in role_cases:
             matching = [group for group in role_groups if group["case_id"] == case.get("id")]
+            cohort_coverage = [
+                next(
+                    item for item in cohort["case_coverage"]
+                    if item["case_id"] == case.get("id")
+                )
+                | {
+                    name: cohort[name] for name in EVALUATOR_COHORT_FIELDS
+                }
+                for cohort in evaluator_cohorts
+            ]
+            selected_case = next(
+                (item for item in cohort_coverage if selected_key is not None and tuple(item[name] for name in EVALUATOR_COHORT_FIELDS) == selected_key),
+                None,
+            )
             case_coverage.append(
                 {
                     "case_id": case.get("id"),
@@ -1119,20 +1390,35 @@ def benchmark_rollup(root: Path | None) -> dict[str, Any]:
                     "required_capabilities": case.get("requiredCapabilities", []),
                     "applicability": case.get("applicability"),
                     "compatible_groups": len(matching),
-                    "comparable_attempts": sum(group["comparable_attempts"] for group in matching),
-                    "validated_attempts": sum(group["validated_attempts"] for group in matching),
+                    "comparable_attempts": selected_case["comparable_attempts"] if selected_case is not None else None,
+                    "validated_attempts": selected_case["validated_attempts"] if selected_case is not None else None,
+                    "evaluator_cohorts": cohort_coverage,
                     "latest_observed_at": max(
                         (group["latest_observed_at"] for group in matching if group["latest_observed_at"] is not None),
                         default=None,
                     ),
                 }
             )
-        missing_cases = [item["case_id"] for item in case_coverage if item["comparable_attempts"] == 0]
-        first_pass = [group["first_pass_validated"] for group in role_groups if group["first_pass_validated"] is not None]
-        valid_groups = [group for group in role_groups if group["attempts_to_valid"] is not None]
+        missing_cases = [
+            item["case_id"] for item in case_coverage
+            if not any(cohort["comparable_attempts"] > 0 for cohort in item["evaluator_cohorts"])
+        ]
         latest = max(
             (group["latest_observed_at"] for group in role_groups if group["latest_observed_at"] is not None),
             default=None,
+        )
+        has_comparable = bool(metric_cohorts)
+        instrumentation = (
+            selected_cohort["instrumentation"]
+            if selected_cohort is not None
+            else {
+                field: {"recorded": None, "attempts": None, "rate": None}
+                for field in (
+                    "duration_seconds", "prompt_tokens", "completion_tokens", "reasoning_tokens",
+                    "cache_read_tokens", "cache_creation_tokens", "context_tokens", "tool_calls",
+                    "correction_count", "useful_findings", "false_positives",
+                )
+            }
         )
         role_rows.append(
             {
@@ -1140,44 +1426,38 @@ def benchmark_rollup(root: Path | None) -> dict[str, Any]:
                 "policy_candidates": len(candidates) if isinstance(candidates, list) else 0,
                 "required_cases": len(role_cases),
                 "case_coverage": case_coverage,
-                "missing_cases": missing_cases,
-                "gap": "no comparable current evidence" if not role_attempts else ("incomplete case coverage" if missing_cases else None),
-                "confidence": "none" if not role_attempts else ("partial" if missing_cases else "controlled-current"),
-                "freshness": {"latest_observed_at": latest, "suite_revision": suite.get("suiteRevision"), "policy_snapshot": policy.get("matrixSnapshot")},
-                "best_deterministic_quality": max(
-                    (group["best_deterministic_quality"] for group in role_groups if group["best_deterministic_quality"] is not None),
-                    default=None,
+                "evaluator_cohorts": evaluator_cohorts,
+                "complete_evaluator_cohorts": sum(
+                    cohort["complete_case_coverage"] for cohort in evaluator_cohorts
                 ),
-                "validated_attempts": sum(group["validated_attempts"] for group in role_groups),
-                "comparable_attempts": sum(group["comparable_attempts"] for group in role_groups),
-                "first_pass_validated_rate": sum(first_pass) / len(first_pass) if first_pass else None,
-                "median_time_to_first_validated_seconds": median(group["time_to_first_validated_seconds"] for group in valid_groups),
-                "median_attempts_to_valid": median(group["attempts_to_valid"] for group in valid_groups),
-                "median_model_rework_to_valid": median(group["model_rework_to_valid"] for group in valid_groups),
-                "median_tokens_to_first_validated": {
-                    field: median(group["tokens_to_first_validated"][field] for group in valid_groups)
-                    for field in (
+                "missing_cases": missing_cases,
+                "gap": "no comparable current evidence" if not has_comparable else ("multiple evaluator cohorts" if len(metric_cohorts) > 1 else ("incomplete case coverage" if missing_cases else None)),
+                "confidence": "none" if not has_comparable else ("cohort-separated" if len(metric_cohorts) > 1 else ("partial" if missing_cases else "controlled-current")),
+                "freshness": {"latest_observed_at": latest, "suite_revision": suite.get("suiteRevision"), "policy_snapshot": policy.get("matrixSnapshot")},
+                "best_deterministic_quality": selected_cohort["best_deterministic_quality"] if selected_cohort is not None else None,
+                "validated_attempts": selected_cohort["validated_attempts"] if selected_cohort is not None else None,
+                "comparable_attempts": selected_cohort["comparable_attempts"] if selected_cohort is not None else None,
+                "first_pass_validated_rate": selected_cohort["first_pass_validated_rate"] if selected_cohort is not None else None,
+                "median_duration_seconds": selected_cohort["median_duration_seconds"] if selected_cohort is not None else None,
+                "median_time_to_first_validated_seconds": selected_cohort["median_time_to_first_validated_seconds"] if selected_cohort is not None else None,
+                "median_attempts_to_valid": selected_cohort["median_attempts_to_valid"] if selected_cohort is not None else None,
+                "median_model_rework_to_valid": selected_cohort["median_model_rework_to_valid"] if selected_cohort is not None else None,
+                "median_tokens_to_first_validated": selected_cohort["median_tokens_to_first_validated"] if selected_cohort is not None else {
+                    field: None for field in (
                         "prompt_tokens", "completion_tokens", "reasoning_tokens",
                         "cache_read_tokens", "cache_creation_tokens",
                     )
                 },
-                "median_context_to_first_validated": median(group["context_to_first_validated"] for group in valid_groups),
-                "useful_finding_yield": median(group["useful_finding_yield"] for group in role_groups),
-                "false_positive_yield": median(group["false_positive_yield"] for group in role_groups),
+                "median_context_to_first_validated": selected_cohort["median_context_to_first_validated"] if selected_cohort is not None else None,
+                "useful_finding_yield": selected_cohort["useful_finding_yield"] if selected_cohort is not None else None,
+                "false_positive_yield": selected_cohort["false_positive_yield"] if selected_cohort is not None else None,
                 "operational_retries": dict(sorted(role_operational_retries.items())),
-                "model_failure_counts": dict(sorted(sum((Counter({key: value for key, value in group["failure_counts"].items() if key in MODEL_FAILURE_CATEGORIES}) for group in role_groups), Counter()).items())),
-                "instrumentation": {
-                    field: telemetry_coverage(role_attempts, field)
-                    for field in (
-                        "duration_seconds", "prompt_tokens", "completion_tokens", "reasoning_tokens",
-                        "cache_read_tokens", "cache_creation_tokens", "context_tokens", "tool_calls",
-                        "correction_count", "useful_findings", "false_positives",
-                    )
-                } | {
+                "model_failure_counts": dict(sorted(sum((Counter({key: value for key, value in group["failure_counts"].items() if key in MODEL_FAILURE_CATEGORIES}) for group in selected_groups), Counter()).items())) if selected_cohort is not None else {},
+                "instrumentation": instrumentation | {
                     "attempt_order": {
-                        "recorded": sum(group["ordering_available"] for group in role_groups),
-                        "groups": len(role_groups),
-                        "rate": (sum(group["ordering_available"] for group in role_groups) / len(role_groups)) if role_groups else None,
+                        "recorded": sum(group["ordering_available"] for group in selected_groups) if selected_cohort is not None else None,
+                        "groups": len(selected_groups) if selected_cohort is not None else None,
+                        "rate": (sum(group["ordering_available"] for group in selected_groups) / len(selected_groups)) if selected_groups else None,
                     }
                 },
                 "editorial_human_evidence": (
@@ -1190,7 +1470,8 @@ def benchmark_rollup(root: Path | None) -> dict[str, Any]:
                     if any(group["editorial_human_evidence"] is not None for group in role_groups) else None
                 ),
                 "incomplete_attempts": len(incomplete_for_role),
-                "retained_attempts": sum(group["attempts"] for group in role_groups) + len(incomplete_for_role),
+                "incompatible_v2_attempts": len(incompatible_for_role),
+                "retained_attempts": sum(group["attempts"] for group in role_groups) + len(incomplete_for_role) + len(incompatible_for_role),
             }
         )
 
@@ -1209,7 +1490,14 @@ def benchmark_rollup(root: Path | None) -> dict[str, Any]:
             observed_cases = {group["case_id"] for group in candidate_groups if group["comparable_attempts"]}
             validated_cases = {group["case_id"] for group in candidate_groups if group["validated_attempts"]}
             strengths = [
-                {"case_id": group["case_id"], "validated_attempts": group["validated_attempts"], "best_deterministic_quality": group["best_deterministic_quality"]}
+                {
+                    "case_id": group["case_id"], "case_revision": group["case_revision"],
+                    "case_digest": group["case_digest"], "prompt_revision": group["prompt_revision"],
+                    "prompt_digest": group["prompt_digest"], "scorer_revision": group["scorer_revision"],
+                    "scorer_digest": group["scorer_digest"],
+                    "validated_attempts": group["validated_attempts"],
+                    "best_deterministic_quality": group["best_deterministic_quality"],
+                }
                 for group in candidate_groups if group["validated_attempts"]
             ]
             failures = [
@@ -1221,32 +1509,48 @@ def benchmark_rollup(root: Path | None) -> dict[str, Any]:
                 sum(value for key, value in group["failure_counts"].items() if key in {"benchmark", "prompt", "parser", "scorer", "harness"})
                 for group in candidate_groups
             )
-            evaluator_families = {
-                (
-                    group["suite_revision"], group["suite_digest"],
-                    group["scorer_revision"],
-                    group["normalizer_revision"], group["normalizer_digest"],
-                    group["behavior_revision"], group["behavior_digest"],
+            candidate_cohorts: dict[tuple[Any, ...], list[dict[str, Any]]] = defaultdict(list)
+            for group in candidate_groups:
+                candidate_cohorts[evaluator_cohort_key(group)].append(group)
+            competitive_cohorts = []
+            for cohort_key, cohort_groups_for_candidate in sorted(
+                candidate_cohorts.items(), key=lambda item: tuple(str(part) for part in item[0])
+            ):
+                complete_case_groups: list[dict[str, Any]] = []
+                complete = bool(role_case_ids)
+                for case_id in role_case_ids:
+                    eligible = [
+                        group for group in cohort_groups_for_candidate
+                        if group["case_id"] == case_id and group["validated_attempts"] >= 3
+                    ]
+                    if not eligible:
+                        complete = False
+                    complete_case_groups.extend(eligible)
+                cohort_has_model_failures = any(
+                    any(key in MODEL_FAILURE_CATEGORIES for key in group["failure_counts"])
+                    for group in cohort_groups_for_candidate
                 )
-                for group in candidate_groups
-            }
-            competitive = any(
-                all(
-                    any(
-                        group["case_id"] == case_id
-                        and group["validated_attempts"] >= 3
-                        and (
-                            group["suite_revision"], group["suite_digest"],
-                            group["scorer_revision"],
-                            group["normalizer_revision"], group["normalizer_digest"],
-                            group["behavior_revision"], group["behavior_digest"],
-                        ) == evaluator_family
-                        for group in candidate_groups
+                if complete and not cohort_has_model_failures:
+                    competitive_cohorts.append(
+                        {
+                            **dict(zip(EVALUATOR_COHORT_FIELDS, cohort_key)),
+                            "case_groups": [
+                                {
+                                    "case_id": group["case_id"],
+                                    "case_revision": group["case_revision"],
+                                    "case_digest": group["case_digest"],
+                                    "prompt_revision": group["prompt_revision"],
+                                    "prompt_digest": group["prompt_digest"],
+                                    "scorer_revision": group["scorer_revision"],
+                                    "scorer_digest": group["scorer_digest"],
+                                    "normalizer_revision": group["normalizer_revision"],
+                                    "normalizer_digest": group["normalizer_digest"],
+                                    "validated_attempts": group["validated_attempts"],
+                                }
+                                for group in complete_case_groups
+                            ],
+                        }
                     )
-                    for case_id in role_case_ids
-                )
-                for evaluator_family in evaluator_families
-            )
             model_rows.append(
                 {
                     "model": candidate["model"],
@@ -1260,9 +1564,11 @@ def benchmark_rollup(root: Path | None) -> dict[str, Any]:
                     "prohibited_evidence": [],
                     "gaps": sorted(set(role_case_ids) - observed_cases),
                     "validated_case_coverage": len(validated_cases),
-                    "controlled_competitive_evidence": bool(role_case_ids and competitive and not failures),
+                    "controlled_competitive_evidence": bool(competitive_cohorts),
+                    "competitive_evidence_cohorts": competitive_cohorts,
                     "benchmark_faults": benchmark_faults,
                     "benchmark_fault_conclusion": "no model conclusion" if benchmark_faults else None,
+                    "row_level_conclusion": "no model conclusion" if benchmark_faults else ("attributable model evidence" if strengths or failures else None),
                     "routing_conclusion": "no routing change justified",
                 }
             )
@@ -1277,23 +1583,48 @@ def benchmark_rollup(root: Path | None) -> dict[str, Any]:
         "incomplete_attempts": incomplete,
         "historical_v1": historical_v1,
         "incompatible_v2": incompatible_v2,
-        "measured_cost_usd": measured_cost_usd,
+        "measured_cost_usd": sum(recorded_costs) if recorded_costs else None,
         "matrix_opportunities": [],
         "routing_conclusion": "no routing change justified",
         "views": {
             "quality": {
-                "validated_attempts": sum(role["validated_attempts"] for role in role_rows),
-                "comparable_attempts": sum(role["comparable_attempts"] for role in role_rows),
-                "roles_with_validated_evidence": [role["role"] for role in role_rows if role["validated_attempts"]],
+                "validated_attempts": (
+                    None if any(role["comparable_attempts"] is None and len([cohort for cohort in role["evaluator_cohorts"] if cohort["comparable_attempts"]]) > 1 for role in role_rows)
+                    else sum((role["validated_attempts"] or 0) for role in role_rows)
+                ),
+                "comparable_attempts": (
+                    None if any(role["comparable_attempts"] is None and len([cohort for cohort in role["evaluator_cohorts"] if cohort["comparable_attempts"]]) > 1 for role in role_rows)
+                    else sum((role["comparable_attempts"] or 0) for role in role_rows)
+                ),
+                "roles_with_validated_evidence": [
+                    role["role"] for role in role_rows
+                    if any(cohort["validated_attempts"] for cohort in role["evaluator_cohorts"])
+                ],
+                "evaluator_cohorts": {
+                    role["role"]: role["evaluator_cohorts"] for role in role_rows
+                },
             },
             "reliability": {
                 "model_failure_counts": dict(sorted(sum((Counter(role["model_failure_counts"]) for role in role_rows), Counter()).items())),
                 "operational_retry_counts": dict(sorted(sum((Counter(role["operational_retries"]) for role in role_rows), Counter()).items())),
                 "historical_v1_attempts": len(historical_v1),
                 "incompatible_v2_attempts": len(incompatible_v2),
+                "retained_attempts": len(directories),
             },
             "latency": {
-                role["role"]: role["instrumentation"]["duration_seconds"] for role in role_rows
+                role["role"]: {
+                    "median_duration_seconds": role["median_duration_seconds"],
+                    "coverage": role["instrumentation"]["duration_seconds"],
+                    "evaluator_cohorts": [
+                        {
+                            **{name: cohort[name] for name in EVALUATOR_COHORT_FIELDS},
+                            "median_duration_seconds": cohort["median_duration_seconds"],
+                            "coverage": cohort["instrumentation"]["duration_seconds"],
+                        }
+                        for cohort in role["evaluator_cohorts"]
+                    ],
+                }
+                for role in role_rows
             },
             "tokens_context": {
                 role["role"]: {
@@ -1305,7 +1636,14 @@ def benchmark_rollup(root: Path | None) -> dict[str, Any]:
                 }
                 for role in role_rows
             },
-            "provider_spend": {"measured_cost_usd": measured_cost_usd},
+            "provider_spend": {
+                "measured_cost_usd": sum(recorded_costs) if recorded_costs else None,
+                "recorded_cost_coverage": {
+                    "recorded": len(recorded_costs),
+                    "attempts": len(directories),
+                    "rate": len(recorded_costs) / len(directories) if directories else None,
+                },
+            },
             "subscription_marginal_cost": {"value": None, "reason": "reported only when supplied by production evidence"},
             "api_equivalent_cost": {"value": None, "reason": "not inferred or combined with billed spend"},
             "capabilities": {
@@ -1331,18 +1669,20 @@ def render_report(report: dict[str, Any]) -> str:
         "",
         "## Per-role validated quality and efficiency",
         "",
-        "| Role | Cases | Validated | Best quality | First pass | Time to valid | Attempts/rework | Confidence | Freshness | Gap |",
-        "|---|---:|---:|---:|---:|---:|---:|---|---|---|",
+        "| Role | Cases | Validated | Best quality | First pass | Median duration | Time to valid | Attempts/rework | Confidence | Freshness | Gap |",
+        "|---|---:|---:|---:|---:|---:|---:|---:|---|---|---|",
     ]
     for role in benchmark["roles"]:
         first_pass = "n/a" if role["first_pass_validated_rate"] is None else f"{role['first_pass_validated_rate']:.0%}"
         time_valid = "n/a" if role["median_time_to_first_validated_seconds"] is None else f"{role['median_time_to_first_validated_seconds']:.1f}s"
         attempts = "n/a" if role["median_attempts_to_valid"] is None else f"{role['median_attempts_to_valid']:g}/{role['median_model_rework_to_valid']:g}"
         score = "n/a" if role["best_deterministic_quality"] is None else f"{role['best_deterministic_quality']:g}"
+        duration = "n/a" if role["median_duration_seconds"] is None else f"{role['median_duration_seconds']:.1f}s"
+        validated = "n/a" if role["validated_attempts"] is None else f"{role['validated_attempts']}/{role['comparable_attempts']}"
         freshness = role["freshness"]["latest_observed_at"] or "none"
         lines.append(
             f"| {role['role']} | {role['required_cases'] - len(role['missing_cases'])}/{role['required_cases']} | "
-            f"{role['validated_attempts']}/{role['comparable_attempts']} | {score} | {first_pass} | {time_valid} | "
+            f"{validated} | {score} | {first_pass} | {duration} | {time_valid} | "
             f"{attempts} | {role['confidence']} | {freshness} | {role['gap'] or 'none'} |"
         )
     lines.extend(
@@ -1372,6 +1712,24 @@ def render_report(report: dict[str, Any]) -> str:
                 "",
             ]
         )
+        if role["evaluator_cohorts"]:
+            lines.extend(
+                [
+                    "| Evaluator cohort scorer | Complete cases | Validated | Best quality | First pass | Median duration | Time to valid |",
+                    "|---|---:|---:|---:|---:|---:|---:|",
+                ]
+            )
+            for cohort in role["evaluator_cohorts"]:
+                cohort_first_pass = "n/a" if cohort["first_pass_validated_rate"] is None else f"{cohort['first_pass_validated_rate']:.0%}"
+                cohort_duration = "n/a" if cohort["median_duration_seconds"] is None else f"{cohort['median_duration_seconds']:.1f}s"
+                cohort_time = "n/a" if cohort["median_time_to_first_validated_seconds"] is None else f"{cohort['median_time_to_first_validated_seconds']:.1f}s"
+                cohort_quality = "n/a" if cohort["best_deterministic_quality"] is None else f"{cohort['best_deterministic_quality']:g}"
+                lines.append(
+                    f"| {cohort['scorer_revision']}/{cohort['scorer_digest']} | "
+                    f"{str(cohort['complete_case_coverage']).lower()} | {cohort['validated_attempts']}/{cohort['comparable_attempts']} | "
+                    f"{cohort_quality} | {cohort_first_pass} | {cohort_duration} | {cohort_time} |"
+                )
+            lines.append("")
 
     lines.extend(["## Controlled model-role evidence", ""])
     evidenced_models = [
@@ -1381,14 +1739,15 @@ def render_report(report: dict[str, Any]) -> str:
     if evidenced_models:
         lines.extend(
             [
-                "| Role | Requested candidate | Transport | Validated strengths | Attributable failures | Gaps | Benchmark faults | Conclusion |",
-                "|---|---|---|---:|---:|---:|---:|---|",
+                "| Role | Requested candidate | Transport | Validated strengths | Attributable failures | Gaps | Benchmark faults | Row conclusion | Routing |",
+                "|---|---|---|---:|---:|---:|---:|---|---|",
             ]
         )
         for row in evidenced_models:
             lines.append(
                 f"| {row['role']} | {row['model']} | {row['transport']} | {len(row['strengths'])} | "
-                f"{len(row['failures'])} | {len(row['gaps'])} | {row['benchmark_faults']} | {row['routing_conclusion']} |"
+                f"{len(row['failures'])} | {len(row['gaps'])} | {row['benchmark_faults']} | "
+                f"{row['row_level_conclusion'] or 'none'} | {row['routing_conclusion']} |"
             )
     else:
         lines.append("No attributable current v2 model-role evidence is available.")
@@ -1397,17 +1756,18 @@ def render_report(report: dict[str, Any]) -> str:
     if benchmark["groups"]:
         lines.extend(
             [
-                "| Candidate | Transport | Role | Case/revision | Validated | First pass | Rework | Operational retries | Endpoint providers |",
-                "|---|---|---|---|---:|---:|---:|---|---|",
+                "| Candidate | Transport | Role | Case/revision | Validated | First pass | Rework | Median duration | Operational retries | Endpoint providers |",
+                "|---|---|---|---|---:|---:|---:|---:|---|---|",
             ]
         )
         for group in benchmark["groups"]:
             first_pass = "n/a" if group["first_pass_validated"] is None else str(group["first_pass_validated"]).lower()
             rework = "n/a" if group["model_rework_to_valid"] is None else str(group["model_rework_to_valid"])
+            duration = "n/a" if group["median_duration_seconds"] is None else f"{group['median_duration_seconds']:.1f}s"
             lines.append(
                 f"| {group['requested_candidate']} | {group['transport']} | {group['role']} | "
                 f"{group['case_id']}/{group['case_revision']} | {group['validated_attempts']}/{group['comparable_attempts']} | "
-                f"{first_pass} | {rework} | `{json.dumps(group['operational_retries'], sort_keys=True)}` | "
+                f"{first_pass} | {rework} | {duration} | `{json.dumps(group['operational_retries'], sort_keys=True)}` | "
                 f"`{json.dumps(group['endpoint_providers'], sort_keys=True)}` |"
             )
     else:
@@ -1456,6 +1816,9 @@ def render_report(report: dict[str, Any]) -> str:
             "Recorded duration, prompt/completion/reasoning/cache tokens, context, and tool telemetry remain independent axes. Coverage is reported above; missing values are not zero.",
             "",
             "## Provider spend and access economics",
+            "",
+            f"- Benchmark provider-billed cost: {benchmark['views']['provider_spend']['measured_cost_usd']}",
+            f"- Benchmark recorded-cost coverage: `{json.dumps(benchmark['views']['provider_spend']['recorded_cost_coverage'], sort_keys=True)}`",
             "",
         ]
     )

--- a/tools/model-intelligence.py
+++ b/tools/model-intelligence.py
@@ -33,6 +33,13 @@ DEFAULT_MATRIX = (
     / "plugins/openrouter/skills/openrouter-delegate/references/model-matrix.json"
 )
 DEFAULT_RUN_ROOTS = (REPO_ROOT / "plans", REPO_ROOT / ".workflow-kernel" / "runs")
+DEFAULT_ROLE_POLICY = (
+    REPO_ROOT / "plugins/model-router/skills/model-router/references/role-policy.json"
+)
+DEFAULT_BENCHMARK_SUITE = (
+    REPO_ROOT
+    / "plugins/openrouter/skills/openrouter-delegate/references/depot-role-benchmark-suite.json"
+)
 
 
 class IntelligenceError(ValueError):
@@ -525,75 +532,794 @@ def result_dirs(root: Path) -> list[Path]:
     return sorted(candidates)
 
 
+V2_BINDINGS = (
+    "suiteRevision",
+    "suiteDigest",
+    "caseRevision",
+    "caseDigest",
+    "promptRevision",
+    "promptDigest",
+    "scorerRevision",
+    "scorerDigest",
+    "normalizerRevision",
+    "normalizerDigest",
+)
+MODEL_FAILURE_CATEGORIES = {"contract", "mandatory", "semantic", "validation"}
+OPERATIONAL_FAILURE_CATEGORIES = {"benchmark", "prompt", "parser", "scorer", "harness", "transport", "identity"}
+
+
+def binding_value(result: dict[str, Any], name: str) -> Any:
+    bindings = result.get("evidenceBindings")
+    binding = bindings.get(name) if isinstance(bindings, dict) else None
+    return binding.get("actual") if isinstance(binding, dict) else None
+
+
+def result_usage(result: dict[str, Any], receipt: dict[str, Any]) -> dict[str, float | None]:
+    usage = result.get("usage")
+    usage = usage if isinstance(usage, dict) else receipt.get("usage")
+    usage = usage if isinstance(usage, dict) else {}
+
+    def usage_number(*names: str) -> float | None:
+        for name in names:
+            parsed = number(usage.get(name))
+            if parsed is not None:
+                return parsed
+        return None
+
+    return {
+        "prompt_tokens": usage_number("prompt_tokens", "input_tokens"),
+        "completion_tokens": usage_number("completion_tokens", "output_tokens"),
+        "reasoning_tokens": usage_number("reasoning_tokens", "reasoning_output_tokens"),
+        "cache_read_tokens": usage_number(
+            "cache_read_tokens", "cached_input_tokens", "cached_tokens", "cache_read_input_tokens"
+        ),
+        "cache_creation_tokens": usage_number(
+            "cache_creation_tokens", "cache_write_tokens", "cache_creation_input_tokens"
+        ),
+        "cost_usd": usage_number("cost", "cost_usd"),
+    }
+
+
+def supplied_number(result: dict[str, Any], receipt: dict[str, Any], *names: str) -> float | None:
+    usage = result.get("usage") if isinstance(result.get("usage"), dict) else {}
+    for source in (result, usage, receipt):
+        for name in names:
+            parsed = number(source.get(name))
+            if parsed is not None:
+                return parsed
+    return None
+
+
+def attempt_order(result: dict[str, Any], receipt: dict[str, Any]) -> tuple[str, float] | None:
+    for name in ("attemptIndex", "attemptNumber", "attempt_index", "attempt_number"):
+        parsed = number(result.get(name))
+        if parsed is None:
+            parsed = number(receipt.get(name))
+        if parsed is not None:
+            return ("index", parsed)
+    observed = result.get("observedAt") or receipt.get("observedAt")
+    if isinstance(observed, str):
+        try:
+            parsed_at = datetime.fromisoformat(observed.replace("Z", "+00:00"))
+        except ValueError:
+            return None
+        if parsed_at.tzinfo is not None and parsed_at.utcoffset() is not None:
+            return ("time", parsed_at.timestamp())
+    return None
+
+
+def failure_category(result: dict[str, Any], compatible: bool, fallback_ok: bool) -> str | None:
+    failure_class = result.get("failureClass")
+    failure_class = failure_class if isinstance(failure_class, str) else ""
+    if not compatible:
+        return "harness"
+    if result.get("benchmarkFault") is True:
+        if "prompt" in failure_class:
+            return "prompt"
+        if "parser" in failure_class or "normalizer" in failure_class:
+            return "parser"
+        if "scorer" in failure_class:
+            return "scorer"
+        if "harness" in failure_class or "binding" in failure_class:
+            return "harness"
+        return "benchmark"
+    transport = result.get("transportOutcome")
+    if not isinstance(transport, dict) or transport.get("status") != "success":
+        return "transport"
+    identity = result.get("identityStatus")
+    if not isinstance(identity, dict) or identity.get("confidence") != "confirmed" or not fallback_ok:
+        return "identity"
+    if result.get("contractPassed") is not True:
+        return "contract"
+    if result.get("mandatoryPassed") is not True:
+        return "mandatory"
+    if result.get("semanticPassed") is not True:
+        return "semantic"
+    if result.get("validationPassed") is not True:
+        return "validation"
+    return None
+
+
+def safe_failure_reason(result: dict[str, Any], receipt: dict[str, Any], category: str | None) -> str | None:
+    reasons = result.get("failureReasons")
+    if isinstance(reasons, list):
+        for reason in reasons:
+            if isinstance(reason, str) and reason:
+                return reason.replace("\n", " ")[:240]
+    for source, name in ((result, "failureClass"), (receipt, "failureKind")):
+        reason = source.get(name)
+        if isinstance(reason, str) and reason:
+            return reason.replace("\n", " ")[:240]
+    return category
+
+
+def normalized_output_digest(directory: Path, result: dict[str, Any]) -> str | None:
+    for name in ("normalizedOutputArtifactSha256", "normalizedOutputDigest"):
+        digest = result.get(name)
+        if isinstance(digest, str) and digest:
+            return digest.removeprefix("sha256:")
+    normalized = result.get("normalizedOutput")
+    if not isinstance(normalized, dict):
+        output_path = directory / "output.json"
+        if not output_path.is_file() or output_path.is_symlink():
+            return None
+        try:
+            candidate = json.loads(output_path.read_text())
+        except (OSError, json.JSONDecodeError):
+            return None
+        normalized = candidate if isinstance(candidate, dict) else None
+    if not isinstance(normalized, dict):
+        return None
+    artifact = json.dumps(normalized, indent=2, ensure_ascii=False) + "\n"
+    return sha256_bytes(artifact.encode())
+
+
+def human_rubric_evidence(
+    directory: Path,
+    result: dict[str, Any],
+    case: dict[str, Any] | None,
+) -> tuple[dict[str, Any] | None, str | None]:
+    if not isinstance(case, dict) or case.get("humanRubricRequired") is not True:
+        return None, None
+    path = directory / "human-rubric.json"
+    if not path.exists():
+        return None, None
+    try:
+        receipt = load_json(path)
+    except IntelligenceError:
+        return None, "malformed human rubric receipt"
+    allowed = {
+        "blindToCandidate", "caseId", "caseRevision", "criterionScores",
+        "observedAt", "outputArtifactSha256", "rubricRevision", "schemaVersion", "suiteId",
+    }
+    rubric = case.get("humanRubric")
+    rubric = rubric if isinstance(rubric, dict) else {}
+    criteria = rubric.get("criteria")
+    criteria = criteria if isinstance(criteria, list) else []
+    criterion_ids = sorted(
+        item["id"] for item in criteria
+        if isinstance(item, dict) and isinstance(item.get("id"), str)
+    )
+    scores = receipt.get("criterionScores") if isinstance(receipt, dict) else None
+    digest = normalized_output_digest(directory, result)
+    valid_scores = (
+        isinstance(scores, dict)
+        and sorted(scores) == criterion_ids
+        and all(
+            not isinstance(value, bool) and isinstance(value, (int, float)) and 1 <= value <= 5
+            for value in scores.values()
+        )
+    )
+    if not isinstance(receipt, dict) or set(receipt) != allowed:
+        return None, "malformed or identity-bearing human rubric fields"
+    if receipt.get("blindToCandidate") is not True:
+        return None, "human rubric is not blinded"
+    observed_at = receipt.get("observedAt")
+    try:
+        observed_valid = bool(
+            isinstance(observed_at, str)
+            and datetime.strptime(observed_at, "%Y-%m-%dT%H:%M:%SZ")
+        )
+    except ValueError:
+        observed_valid = False
+    if receipt.get("schemaVersion") != 1 or not observed_valid:
+        return None, "malformed human rubric receipt"
+    if (
+        receipt.get("suiteId") != result.get("suiteId")
+        or receipt.get("caseId") != result.get("caseId")
+        or receipt.get("caseRevision") != case.get("revision")
+        or receipt.get("rubricRevision") != rubric.get("rubricRevision")
+    ):
+        return None, "human rubric case or rubric mismatch"
+    receipt_digest = receipt.get("outputArtifactSha256")
+    if not isinstance(receipt_digest, str) or digest is None or receipt_digest.removeprefix("sha256:") != digest:
+        return None, "human rubric output digest mismatch"
+    if not valid_scores:
+        return None, "unknown criterion IDs or invalid criterion scores"
+    return {
+        "rubric_revision": receipt["rubricRevision"],
+        "criterion_scores": dict(sorted(scores.items())),
+        "mean_score": sum(float(value) for value in scores.values()) / len(scores),
+        "observed_at": receipt["observedAt"],
+    }, None
+
+
+def telemetry_coverage(attempts: list[dict[str, Any]], field: str) -> dict[str, Any]:
+    total = len(attempts)
+    recorded = sum(item.get(field) is not None for item in attempts)
+    return {
+        "recorded": recorded,
+        "attempts": total,
+        "rate": recorded / total if total else None,
+    }
+
+
+def sum_through_valid(attempts: list[dict[str, Any]], field: str) -> float | None:
+    if not attempts or any(item.get(field) is None for item in attempts):
+        return None
+    return sum(float(item[field]) for item in attempts)
+
+
+def group_rollup(key: tuple[Any, ...], attempts: list[dict[str, Any]]) -> dict[str, Any]:
+    comparable = [item for item in attempts if item["comparable"]]
+    validated = [item for item in comparable if item["validated"]]
+    model_failures = [
+        item for item in comparable if item["failure_category"] in MODEL_FAILURE_CATEGORIES
+    ]
+    comparable_orders = [item["_order"] for item in comparable]
+    ordering_available = bool(comparable) and all(order is not None for order in comparable_orders)
+    ordering_available = (
+        ordering_available
+        and len({order[0] for order in comparable_orders}) == 1
+        and len(set(comparable_orders)) == len(comparable_orders)
+    )
+    ordered_comparable = sorted(comparable, key=lambda item: item["_order"]) if ordering_available else []
+    all_orders = [item["_order"] for item in attempts]
+    operational_ordering = bool(attempts) and all(order is not None for order in all_orders)
+    operational_ordering = (
+        operational_ordering
+        and len({order[0] for order in all_orders}) == 1
+        and len(set(all_orders)) == len(all_orders)
+    )
+    ordered = sorted(attempts, key=lambda item: item["_order"]) if operational_ordering else []
+    first_pass: bool | None = None
+    first_validated: dict[str, Any] | None = None
+    through_valid: list[dict[str, Any]] = []
+    operational_before: dict[str, int] | None = None
+    if ordered_comparable:
+        first_pass = ordered_comparable[0]["validated"]
+        first_validated = next((item for item in ordered_comparable if item["validated"]), None)
+    if first_validated is not None:
+        first_order = first_validated["_order"]
+        through_valid = [
+            item for item in ordered_comparable if item["_order"] <= first_order
+        ]
+        if operational_ordering:
+            operational_before = dict(sorted(Counter(
+                item["failure_category"] for item in ordered
+                if item["_order"] < first_order and item["failure_category"] in OPERATIONAL_FAILURE_CATEGORIES
+            ).items()))
+    model_rework = (
+        sum(item["failure_category"] in MODEL_FAILURE_CATEGORIES for item in through_valid)
+        if through_valid else None
+    )
+    compat_names = (
+        "requested_candidate", "transport", "role", "case_id", "case_revision",
+        "suite_id", "suite_revision", "suite_digest", "case_digest", "prompt_revision",
+        "prompt_digest", "scorer_revision", "scorer_digest", "normalizer_revision",
+        "normalizer_digest", "behavior_revision", "behavior_digest",
+    )
+    providers = Counter(
+        item["endpoint_provider"] for item in attempts if item["endpoint_provider"] is not None
+    )
+    served = Counter(
+        item["served_identity"] for item in attempts if item["served_identity"] is not None
+    )
+    billing_modes = Counter(
+        item["billing_mode"] for item in attempts if item["billing_mode"] is not None
+    )
+    human = [item["human_evidence"] for item in attempts if item["human_evidence"] is not None]
+    human_rejections = Counter(
+        item["human_rejection"] for item in attempts if item["human_rejection"] is not None
+    )
+    failure_counts = Counter(
+        item["failure_category"] for item in attempts if item["failure_category"] is not None
+    )
+    return {
+        **dict(zip(compat_names, key)),
+        "attempts": len(attempts),
+        "comparable_attempts": len(comparable),
+        "validated_attempts": len(validated),
+        "validated_rate": len(validated) / len(comparable) if comparable else None,
+        "best_deterministic_quality": max(
+            (item["quality_score"] for item in comparable if item["quality_score"] is not None),
+            default=None,
+        ),
+        "validator_passes": sum(item["validation_passed"] is True for item in comparable),
+        "model_attributable_failures": len(model_failures),
+        "first_pass_validated": first_pass,
+        "model_rework_to_valid": model_rework,
+        "attempts_to_valid": len(through_valid) if through_valid else None,
+        "time_to_first_validated_seconds": sum_through_valid(through_valid, "duration_seconds"),
+        "tokens_to_first_validated": {
+            field: sum_through_valid(through_valid, field)
+            for field in (
+                "prompt_tokens", "completion_tokens", "reasoning_tokens",
+                "cache_read_tokens", "cache_creation_tokens",
+            )
+        },
+        "context_to_first_validated": sum_through_valid(through_valid, "context_tokens"),
+        "ordering_available": ordering_available,
+        "operational_ordering_available": operational_ordering,
+        "operational_retries": dict(sorted(Counter(
+            item["failure_category"] for item in attempts
+            if item["failure_category"] in OPERATIONAL_FAILURE_CATEGORIES
+        ).items())),
+        "operational_retries_before_valid": operational_before,
+        "failure_counts": dict(sorted(failure_counts.items())),
+        "telemetry_coverage": {
+            field: telemetry_coverage(comparable, field)
+            for field in (
+                "duration_seconds", "prompt_tokens", "completion_tokens", "reasoning_tokens",
+                "cache_read_tokens", "cache_creation_tokens", "context_tokens", "tool_calls",
+                "correction_count", "useful_findings", "false_positives",
+            )
+        },
+        "useful_finding_yield": median(item["useful_findings"] for item in comparable),
+        "false_positive_yield": median(item["false_positives"] for item in comparable),
+        "endpoint_providers": dict(sorted(providers.items())),
+        "served_identities": dict(sorted(served.items())),
+        "billing_modes": dict(sorted(billing_modes.items())),
+        "fallback_attempts": sum(item["fallback_used"] is True for item in attempts),
+        "latest_observed_at": max(
+            (item["observed_at"] for item in attempts if item["observed_at"] is not None),
+            default=None,
+        ),
+        "editorial_human_evidence": (
+            {
+                "accepted_receipts": len(human),
+                "median_mean_score": median(item["mean_score"] for item in human),
+            }
+            if human else None
+        ),
+        "editorial_human_rejections": dict(sorted(human_rejections.items())),
+        "attempt_records": [
+            {name: value for name, value in item.items() if not name.startswith("_")}
+            for item in attempts
+        ],
+    }
+
+
 def benchmark_rollup(root: Path | None) -> dict[str, Any]:
-    if root is None:
-        return {"result_root": None, "attempts": 0, "groups": [], "incomplete_attempts": []}
-    directories = result_dirs(root)
-    grouped: dict[tuple[str, str, str], list[dict[str, Any]]] = defaultdict(list)
-    incomplete: list[str] = []
+    policy = load_json(DEFAULT_ROLE_POLICY)
+    suite = load_json(DEFAULT_BENCHMARK_SUITE)
+    policy_roles = policy.get("roles") if isinstance(policy, dict) else None
+    cases = suite.get("cases") if isinstance(suite, dict) else None
+    if not isinstance(policy_roles, dict) or not isinstance(cases, list):
+        raise IntelligenceError("role policy and v2 benchmark suite authorities are malformed")
+    case_by_id = {
+        item["id"]: item for item in cases
+        if isinstance(item, dict) and isinstance(item.get("id"), str)
+    }
+    directories = result_dirs(root) if root is not None else []
+    grouped: dict[tuple[Any, ...], list[dict[str, Any]]] = defaultdict(list)
+    incomplete: list[dict[str, Any]] = []
+    historical_v1: list[dict[str, Any]] = []
+    incompatible_v2: list[dict[str, Any]] = []
     measured_cost_usd = 0.0
+    expected_behavior = suite.get("behavioralContract")
+    expected_behavior = expected_behavior if isinstance(expected_behavior, dict) else {}
+
     for directory in directories:
+        receipt_path = directory / "receipt.json"
+        try:
+            receipt = load_json(receipt_path) if receipt_path.is_file() else {}
+        except IntelligenceError:
+            receipt = {}
+        receipt = receipt if isinstance(receipt, dict) else {}
         result_path = directory / "result.json"
         if not result_path.is_file():
-            incomplete.append(str(directory))
+            usage = result_usage({}, receipt)
+            benchmark = receipt.get("benchmark")
+            benchmark = benchmark if isinstance(benchmark, dict) else {}
+            case_id = benchmark.get("caseId")
+            case = case_by_id.get(case_id) if isinstance(case_id, str) else None
+            incomplete.append(
+                {
+                    "path": str(directory),
+                    "requested_candidate": receipt.get("requestedModel"),
+                    "transport": receipt.get("transport"),
+                    "role": benchmark.get("role") or (case.get("role") if isinstance(case, dict) else None),
+                    "case_id": case_id,
+                    "duration_seconds": supplied_number({}, receipt, "durationSeconds", "duration_seconds"),
+                    **usage,
+                    "receipt_outcome": receipt.get("outcome"),
+                    "failure_category": "transport" if receipt.get("outcome") == "failed" else "harness",
+                    "failure_reason": safe_failure_reason({}, receipt, "incomplete attempt"),
+                }
+            )
+            cost = usage["cost_usd"]
+            measured_cost_usd += cost if cost is not None else 0
             continue
         try:
             result = load_json(result_path)
-        except IntelligenceError:
-            incomplete.append(str(directory))
+        except IntelligenceError as exc:
+            usage = result_usage({}, receipt)
+            benchmark = receipt.get("benchmark")
+            benchmark = benchmark if isinstance(benchmark, dict) else {}
+            incomplete.append(
+                {
+                    "path": str(directory),
+                    "requested_candidate": receipt.get("requestedModel"),
+                    "transport": receipt.get("transport"),
+                    "role": benchmark.get("role"),
+                    "case_id": benchmark.get("caseId"),
+                    "duration_seconds": supplied_number({}, receipt, "durationSeconds", "duration_seconds"),
+                    **usage,
+                    "receipt_outcome": receipt.get("outcome"),
+                    "failure_category": "parser",
+                    "failure_reason": str(exc),
+                }
+            )
             continue
         if not isinstance(result, dict):
-            incomplete.append(str(directory))
+            incomplete.append({"path": str(directory), "failure_category": "parser", "failure_reason": "result object required"})
             continue
-        usage = result.get("usage")
-        if isinstance(usage, dict):
-            cost = number(usage.get("cost") if "cost" in usage else usage.get("cost_usd"))
-            if cost is not None:
-                measured_cost_usd += cost
-        model = result.get("servedModel") or result.get("requestedModel") or "unknown"
-        case_id = result.get("caseId") or "unknown"
-        transport = result.get("transport") or result.get("provider") or "unknown"
-        grouped[(str(model), str(case_id), str(transport))].append(result)
+        if result.get("schemaVersion") != 2:
+            usage = result_usage(result, receipt)
+            historical_v1.append(
+                {
+                    "path": str(directory),
+                    "schema_version": result.get("schemaVersion", 1),
+                    "requested_candidate": result.get("requestedModel"),
+                    "served_identity": result.get("servedModel"),
+                    "transport": result.get("transport"),
+                    "case_id": result.get("caseId"),
+                    "parsed": result.get("parsed") if isinstance(result.get("parsed"), bool) else None,
+                    "quality_score": number(result.get("qualityScore")),
+                    "duration_seconds": supplied_number(result, receipt, "durationSeconds", "duration_seconds"),
+                    **usage,
+                    "receipt_outcome": receipt.get("outcome"),
+                    "failure_reason": safe_failure_reason(result, receipt, None),
+                    "classification": "historical/incompatible; no model conclusion",
+                }
+            )
+            continue
 
-    groups = []
-    for (model, case_id, transport), results in sorted(grouped.items()):
-        parsed_successes = [item for item in results if item.get("parsed") is True]
-        quality = [number(item.get("qualityScore")) for item in parsed_successes]
-        duration = [number(item.get("durationSeconds")) for item in parsed_successes]
-        costs = []
-        prompt_tokens = []
-        completion_tokens = []
-        reasoning_tokens = []
-        for item in parsed_successes:
-            usage = item.get("usage")
-            if not isinstance(usage, dict):
-                continue
-            costs.append(number(usage.get("cost") if "cost" in usage else usage.get("cost_usd")))
-            prompt_tokens.append(number(usage.get("prompt_tokens") if "prompt_tokens" in usage else usage.get("input_tokens")))
-            completion_tokens.append(number(usage.get("completion_tokens") if "completion_tokens" in usage else usage.get("output_tokens")))
-            reasoning_tokens.append(number(usage.get("reasoning_tokens")))
-        groups.append(
+        case_id = result.get("caseId")
+        case = case_by_id.get(case_id) if isinstance(case_id, str) else None
+        behavior = result.get("behavioralContract")
+        behavior = behavior if isinstance(behavior, dict) else {}
+        bindings = result.get("evidenceBindings")
+        bindings_ok = isinstance(bindings, dict) and all(
+            isinstance(bindings.get(name), dict)
+            and bindings[name].get("match") is True
+            and bindings[name].get("actual") is not None
+            for name in V2_BINDINGS
+        )
+        authority_ok = bool(
+            isinstance(case, dict)
+            and result.get("suiteId") == suite.get("suiteId")
+            and binding_value(result, "suiteRevision") == suite.get("suiteRevision")
+            and binding_value(result, "caseRevision") == case.get("revision")
+            and binding_value(result, "promptRevision") == case.get("promptRevision")
+            and behavior.get("revision") == expected_behavior.get("revision")
+            and behavior.get("digest") == expected_behavior.get("digest")
+        )
+        compatible = bindings_ok and authority_ok
+        fallback = result.get("fallback")
+        fallback_ok = bool(
+            isinstance(fallback, dict)
+            and isinstance(fallback.get("used"), bool)
+            and isinstance(fallback.get("provenance"), str)
+            and fallback.get("provenance")
+        )
+        category = failure_category(result, compatible, fallback_ok)
+        transport_outcome = result.get("transportOutcome")
+        transport_outcome = transport_outcome if isinstance(transport_outcome, dict) else {}
+        identity_status = result.get("identityStatus")
+        identity_status = identity_status if isinstance(identity_status, dict) else {}
+        comparable = bool(
+            compatible
+            and result.get("benchmarkFault") is False
+            and transport_outcome.get("status") == "success"
+            and identity_status.get("confidence") == "confirmed"
+            and fallback_ok
+            and isinstance(result.get("requestedIdentity"), str)
+            and bool(result.get("requestedIdentity"))
+            and isinstance(result.get("servedIdentity"), str)
+            and bool(result.get("servedIdentity"))
+        )
+        validated = bool(
+            comparable
+            and result.get("contractPassed") is True
+            and result.get("mandatoryPassed") is True
+            and result.get("semanticPassed") is True
+            and result.get("validationPassed") is True
+        )
+        usage = result_usage(result, receipt)
+        cost = usage["cost_usd"]
+        measured_cost_usd += cost if cost is not None else 0
+        human, human_rejection = human_rubric_evidence(directory, result, case)
+        attempt = {
+            "path": str(directory),
+            "requested_candidate": result.get("requestedIdentity"),
+            "served_identity": result.get("servedIdentity"),
+            "endpoint_provider": result.get("endpointProvider"),
+            "billing_mode": result.get("billingMode") or receipt.get("billingMode"),
+            "transport": result.get("transport"),
+            "role": result.get("role"),
+            "case_id": case_id,
+            "case_revision": binding_value(result, "caseRevision"),
+            "observed_at": result.get("observedAt") if isinstance(result.get("observedAt"), str) else None,
+            "receipt_outcome": receipt.get("outcome") or transport_outcome.get("status"),
+            "parsed": result.get("parsed") if isinstance(result.get("parsed"), bool) else None,
+            "quality_score": number(result.get("qualityScore")),
+            "validation_passed": result.get("validationPassed") if isinstance(result.get("validationPassed"), bool) else None,
+            "comparable": comparable,
+            "validated": validated,
+            "model_conclusion": result.get("modelConclusion") if comparable else None,
+            "failure_category": category,
+            "failure_class": result.get("failureClass"),
+            "failure_reason": safe_failure_reason(result, receipt, category),
+            "duration_seconds": supplied_number(result, receipt, "durationSeconds", "duration_seconds"),
+            **usage,
+            "context_tokens": supplied_number(result, receipt, "contextTokens", "context_tokens", "inputContextTokens"),
+            "tool_calls": supplied_number(result, receipt, "toolCalls", "tool_calls", "toolUseCount"),
+            "correction_count": supplied_number(result, receipt, "correctionCount", "correction_count"),
+            "useful_findings": supplied_number(result, receipt, "usefulFindings", "usefulFindingCount", "useful_finding_count", "truePositiveCount"),
+            "false_positives": supplied_number(result, receipt, "falsePositives", "falsePositiveCount", "false_positive_count"),
+            "fallback_used": fallback.get("used") if isinstance(fallback, dict) else None,
+            "human_evidence": human,
+            "human_rejection": human_rejection,
+            "_order": attempt_order(result, receipt),
+        }
+        key = (
+            attempt["requested_candidate"], attempt["transport"], attempt["role"], attempt["case_id"],
+            attempt["case_revision"], result.get("suiteId"), binding_value(result, "suiteRevision"),
+            binding_value(result, "suiteDigest"), binding_value(result, "caseDigest"),
+            binding_value(result, "promptRevision"), binding_value(result, "promptDigest"),
+            binding_value(result, "scorerRevision"), binding_value(result, "scorerDigest"),
+            binding_value(result, "normalizerRevision"), binding_value(result, "normalizerDigest"),
+            behavior.get("revision"), behavior.get("digest"),
+        )
+        if compatible:
+            grouped[key].append(attempt)
+        else:
+            incompatible_v2.append(
+                {name: value for name, value in attempt.items() if not name.startswith("_")}
+                | {"classification": "incompatible v2; no model conclusion"}
+            )
+
+    groups = [group_rollup(key, attempts) for key, attempts in sorted(grouped.items(), key=lambda item: tuple(str(part) for part in item[0]))]
+    role_rows: list[dict[str, Any]] = []
+    for role, candidates in policy_roles.items():
+        role_cases = [case for case in cases if isinstance(case, dict) and case.get("role") == role]
+        role_groups = [group for group in groups if group["role"] == role]
+        role_attempts = [
+            attempt for group in role_groups for attempt in group["attempt_records"]
+            if attempt["comparable"]
+        ]
+        incomplete_for_role = [item for item in incomplete if item.get("role") == role]
+        role_operational_retries = sum(
+            (Counter(group["operational_retries"]) for group in role_groups), Counter()
+        )
+        role_operational_retries.update(
+            item["failure_category"] for item in incomplete_for_role
+            if item.get("failure_category") in OPERATIONAL_FAILURE_CATEGORIES
+        )
+        case_coverage = []
+        for case in role_cases:
+            matching = [group for group in role_groups if group["case_id"] == case.get("id")]
+            case_coverage.append(
+                {
+                    "case_id": case.get("id"),
+                    "case_revision": case.get("revision"),
+                    "prompt_revision": case.get("promptRevision"),
+                    "required_capabilities": case.get("requiredCapabilities", []),
+                    "applicability": case.get("applicability"),
+                    "compatible_groups": len(matching),
+                    "comparable_attempts": sum(group["comparable_attempts"] for group in matching),
+                    "validated_attempts": sum(group["validated_attempts"] for group in matching),
+                    "latest_observed_at": max(
+                        (group["latest_observed_at"] for group in matching if group["latest_observed_at"] is not None),
+                        default=None,
+                    ),
+                }
+            )
+        missing_cases = [item["case_id"] for item in case_coverage if item["comparable_attempts"] == 0]
+        first_pass = [group["first_pass_validated"] for group in role_groups if group["first_pass_validated"] is not None]
+        valid_groups = [group for group in role_groups if group["attempts_to_valid"] is not None]
+        latest = max(
+            (group["latest_observed_at"] for group in role_groups if group["latest_observed_at"] is not None),
+            default=None,
+        )
+        role_rows.append(
             {
-                "model": model,
-                "case_id": case_id,
-                "transport": transport,
-                "attempts": len(results),
-                "parsed_successes": len(parsed_successes),
-                "success_rate": len(parsed_successes) / len(results) if results else 0,
-                "median_quality_score": median(quality),
-                "median_duration_seconds": median(duration),
-                "median_cost_usd": median(costs),
-                "median_prompt_tokens": median(prompt_tokens),
-                "median_completion_tokens": median(completion_tokens),
-                "median_reasoning_tokens": median(reasoning_tokens),
+                "role": role,
+                "policy_candidates": len(candidates) if isinstance(candidates, list) else 0,
+                "required_cases": len(role_cases),
+                "case_coverage": case_coverage,
+                "missing_cases": missing_cases,
+                "gap": "no comparable current evidence" if not role_attempts else ("incomplete case coverage" if missing_cases else None),
+                "confidence": "none" if not role_attempts else ("partial" if missing_cases else "controlled-current"),
+                "freshness": {"latest_observed_at": latest, "suite_revision": suite.get("suiteRevision"), "policy_snapshot": policy.get("matrixSnapshot")},
+                "best_deterministic_quality": max(
+                    (group["best_deterministic_quality"] for group in role_groups if group["best_deterministic_quality"] is not None),
+                    default=None,
+                ),
+                "validated_attempts": sum(group["validated_attempts"] for group in role_groups),
+                "comparable_attempts": sum(group["comparable_attempts"] for group in role_groups),
+                "first_pass_validated_rate": sum(first_pass) / len(first_pass) if first_pass else None,
+                "median_time_to_first_validated_seconds": median(group["time_to_first_validated_seconds"] for group in valid_groups),
+                "median_attempts_to_valid": median(group["attempts_to_valid"] for group in valid_groups),
+                "median_model_rework_to_valid": median(group["model_rework_to_valid"] for group in valid_groups),
+                "median_tokens_to_first_validated": {
+                    field: median(group["tokens_to_first_validated"][field] for group in valid_groups)
+                    for field in (
+                        "prompt_tokens", "completion_tokens", "reasoning_tokens",
+                        "cache_read_tokens", "cache_creation_tokens",
+                    )
+                },
+                "median_context_to_first_validated": median(group["context_to_first_validated"] for group in valid_groups),
+                "useful_finding_yield": median(group["useful_finding_yield"] for group in role_groups),
+                "false_positive_yield": median(group["false_positive_yield"] for group in role_groups),
+                "operational_retries": dict(sorted(role_operational_retries.items())),
+                "model_failure_counts": dict(sorted(sum((Counter({key: value for key, value in group["failure_counts"].items() if key in MODEL_FAILURE_CATEGORIES}) for group in role_groups), Counter()).items())),
+                "instrumentation": {
+                    field: telemetry_coverage(role_attempts, field)
+                    for field in (
+                        "duration_seconds", "prompt_tokens", "completion_tokens", "reasoning_tokens",
+                        "cache_read_tokens", "cache_creation_tokens", "context_tokens", "tool_calls",
+                        "correction_count", "useful_findings", "false_positives",
+                    )
+                } | {
+                    "attempt_order": {
+                        "recorded": sum(group["ordering_available"] for group in role_groups),
+                        "groups": len(role_groups),
+                        "rate": (sum(group["ordering_available"] for group in role_groups) / len(role_groups)) if role_groups else None,
+                    }
+                },
+                "editorial_human_evidence": (
+                    {
+                        "accepted_receipts": sum((group["editorial_human_evidence"] or {}).get("accepted_receipts", 0) for group in role_groups),
+                        "median_mean_score": median(
+                            (group["editorial_human_evidence"] or {}).get("median_mean_score") for group in role_groups
+                        ),
+                    }
+                    if any(group["editorial_human_evidence"] is not None for group in role_groups) else None
+                ),
+                "incomplete_attempts": len(incomplete_for_role),
+                "retained_attempts": sum(group["attempts"] for group in role_groups) + len(incomplete_for_role),
             }
         )
+
+    model_rows: list[dict[str, Any]] = []
+    for role, candidates in policy_roles.items():
+        role_case_ids = [case["id"] for case in cases if isinstance(case, dict) and case.get("role") == role]
+        for candidate in candidates if isinstance(candidates, list) else []:
+            if not isinstance(candidate, dict) or not isinstance(candidate.get("model"), str):
+                continue
+            candidate_groups = [
+                group for group in groups
+                if group["role"] == role
+                and group["requested_candidate"] == candidate["model"]
+                and group["transport"] == candidate.get("transport")
+            ]
+            observed_cases = {group["case_id"] for group in candidate_groups if group["comparable_attempts"]}
+            validated_cases = {group["case_id"] for group in candidate_groups if group["validated_attempts"]}
+            strengths = [
+                {"case_id": group["case_id"], "validated_attempts": group["validated_attempts"], "best_deterministic_quality": group["best_deterministic_quality"]}
+                for group in candidate_groups if group["validated_attempts"]
+            ]
+            failures = [
+                {"case_id": group["case_id"], "failure_counts": {key: value for key, value in group["failure_counts"].items() if key in MODEL_FAILURE_CATEGORIES}}
+                for group in candidate_groups
+                if any(key in MODEL_FAILURE_CATEGORIES for key in group["failure_counts"])
+            ]
+            benchmark_faults = sum(
+                sum(value for key, value in group["failure_counts"].items() if key in {"benchmark", "prompt", "parser", "scorer", "harness"})
+                for group in candidate_groups
+            )
+            evaluator_families = {
+                (
+                    group["suite_revision"], group["suite_digest"],
+                    group["scorer_revision"],
+                    group["normalizer_revision"], group["normalizer_digest"],
+                    group["behavior_revision"], group["behavior_digest"],
+                )
+                for group in candidate_groups
+            }
+            competitive = any(
+                all(
+                    any(
+                        group["case_id"] == case_id
+                        and group["validated_attempts"] >= 3
+                        and (
+                            group["suite_revision"], group["suite_digest"],
+                            group["scorer_revision"],
+                            group["normalizer_revision"], group["normalizer_digest"],
+                            group["behavior_revision"], group["behavior_digest"],
+                        ) == evaluator_family
+                        for group in candidate_groups
+                    )
+                    for case_id in role_case_ids
+                )
+                for evaluator_family in evaluator_families
+            )
+            model_rows.append(
+                {
+                    "model": candidate["model"],
+                    "role": role,
+                    "transport": candidate.get("transport"),
+                    "family": candidate.get("family"),
+                    "billing": candidate.get("billing"),
+                    "capabilities": candidate.get("capabilities", []),
+                    "strengths": strengths,
+                    "failures": failures,
+                    "prohibited_evidence": [],
+                    "gaps": sorted(set(role_case_ids) - observed_cases),
+                    "validated_case_coverage": len(validated_cases),
+                    "controlled_competitive_evidence": bool(role_case_ids and competitive and not failures),
+                    "benchmark_faults": benchmark_faults,
+                    "benchmark_fault_conclusion": "no model conclusion" if benchmark_faults else None,
+                    "routing_conclusion": "no routing change justified",
+                }
+            )
+
     return {
-        "result_root": str(root),
-        "attempts": sum(group["attempts"] for group in groups) + len(incomplete),
+        "result_root": str(root) if root is not None else None,
+        "attempts": len(directories),
+        "current_v2_attempts": sum(group["attempts"] for group in groups),
         "groups": groups,
+        "roles": role_rows,
+        "model_role_evidence": model_rows,
         "incomplete_attempts": incomplete,
+        "historical_v1": historical_v1,
+        "incompatible_v2": incompatible_v2,
         "measured_cost_usd": measured_cost_usd,
+        "matrix_opportunities": [],
+        "routing_conclusion": "no routing change justified",
+        "views": {
+            "quality": {
+                "validated_attempts": sum(role["validated_attempts"] for role in role_rows),
+                "comparable_attempts": sum(role["comparable_attempts"] for role in role_rows),
+                "roles_with_validated_evidence": [role["role"] for role in role_rows if role["validated_attempts"]],
+            },
+            "reliability": {
+                "model_failure_counts": dict(sorted(sum((Counter(role["model_failure_counts"]) for role in role_rows), Counter()).items())),
+                "operational_retry_counts": dict(sorted(sum((Counter(role["operational_retries"]) for role in role_rows), Counter()).items())),
+                "historical_v1_attempts": len(historical_v1),
+                "incompatible_v2_attempts": len(incompatible_v2),
+            },
+            "latency": {
+                role["role"]: role["instrumentation"]["duration_seconds"] for role in role_rows
+            },
+            "tokens_context": {
+                role["role"]: {
+                    field: role["instrumentation"][field]
+                    for field in (
+                        "prompt_tokens", "completion_tokens", "reasoning_tokens",
+                        "cache_read_tokens", "cache_creation_tokens", "context_tokens",
+                    )
+                }
+                for role in role_rows
+            },
+            "provider_spend": {"measured_cost_usd": measured_cost_usd},
+            "subscription_marginal_cost": {"value": None, "reason": "reported only when supplied by production evidence"},
+            "api_equivalent_cost": {"value": None, "reason": "not inferred or combined with billed spend"},
+            "capabilities": {
+                role: sorted({capability for candidate in candidates if isinstance(candidate, dict) for capability in candidate.get("capabilities", [])})
+                for role, candidates in policy_roles.items() if isinstance(candidates, list)
+            },
+            "family_diversity": {
+                role: sorted({candidate["family"] for candidate in candidates if isinstance(candidate, dict) and isinstance(candidate.get("family"), str)})
+                for role, candidates in policy_roles.items() if isinstance(candidates, list)
+            },
+            "editorial_human": next(
+                (role["editorial_human_evidence"] for role in role_rows if role["role"] == "editorial"), None
+            ),
+        },
     }
 
 
@@ -603,45 +1329,109 @@ def render_report(report: dict[str, Any]) -> str:
     lines = [
         f"# Depot model intelligence — {report['generated_at'][:10]}",
         "",
-        "## Evidence coverage",
+        "## Per-role validated quality and efficiency",
         "",
-        f"- Run cost summaries: {production['cost_summary_artifacts']}",
-        f"- Workflow metrics: {production['metrics_artifacts']}",
-        f"- Empty cost summaries: {production['empty_cost_summaries']}",
-        f"- Benchmark attempts: {benchmark['attempts']}",
-        f"- Incomplete benchmark attempts: {len(benchmark['incomplete_attempts'])}",
+        "| Role | Cases | Validated | Best quality | First pass | Time to valid | Attempts/rework | Confidence | Freshness | Gap |",
+        "|---|---:|---:|---:|---:|---:|---:|---|---|---|",
     ]
-    if production["malformed_artifacts"]:
-        lines.append(f"- Malformed artifacts: {len(production['malformed_artifacts'])}")
-    lines.extend(["", "## Production economics by model", ""])
-    if production["by_model"]:
+    for role in benchmark["roles"]:
+        first_pass = "n/a" if role["first_pass_validated_rate"] is None else f"{role['first_pass_validated_rate']:.0%}"
+        time_valid = "n/a" if role["median_time_to_first_validated_seconds"] is None else f"{role['median_time_to_first_validated_seconds']:.1f}s"
+        attempts = "n/a" if role["median_attempts_to_valid"] is None else f"{role['median_attempts_to_valid']:g}/{role['median_model_rework_to_valid']:g}"
+        score = "n/a" if role["best_deterministic_quality"] is None else f"{role['best_deterministic_quality']:g}"
+        freshness = role["freshness"]["latest_observed_at"] or "none"
+        lines.append(
+            f"| {role['role']} | {role['required_cases'] - len(role['missing_cases'])}/{role['required_cases']} | "
+            f"{role['validated_attempts']}/{role['comparable_attempts']} | {score} | {first_pass} | {time_valid} | "
+            f"{attempts} | {role['confidence']} | {freshness} | {role['gap'] or 'none'} |"
+        )
+    lines.extend(
+        [
+            "",
+            "Missing ordering, duration, token, cache, context, tool, correction, and finding telemetry stays null. Independent repeated attempts do not imply an in-session tool call or correction loop.",
+            "",
+            "## Role case coverage and instrumentation",
+            "",
+        ]
+    )
+    for role in benchmark["roles"]:
+        instrumentation = {
+            key: value["rate"]
+            for key, value in role["instrumentation"].items()
+            if isinstance(value, dict) and "rate" in value
+        }
         lines.extend(
             [
-                "| Model | Attempts | Duration | Input tokens | Output tokens | Input bytes | Cost | Finding contributions |",
-                "|---|---:|---:|---:|---:|---:|---:|---:|",
+                f"### {role['role']}",
+                "",
+                f"- Missing cases: {', '.join(role['missing_cases']) or 'none'}",
+                f"- Operational retries: `{json.dumps(role['operational_retries'], sort_keys=True)}`",
+                f"- Model-attributable failures: `{json.dumps(role['model_failure_counts'], sort_keys=True)}`",
+                f"- Instrumentation coverage: `{json.dumps(instrumentation, sort_keys=True)}`",
+                f"- Policy snapshot: {role['freshness']['policy_snapshot']}; suite revision: {role['freshness']['suite_revision']}",
+                "",
             ]
         )
-        for row in production["by_model"]:
-            lines.append(
-                "| {model} | {attempts} | {duration_seconds:.1f}s | {input_tokens:.0f} | {output_tokens:.0f} | {input_bytes:.0f} | ${measured_cost_usd:.4f} | {finding_contributions} |".format(**row)
-            )
-    else:
-        lines.append("No model-attributed lane usage is available.")
 
-    lines.extend(["", "## Production economics by lane and model", ""])
-    if production["by_lane_model"]:
+    lines.extend(["## Controlled model-role evidence", ""])
+    evidenced_models = [
+        row for row in benchmark["model_role_evidence"]
+        if row["strengths"] or row["failures"] or row["benchmark_faults"]
+    ]
+    if evidenced_models:
         lines.extend(
             [
-                "| Lane | Model | Attempts | Duration | Input tokens | Output tokens | Input bytes | Cost |",
-                "|---|---|---:|---:|---:|---:|---:|---:|",
+                "| Role | Requested candidate | Transport | Validated strengths | Attributable failures | Gaps | Benchmark faults | Conclusion |",
+                "|---|---|---|---:|---:|---:|---:|---|",
             ]
         )
-        for row in production["by_lane_model"]:
+        for row in evidenced_models:
             lines.append(
-                "| {lane} | {model} | {attempts} | {duration_seconds:.1f}s | {input_tokens:.0f} | {output_tokens:.0f} | {input_bytes:.0f} | ${measured_cost_usd:.4f} |".format(**row)
+                f"| {row['role']} | {row['model']} | {row['transport']} | {len(row['strengths'])} | "
+                f"{len(row['failures'])} | {len(row['gaps'])} | {row['benchmark_faults']} | {row['routing_conclusion']} |"
             )
     else:
-        lines.append("No lane/model-attributed usage is available.")
+        lines.append("No attributable current v2 model-role evidence is available.")
+
+    lines.extend(["", "## Controlled reliability and failure attribution", ""])
+    if benchmark["groups"]:
+        lines.extend(
+            [
+                "| Candidate | Transport | Role | Case/revision | Validated | First pass | Rework | Operational retries | Endpoint providers |",
+                "|---|---|---|---|---:|---:|---:|---|---|",
+            ]
+        )
+        for group in benchmark["groups"]:
+            first_pass = "n/a" if group["first_pass_validated"] is None else str(group["first_pass_validated"]).lower()
+            rework = "n/a" if group["model_rework_to_valid"] is None else str(group["model_rework_to_valid"])
+            lines.append(
+                f"| {group['requested_candidate']} | {group['transport']} | {group['role']} | "
+                f"{group['case_id']}/{group['case_revision']} | {group['validated_attempts']}/{group['comparable_attempts']} | "
+                f"{first_pass} | {rework} | `{json.dumps(group['operational_retries'], sort_keys=True)}` | "
+                f"`{json.dumps(group['endpoint_providers'], sort_keys=True)}` |"
+            )
+    else:
+        lines.append("No compatible v2 controlled groups were found.")
+    lines.extend(
+        [
+            "",
+            f"- Incomplete attempts retained: {len(benchmark['incomplete_attempts'])}",
+            f"- Incompatible v2 attempts retained: {len(benchmark['incompatible_v2'])}",
+            f"- Historical v1 attempts retained: {len(benchmark['historical_v1'])}",
+            "- Benchmark, prompt, parser, scorer, and harness faults have `no model conclusion` and do not enter model reliability or demotion evidence.",
+            "",
+            "## Editorial blinded human evidence",
+            "",
+        ]
+    )
+    editorial = next((role for role in benchmark["roles"] if role["role"] == "editorial"), None)
+    if editorial is not None and editorial["editorial_human_evidence"] is not None:
+        human = editorial["editorial_human_evidence"]
+        lines.append(
+            f"Accepted blinded digest-matched receipts: {human['accepted_receipts']}; median rubric mean: {human['median_mean_score']}."
+        )
+    else:
+        lines.append("No accepted blinded digest-matched editorial human evidence is available; human quality remains null.")
 
     quality = production["quality"]
     lines.extend(
@@ -657,33 +1447,54 @@ def render_report(report: dict[str, Any]) -> str:
             "",
             "These are workflow signals, not direct causal model-quality scores. Missing model attribution remains missing.",
             "",
-            "## Controlled benchmarks",
+            "## Capabilities and family diversity",
+            "",
+            "Capabilities and model families are policy dimensions. They are not folded into quality, reliability, latency, tokens, or cost.",
+            "",
+            "## Latency, tokens, context, and tools",
+            "",
+            "Recorded duration, prompt/completion/reasoning/cache tokens, context, and tool telemetry remain independent axes. Coverage is reported above; missing values are not zero.",
+            "",
+            "## Provider spend and access economics",
             "",
         ]
     )
-    if benchmark["groups"]:
+    if production["by_model"]:
         lines.extend(
             [
-                "| Model | Transport | Case | Success | Median quality | Median duration | Median cost |",
-                "|---|---|---|---:|---:|---:|---:|",
+                "| Model | Attempts | Duration | Input tokens | Output tokens | Input bytes | Provider-billed cost | Finding contributions |",
+                "|---|---:|---:|---:|---:|---:|---:|---:|",
             ]
         )
-        for group in benchmark["groups"]:
-            cost = "n/a" if group["median_cost_usd"] is None else f"${group['median_cost_usd']:.4f}"
+        for row in production["by_model"]:
             lines.append(
-                f"| {group['model']} | {group['transport']} | {group['case_id']} | {group['parsed_successes']}/{group['attempts']} | {group['median_quality_score']} | {group['median_duration_seconds']}s | {cost} |"
+                "| {model} | {attempts} | {duration_seconds:.1f}s | {input_tokens:.0f} | {output_tokens:.0f} | {input_bytes:.0f} | ${measured_cost_usd:.4f} | {finding_contributions} |".format(**row)
             )
     else:
-        lines.append("No benchmark results were found.")
+        lines.append("No model-attributed lane usage is available.")
+    lines.extend(["", "### Production economics by lane and model", ""])
+    if production["by_lane_model"]:
+        lines.extend(
+            [
+                "| Lane | Model | Attempts | Duration | Input tokens | Output tokens | Input bytes | Provider-billed cost |",
+                "|---|---|---:|---:|---:|---:|---:|---:|",
+            ]
+        )
+        for row in production["by_lane_model"]:
+            lines.append(
+                "| {lane} | {model} | {attempts} | {duration_seconds:.1f}s | {input_tokens:.0f} | {output_tokens:.0f} | {input_bytes:.0f} | ${measured_cost_usd:.4f} |".format(**row)
+            )
+    else:
+        lines.append("No lane/model-attributed usage is available.")
     lines.extend(
         [
             "",
             "## Interpretation limits",
             "",
             "- Token counts and deterministic input bytes are different units and are never added together.",
-            "- Subscription API-equivalent cost is opportunity-cost evidence, not billed spend.",
+            "- Subscription marginal cost, API-equivalent opportunity cost, and provider-billed spend remain separate views.",
             "- A model-role change requires three successful attempts on every applicable local case plus production evidence; incomplete coverage cannot promote a model.",
-            "- Exact identity remains in private receipts; this report publishes aggregates only.",
+            f"- Routing conclusion: {benchmark['routing_conclusion']}.",
             "",
         ]
     )
@@ -693,19 +1504,28 @@ def render_report(report: dict[str, Any]) -> str:
 def report_command(args: argparse.Namespace) -> int:
     roots = [Path(item).resolve() for item in args.run_root] if args.run_root else list(DEFAULT_RUN_ROOTS)
     benchmark_root = Path(args.benchmark_root).resolve() if args.benchmark_root else None
+    generated_at = parse_observed_at(args.observed_at).isoformat(timespec="seconds")
+    production = production_rollup(roots)
+    benchmarks = benchmark_rollup(benchmark_root)
     report = {
-        "schema_version": 1,
-        "generated_at": parse_observed_at(args.observed_at).isoformat(timespec="seconds"),
+        "schema_version": 2,
+        "generated_at": generated_at,
+        "quality_efficiency": {
+            "roles": benchmarks["roles"],
+            "model_role_evidence": benchmarks["model_role_evidence"],
+            "routing_conclusion": benchmarks["routing_conclusion"],
+        },
+        "benchmarks": benchmarks,
+        "production": production,
         "repository": str(REPO_ROOT),
         "run_roots": [str(root) for root in roots],
-        "production": production_rollup(roots),
-        "benchmarks": benchmark_rollup(benchmark_root),
     }
+    report_json = json.dumps(report, indent=2, ensure_ascii=False) + "\n"
     if args.json_output:
-        write_atomic(Path(args.json_output).resolve(), pretty_json(report))
+        write_atomic(Path(args.json_output).resolve(), report_json)
     if args.markdown_output:
         write_atomic(Path(args.markdown_output).resolve(), render_report(report))
-    print(pretty_json(report), end="")
+    print(report_json, end="")
     return 0
 
 

--- a/tools/model-intelligence.py
+++ b/tools/model-intelligence.py
@@ -1004,6 +1004,9 @@ EVALUATOR_COHORT_FIELDS = (
     "suite_id", "suite_revision", "suite_digest", "scorer_revision", "scorer_digest",
     "normalizer_revision", "normalizer_digest", "behavior_revision", "behavior_digest",
 )
+CASE_BINDING_FIELDS = (
+    "case_revision", "case_digest", "prompt_revision", "prompt_digest",
+)
 
 
 def evaluator_cohort_key(group: dict[str, Any]) -> tuple[Any, ...]:
@@ -1025,8 +1028,15 @@ def evaluator_cohort_rollup(
     ]
     valid_groups = [group for group in groups if group["attempts_to_valid"] is not None]
     case_coverage = []
+    case_binding_consistent = True
     for case in role_cases:
         matching = [group for group in groups if group["case_id"] == case.get("id")]
+        binding_groups: dict[tuple[Any, ...], list[dict[str, Any]]] = defaultdict(list)
+        for group in matching:
+            if group["comparable_attempts"] > 0:
+                binding_groups[tuple(group[name] for name in CASE_BINDING_FIELDS)].append(group)
+        if len(binding_groups) > 1:
+            case_binding_consistent = False
         case_coverage.append(
             {
                 "case_id": case.get("id"),
@@ -1047,33 +1057,63 @@ def evaluator_cohort_rollup(
                 ],
                 "comparable_attempts": sum(group["comparable_attempts"] for group in matching),
                 "validated_attempts": sum(group["validated_attempts"] for group in matching),
+                "case_binding_cohorts": [
+                    {
+                        **dict(zip(CASE_BINDING_FIELDS, binding)),
+                        "comparable_attempts": sum(
+                            group["comparable_attempts"] for group in binding_matching
+                        ),
+                        "validated_attempts": sum(
+                            group["validated_attempts"] for group in binding_matching
+                        ),
+                    }
+                    for binding, binding_matching in sorted(
+                        binding_groups.items(),
+                        key=lambda item: tuple(str(part) for part in item[0]),
+                    )
+                ],
             }
         )
     return {
         **dict(zip(EVALUATOR_COHORT_FIELDS, key)),
-        "complete_case_coverage": bool(case_coverage) and all(
+        "case_binding_consistent": case_binding_consistent,
+        "complete_case_coverage": case_binding_consistent and bool(case_coverage) and all(
             item["comparable_attempts"] > 0 for item in case_coverage
         ),
         "case_coverage": case_coverage,
-        "comparable_attempts": len(comparable_attempts),
-        "validated_attempts": sum(group["validated_attempts"] for group in groups),
+        "retained_comparable_attempts": len(comparable_attempts),
+        "comparable_attempts": len(comparable_attempts) if case_binding_consistent else None,
+        "validated_attempts": (
+            sum(group["validated_attempts"] for group in groups)
+            if case_binding_consistent else None
+        ),
         "best_deterministic_quality": max(
             (group["best_deterministic_quality"] for group in groups if group["best_deterministic_quality"] is not None),
             default=None,
+        ) if case_binding_consistent else None,
+        "first_pass_validated_rate": (
+            sum(first_pass) / len(first_pass)
+            if case_binding_consistent and first_pass else None
         ),
-        "first_pass_validated_rate": sum(first_pass) / len(first_pass) if first_pass else None,
-        "median_duration_seconds": median(
-            attempt["duration_seconds"] for attempt in comparable_attempts
+        "median_duration_seconds": (
+            median(attempt["duration_seconds"] for attempt in comparable_attempts)
+            if case_binding_consistent else None
         ),
         "median_time_to_first_validated_seconds": median(
             group["time_to_first_validated_seconds"] for group in valid_groups
+        ) if case_binding_consistent else None,
+        "median_attempts_to_valid": (
+            median(group["attempts_to_valid"] for group in valid_groups)
+            if case_binding_consistent else None
         ),
-        "median_attempts_to_valid": median(group["attempts_to_valid"] for group in valid_groups),
         "median_model_rework_to_valid": median(
             group["model_rework_to_valid"] for group in valid_groups
-        ),
+        ) if case_binding_consistent else None,
         "median_tokens_to_first_validated": {
-            field: median(group["tokens_to_first_validated"][field] for group in valid_groups)
+            field: (
+                median(group["tokens_to_first_validated"][field] for group in valid_groups)
+                if case_binding_consistent else None
+            )
             for field in (
                 "prompt_tokens", "completion_tokens", "reasoning_tokens",
                 "cache_read_tokens", "cache_creation_tokens",
@@ -1081,9 +1121,15 @@ def evaluator_cohort_rollup(
         },
         "median_context_to_first_validated": median(
             group["context_to_first_validated"] for group in valid_groups
+        ) if case_binding_consistent else None,
+        "useful_finding_yield": (
+            median(group["useful_finding_yield"] for group in groups)
+            if case_binding_consistent else None
         ),
-        "useful_finding_yield": median(group["useful_finding_yield"] for group in groups),
-        "false_positive_yield": median(group["false_positive_yield"] for group in groups),
+        "false_positive_yield": (
+            median(group["false_positive_yield"] for group in groups)
+            if case_binding_consistent else None
+        ),
         "model_failure_counts": dict(sorted(sum(
             (
                 Counter({
@@ -1098,7 +1144,11 @@ def evaluator_cohort_rollup(
             (Counter(group["operational_retries"]) for group in groups), Counter()
         ).items())),
         "instrumentation": {
-            field: telemetry_coverage(comparable_attempts, field)
+            field: (
+                telemetry_coverage(comparable_attempts, field)
+                if case_binding_consistent
+                else {"recorded": None, "attempts": None, "rate": None}
+            )
             for field in (
                 "duration_seconds", "prompt_tokens", "completion_tokens", "reasoning_tokens",
                 "cache_read_tokens", "cache_creation_tokens", "context_tokens", "tool_calls",
@@ -1341,8 +1391,16 @@ def benchmark_rollup(root: Path | None) -> dict[str, Any]:
             )
         ]
         metric_cohorts = [
-            cohort for cohort in evaluator_cohorts if cohort["comparable_attempts"] > 0
+            cohort for cohort in evaluator_cohorts
+            if cohort["case_binding_consistent"]
+            and cohort["comparable_attempts"] is not None
+            and cohort["comparable_attempts"] > 0
         ]
+        binding_conflict = any(
+            not cohort["case_binding_consistent"]
+            and cohort["retained_comparable_attempts"] > 0
+            for cohort in evaluator_cohorts
+        )
         selected_cohort = metric_cohorts[0] if len(metric_cohorts) == 1 else None
         selected_key = (
             tuple(selected_cohort[name] for name in EVALUATOR_COHORT_FIELDS)
@@ -1430,9 +1488,10 @@ def benchmark_rollup(root: Path | None) -> dict[str, Any]:
                 "complete_evaluator_cohorts": sum(
                     cohort["complete_case_coverage"] for cohort in evaluator_cohorts
                 ),
+                "case_binding_conflict": binding_conflict,
                 "missing_cases": missing_cases,
-                "gap": "no comparable current evidence" if not has_comparable else ("multiple evaluator cohorts" if len(metric_cohorts) > 1 else ("incomplete case coverage" if missing_cases else None)),
-                "confidence": "none" if not has_comparable else ("cohort-separated" if len(metric_cohorts) > 1 else ("partial" if missing_cases else "controlled-current")),
+                "gap": "conflicting case/prompt bindings" if binding_conflict else ("no comparable current evidence" if not has_comparable else ("multiple evaluator cohorts" if len(metric_cohorts) > 1 else ("incomplete case coverage" if missing_cases else None))),
+                "confidence": "cohort-separated" if binding_conflict else ("none" if not has_comparable else ("cohort-separated" if len(metric_cohorts) > 1 else ("partial" if missing_cases else "controlled-current"))),
                 "freshness": {"latest_observed_at": latest, "suite_revision": suite.get("suiteRevision"), "policy_snapshot": policy.get("matrixSnapshot")},
                 "best_deterministic_quality": selected_cohort["best_deterministic_quality"] if selected_cohort is not None else None,
                 "validated_attempts": selected_cohort["validated_attempts"] if selected_cohort is not None else None,
@@ -1519,11 +1578,18 @@ def benchmark_rollup(root: Path | None) -> dict[str, Any]:
                 complete_case_groups: list[dict[str, Any]] = []
                 complete = bool(role_case_ids)
                 for case_id in role_case_ids:
-                    eligible = [
+                    case_groups = [
                         group for group in cohort_groups_for_candidate
-                        if group["case_id"] == case_id and group["validated_attempts"] >= 3
+                        if group["case_id"] == case_id and group["comparable_attempts"] > 0
                     ]
-                    if not eligible:
+                    case_bindings = {
+                        tuple(group[name] for name in CASE_BINDING_FIELDS)
+                        for group in case_groups
+                    }
+                    eligible = [
+                        group for group in case_groups if group["validated_attempts"] >= 3
+                    ]
+                    if len(case_bindings) != 1 or len(eligible) != 1:
                         complete = False
                     complete_case_groups.extend(eligible)
                 cohort_has_model_failures = any(
@@ -1589,11 +1655,11 @@ def benchmark_rollup(root: Path | None) -> dict[str, Any]:
         "views": {
             "quality": {
                 "validated_attempts": (
-                    None if any(role["comparable_attempts"] is None and len([cohort for cohort in role["evaluator_cohorts"] if cohort["comparable_attempts"]]) > 1 for role in role_rows)
+                    None if any(role["case_binding_conflict"] or (role["comparable_attempts"] is None and len([cohort for cohort in role["evaluator_cohorts"] if cohort["comparable_attempts"]]) > 1) for role in role_rows)
                     else sum((role["validated_attempts"] or 0) for role in role_rows)
                 ),
                 "comparable_attempts": (
-                    None if any(role["comparable_attempts"] is None and len([cohort for cohort in role["evaluator_cohorts"] if cohort["comparable_attempts"]]) > 1 for role in role_rows)
+                    None if any(role["case_binding_conflict"] or (role["comparable_attempts"] is None and len([cohort for cohort in role["evaluator_cohorts"] if cohort["comparable_attempts"]]) > 1) for role in role_rows)
                     else sum((role["comparable_attempts"] or 0) for role in role_rows)
                 ),
                 "roles_with_validated_evidence": [
@@ -1724,9 +1790,13 @@ def render_report(report: dict[str, Any]) -> str:
                 cohort_duration = "n/a" if cohort["median_duration_seconds"] is None else f"{cohort['median_duration_seconds']:.1f}s"
                 cohort_time = "n/a" if cohort["median_time_to_first_validated_seconds"] is None else f"{cohort['median_time_to_first_validated_seconds']:.1f}s"
                 cohort_quality = "n/a" if cohort["best_deterministic_quality"] is None else f"{cohort['best_deterministic_quality']:g}"
+                cohort_validated = (
+                    "n/a" if cohort["validated_attempts"] is None
+                    else f"{cohort['validated_attempts']}/{cohort['comparable_attempts']}"
+                )
                 lines.append(
                     f"| {cohort['scorer_revision']}/{cohort['scorer_digest']} | "
-                    f"{str(cohort['complete_case_coverage']).lower()} | {cohort['validated_attempts']}/{cohort['comparable_attempts']} | "
+                    f"{str(cohort['complete_case_coverage']).lower()} | {cohort_validated} | "
                     f"{cohort_quality} | {cohort_first_pass} | {cohort_duration} | {cohort_time} |"
                 )
             lines.append("")


### PR DESCRIPTION
Summary: aggregate v2 evidence by requested candidate, actual transport, role, case, and evaluator compatibility; lead reports with role-complete validated quality and efficiency; retain attributable operational, incomplete, historical, and blinded editorial evidence separately. Routing remains unchanged. Tests: rtk python3 tests/test_model_intelligence.py -v (19 passed). ambiguity_resolved: true — operational and benchmark-fault attempts remain diagnostic-only within compatibility groups, while v1 and incompatible v2 evidence remain distinct.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Design-Machines-Studio/codesmith/depot/pr/109"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790570951&installation_model_id=428410&pr_number=109&repository=Design-Machines-Studio%2Fdepot&return_to=https%3A%2F%2Fgithub.com%2FDesign-Machines-Studio%2Fdepot%2Fpull%2F109&signature=225ba2aff43eeb58c236b11b2a63ae9d9748923e7470fa8ae448a0ef247f77fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->