### PR TITLE
fix(pipeline): allow repository-native verification without a profile

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -361,7 +361,7 @@
     {
       "name": "pipeline",
       "source": "./plugins/pipeline",
-      "version": "1.61.0",
+      "version": "1.61.2",
       "author": {
         "name": "Design Machines",
         "url": "https://designmachines.studio"

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -409,7 +409,7 @@
     {
       "name": "workflow-kernel",
       "source": "./plugins/workflow-kernel",
-      "version": "0.18.0",
+      "version": "0.18.2",
       "author": {
         "name": "Design Machines",
         "url": "https://designmachines.studio"
@@ -456,7 +456,7 @@
     {
       "name": "openrouter",
       "source": "./plugins/openrouter",
-      "version": "1.19.10",
+      "version": "1.20.0",
       "author": {
         "name": "Design Machines",
         "url": "https://designmachines.studio"

--- a/plugins/pipeline/.claude-plugin/plugin.json
+++ b/plugins/pipeline/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "pipeline",
   "description": "Autonomous feature development pipeline with approved-scope intake, minimum-adequate planning, bounded adversarial review, fresh tiered verification, browser recovery, and isolated execution",
-  "version": "1.61.1",
+  "version": "1.61.2",
   "author": {
     "name": "Design Machines",
     "url": "https://designmachines.io"

--- a/plugins/pipeline/.codex-plugin/plugin.json
+++ b/plugins/pipeline/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pipeline",
-  "version": "1.61.1",
+  "version": "1.61.2",
   "description": "Autonomous feature development pipeline with approved-scope intake, minimum-adequate planning, bounded adversarial review, fresh tiered verification, browser recovery, and isolated execution",
   "author": {
     "name": "Design Machines",

--- a/plugins/pipeline/agents/workflow/execution-orchestrator.md
+++ b/plugins/pipeline/agents/workflow/execution-orchestrator.md
@@ -377,17 +377,49 @@ In `sequential-on-branch` mode:
 
 ### 1d: Repository Verification Planner
 
-When the repository carries a verification profile (`.dm/verification.json` or
-an equivalent declaration), load
+First distinguish an absent profile from a declared profile. When the repository
+declares a verification profile (`.dm/verification.json` or an equivalent
+declaration), load
 `plugins/pipeline/references/execution-verification-planner.md` and run its
-planning contract. With no profile, apply the no-profile rule (mirror the Codex
-adapter, do not fork it): an Assembly target (Go+Templ+Datastar) without
-`.dm/verification.json` fails closed -- stop with `human_help_required` for
-project verification configuration rather than restoring hardcoded Go/Docker
-commands. A non-Assembly repository with no profile runs repository-native
-verification and records `verificationPlanner: unavailable`; do not load the
-planner. Never substitute hardcoded Docker, Go package, service, or build-tag
-commands for a declared profile.
+planning contract. A valid profile remains authoritative for planning, cadence,
+and evidence. A malformed or unsafe declared profile stops with
+`human_help_required` and preserves the exact validation evidence; never fall
+back to repository-native verification.
+
+With no profile, apply one host-neutral repository-native policy; repository
+type, including Assembly, does not change it. Applicable root repository
+instructions must designate exactly one canonical full repository-owned
+verification entrypoint. A root instruction may delegate to the other root
+instruction file. Separately scoped focused or pre-push commands do not conflict
+with that canonical designation; different canonical full designations in
+applicable instructions do conflict and block. Confirm that the canonical
+entrypoint's directly named checked-in target or script exists and that it does
+not depend on missing repository configuration. When all checks pass, record
+`verificationPlanner: unavailable` and preserve the exact command and root
+policy-source path in the existing verification evidence where supported; do
+not invent a new receipt field.
+
+If the canonical designation is missing, ambiguous, or conflicting, or its
+entrypoint names a nonexistent target or script or depends on missing repository
+configuration, stop narrowly with `human_help_required` and preserve the failed
+policy evidence. Never invent raw Go, Docker, package, build-tag, race, service,
+remote-CI, or other commands. Never synthesize or commit
+`.dm/verification.json`.
+
+Contract specimen: root `AGENTS.md` designates `make verify` as canonical full
+verification and names `make conformance` as narrower and `make survivor` as
+pre-push; root `CLAUDE.md` delegates to `AGENTS.md`; checked-in `Makefile` owns
+`verify:`, `conformance:`, and `survivor:`. The narrower commands do not conflict,
+so with no missing configuration repository-native verification is available.
+
+On the repository-native path, per-chunk and review checks are focused checks
+explicitly approved by the prompt. Do not run the canonical native command per
+chunk, finding, or execution level. Run it exactly once on the integrated
+candidate before final review. After a repair batch, rerun it once only when
+relevant verification inputs changed; uncertainty counts as relevant and
+permits one rerun. After an irrelevant repair, carry prior canonical-command
+evidence forward only with bounded diff proof that no relevant verification
+input changed since its tested SHA.
 
 ## Step 2: Execute by Level
 
@@ -612,7 +644,7 @@ Verify before proceeding:
 
 1. **Completion check:** the subagent reported completion (not an error or question).
 2. **Commit check:** `git log <featureBranch>..<chunk-branch> --oneline` MUST show at least one commit.
-3. **Focused verification:** on profile-aware repositories, invoke `plan-verification` for boundary `chunk` using the exact chunk diff, then `run-verification`; do not run a repository-wide or race suite here. On the compatibility path, run only the repository's narrow documented check and record that no executable planner/cache authority was available.
+3. **Focused verification:** on profile-aware repositories, invoke `plan-verification` for boundary `chunk` using the exact chunk diff, then `run-verification`; do not run a repository-wide or race suite here. On the repository-native path, run only focused checks explicitly approved by the chunk prompt. Do not run the canonical native command here. Record `verificationPlanner: unavailable` plus the exact command and policy source in existing verification evidence where supported.
 4. **Role receipt check:** the public result contains the requested role,
    anonymous participant, closed disposition, requested/effective effort, and
    fallback state. The private receipt exists and is content-free; do not copy
@@ -650,7 +682,7 @@ For `renderedSurface: required`, run Datastar/markup static checks and one brows
 
 **Per-chunk review uses role dispatch.** dm-review is reserved for Step 4. Every per-chunk review receives the approved requirements and compact alignment context, never concrete participant identity. Flag as P1/P2/P3: work outside approved scope; conflict with project constraints; unnecessary architecture; changes owned by another repository; or correct work that misses the chunk's approved outcome. Reject adjacent useful work that does not repair an observable defect in the approved scope.
 
-**UI and Logic:** Request `review-deep` at high effort. If findings: collect the complete set; apply all accepted fixes as one revision batch; do not test after each individual edit; invoke planner once with `revision_batch`; re-run the affected role once. Max 2 iterations.
+**UI and Logic:** Request `review-deep` at high effort. If findings: collect the complete set; apply all accepted fixes as one revision batch; do not test after each individual edit; on the profile path invoke the planner once with `revision_batch`; on the repository-native path run only affected focused checks from the approved prompt. Re-run the affected role once. Max 2 iterations.
 
 **Integration:** Same, then verify cross-chunk wiring (routes, imports, connections).
 
@@ -702,7 +734,7 @@ Apply `repo-cleanup-contract.md`. Never suppress git exit status. Load `plugins/
 
 ### 3k: Verify the Integrated Execution Level
 
-After every chunk in the current execution level has completed Step 3j and its merge disposition is authoritative, check out `<featureBranch>` and invoke the repository planner exactly once with boundary `execution_level`, supplying the cumulative changed paths for that level, not one invocation per chunk.
+After every chunk in the current execution level has completed Step 3j and its merge disposition is authoritative, check out `<featureBranch>`. On the profile path, invoke the repository planner exactly once with boundary `execution_level`, supplying the cumulative changed paths for that level, not one invocation per chunk. On the repository-native path, do not run the canonical native command at this boundary; retain the focused evidence already collected.
 
 The full non-race lane runs against the first tree where all sibling chunks actually coexist. A documentation or unrelated metadata-only change does not invalidate a code lane unless `.dm/verification.json` explicitly includes that path. A failed required level lane blocks dependent levels. Record:
 
@@ -714,7 +746,15 @@ LEVEL_VERIFICATION: <level> | passed: <N> | failed: <N>
 
 **THIS STEP IS MANDATORY.** After ALL chunks are merged, run exactly the validated final dm-review mode. `full` runs the full fan-out. `quick` runs the installed dm-review-quick protocol only when consequence is not high and the final diff has no bounded security-sensitive path; otherwise escalate to full.
 
-Before dispatching the review, invoke the repository planner with boundary `merge_candidate` on the exact feature-branch tree and run the selected lanes. It materializes every required remote race/security/container/harness lane as `remote_pending`, `blocked`, or `unavailable`; the kernel does not import remote results. The caller separately collects required native CI or independent review evidence bound to the exact candidate head.
+Before dispatching the review, verify the exact integrated feature-branch tree.
+On the profile path, invoke the repository planner with boundary
+`merge_candidate` and run its selected lanes. It materializes every required
+remote race/security/container/harness lane as `remote_pending`, `blocked`, or
+`unavailable`; the kernel does not import remote results. On the
+repository-native path, run the one canonical native command exactly once here
+and bind its result, exact command, policy source, and candidate SHA into the
+existing verification evidence. The caller separately collects required native
+CI or independent review evidence bound to the exact candidate head.
 
 First materialize the cumulative authoritative receipt array through the `all-chunks-complete` boundary and run the first `observe-pipeline` checkpoint. The observation remains shadow evidence and cannot approve the final review.
 
@@ -762,7 +802,12 @@ If P1/P2/P3 issues are found:
 
 1. Collect the complete finding set and fix it as one revision batch.
 2. Stage with `git add -A -- <dir>`, verify `git diff --cached --stat`, commit with `git commit -F <file>`.
-3. Invoke `revision_batch` once, then `merge_candidate` once. Do not test after every finding edit.
+3. On the profile path, invoke `revision_batch` once, then `merge_candidate`
+   once. On the repository-native path, an irrelevant repair may carry forward
+   prior canonical-command evidence only with bounded diff proof that no
+   relevant verification input changed. If a relevant input changed or
+   relevance is uncertain, rerun the canonical native command once and bind the
+   result to the new candidate SHA. Do not test after every finding edit.
 4. Re-run only the affected lanes on the exact newly tested SHA. Repeat the whole selected roster only when prior coverage was incomplete; if a repair changes a security-sensitive boundary, escalate to or repeat full mode.
 5. Stop when no P1/P2/P3 remain and every required lane and repository/browser/remote gate is complete.
 
@@ -780,7 +825,13 @@ After the final review, fire airlift per `plugins/pipeline/references/airlift-ch
 - `BLOCKED PENDING CALLER VERIFICATION` -- any required browser case has a `human_help_required` receipt or lacks complete passing browser evidence. Do NOT say "merge is safe" or "ready to merge".
 - `BLOCKED PENDING REMOTE VERIFICATION` -- any non-browser lane with `required: true` is `remote_pending`, `failed`, `blocked`, or `unavailable`. Caller verifies native CI or review evidence at the exact candidate head.
 
-Before emitting any merge recommendation, require passing local `merge_candidate` results from the current invocation against `.dm/verification.json`. Never substitute hardcoded Docker, Go package, service, or build-tag commands.
+Before emitting any merge recommendation, require passing local
+`merge_candidate` results from the current invocation on the profile path, or
+on the repository-native path either passing canonical-command evidence at the
+current candidate SHA or carried-forward passing evidence plus bounded diff
+proof that no relevant verification input changed since its tested SHA. Never
+substitute hardcoded Docker, Go package, service, build-tag, race, remote-CI, or
+other commands.
 
 **Doc-sync check:** if the feature introduced new patterns, modules, or conventions, verify `CLAUDE.md` and `README.md` reflect them; flag missing updates as P2.
 

--- a/plugins/pipeline/agents/workflow/execution-orchestrator.md
+++ b/plugins/pipeline/agents/workflow/execution-orchestrator.md
@@ -736,7 +736,7 @@ Apply `repo-cleanup-contract.md`. Never suppress git exit status. Load `plugins/
 
 After every chunk in the current execution level has completed Step 3j and its merge disposition is authoritative, check out `<featureBranch>`. On the profile path, invoke the repository planner exactly once with boundary `execution_level`, supplying the cumulative changed paths for that level, not one invocation per chunk. On the repository-native path, do not run the canonical native command at this boundary; retain the focused evidence already collected.
 
-The full non-race lane runs against the first tree where all sibling chunks actually coexist. A documentation or unrelated metadata-only change does not invalidate a code lane unless `.dm/verification.json` explicitly includes that path. A failed required level lane blocks dependent levels. Record:
+On the profile path, the full non-race lane runs against the first tree where all sibling chunks actually coexist. A documentation or unrelated metadata-only change does not invalidate a code lane unless `.dm/verification.json` explicitly includes that path. A failed required profile level lane blocks dependent levels. Record the profile-path result:
 
 ```text
 LEVEL_VERIFICATION: <level> | passed: <N> | failed: <N>

--- a/plugins/pipeline/references/codex-native-execution-adapter.md
+++ b/plugins/pipeline/references/codex-native-execution-adapter.md
@@ -86,9 +86,13 @@ references.
 
 Do not report "Skill tool unavailable" in Codex when this adapter can run. That message is only valid if the session lacks both nested skill invocation and enough local access to execute the dm-review inline protocol.
 
-**Repository verification adapter:** Resolve Workflow Kernel `>=0.15.0` once
-and use its `plan-verification` and `run-verification` subcommands whenever the
-target repository supplies `.dm/verification.json`.
+**Repository verification adapter:** First distinguish an absent profile from a
+declared profile. Resolve Workflow Kernel `>=0.15.0` once and use its
+`plan-verification` and `run-verification` subcommands whenever the target
+repository declares `.dm/verification.json` or an equivalent profile. A valid
+profile remains authoritative for planning, cadence, and evidence. A malformed
+or unsafe declaration stops with `human_help_required`, preserving the exact
+validation evidence; never fall back.
 
 - `chunk`: doctor, fast, and changed-package/dependent checks only.
 - `revision_batch`: apply the complete finding set from one review pass, then
@@ -99,9 +103,34 @@ target repository supplies `.dm/verification.json`.
   race/security/container/harness lanes explicitly.
 
 Do not execute a full or race suite after each chunk or each individual finding
-fix. For an
-Assembly target without `.dm/verification.json`, stop for project
-configuration rather than restoring hardcoded Go/Docker commands.
+fix. With no profile, apply the same repository-native policy as the Claude
+orchestrator regardless of repository type. Applicable root instructions must
+designate exactly one canonical full repository-owned verification entrypoint
+and may delegate to the other root instruction file. Separately scoped focused
+or pre-push commands do not conflict with that designation; different canonical
+full designations do conflict and block. The canonical entrypoint's directly
+named checked-in target or script must exist and must not depend on missing
+repository configuration. Otherwise stop narrowly with `human_help_required`
+and preserve the failed policy evidence. Never invent raw Go, Docker, package,
+build-tag, race, service, remote-CI, or other commands, and never synthesize or
+commit `.dm/verification.json`.
+
+Contract specimen: root `AGENTS.md` designates `make verify` as canonical full
+verification and names `make conformance` as narrower and `make survivor` as
+pre-push; root `CLAUDE.md` delegates to `AGENTS.md`; checked-in `Makefile` owns
+`verify:`, `conformance:`, and `survivor:`. The narrower commands do not conflict,
+so with no missing configuration repository-native verification is available.
+
+When the native policy passes, record `verificationPlanner: unavailable` and
+preserve the exact command and root policy-source path in existing verification
+evidence where supported; add no schema. Per chunk and review batch, run only
+focused checks explicitly approved by the prompt. Do not run the canonical
+native command per chunk, finding, or execution level. Run it exactly once on
+the integrated candidate before final review. After a repair batch, rerun it
+once and bind it to the new SHA when relevant verification inputs changed or
+relevance is uncertain. After an irrelevant repair, prior canonical-command
+evidence may be carried forward only with bounded diff proof that no relevant
+verification input changed since its tested SHA.
 
 **Repository cleanup is host-independent.** The adapter runs the same cleanup
 contract at the same points (Step 0e registry init, Step 3j per chunk, Step 5b

--- a/plugins/pipeline/references/execution-verification-planner.md
+++ b/plugins/pipeline/references/execution-verification-planner.md
@@ -1,15 +1,20 @@
 # Repository verification planner (1d)
 
-Loaded at Step 1d only when the repository carries a workflow-kernel
+Loaded at Step 1d only when the repository declares a workflow-kernel
 verification profile (`.dm/verification.json` or an equivalent declaration). A
 repository with no profile records that verification planning is not applicable
-and never loads this file.
+and never loads this file. A malformed or unsafe declared profile is still a
+declared profile: preserve its exact validation evidence and stop with
+`human_help_required`; never fall back to repository-native verification.
 
 ### 1d: Repository Verification Planner
 
 Use Workflow Kernel `>=0.15.0` as the only executable source of repository test selection. Pin the launcher already resolved for this run. Shadow may degrade to `shadow unavailable`; repository verification on a profile-aware repository fails closed with `human_help_required`.
 
-If `.dm/verification.json` exists, validate it with `plan-verification` before the first builder dispatch. An Assembly project without the file stops with `human_help_required`. Non-Assembly repos without a profile keep their native command, record `verificationPlanner: unavailable`, and propose adopting the profile.
+Validate the declared profile with `plan-verification` before the first builder
+dispatch. When valid, the resulting plan remains authoritative for selection,
+tiered cadence, and evidence. Profile cadence is unchanged by the separate
+no-profile repository-native policy in the orchestrator and Codex adapter.
 
 Before dispatch, run `plan-verification` with the exact base ref, candidate ref, and worktree-inclusion choice. Write a fresh plan under `plans/<feature-slug>/verification-plans/`, then `run-verification`. Required remote lanes remain `remote_pending`; report native CI or review evidence at the exact candidate head rather than importing it into the local result.
 

--- a/tools/validate-dm-review-codex-perspective.sh
+++ b/tools/validate-dm-review-codex-perspective.sh
@@ -395,7 +395,7 @@ for zero_deferral_surface in \
 done
 require_text "$REPO_ROOT/plugins/dm-review/.claude-plugin/plugin.json" '"version": "1.74.0"' "canonical dm-review version is 1.74.0"
 require_text "$REPO_ROOT/plugins/dm-review/.codex-plugin/plugin.json" '"version": "1.74.0"' "generated dm-review version is 1.74.0"
-require_text "$REPO_ROOT/plugins/pipeline/.claude-plugin/plugin.json" '"version": "1.61.1"' "canonical Pipeline version is 1.61.1"
+require_text "$REPO_ROOT/plugins/pipeline/.claude-plugin/plugin.json" '"version": "1.61.2"' "canonical Pipeline version is 1.61.2"
 require_text "$REPO_ROOT/plugins/pipeline/.codex-plugin/plugin.json" '"dm-review": ">=1.74.0"' "generated Pipeline dependency floor is current"
 
 printf "Synthesis identity fixtures\n"

--- a/tools/validate-workflow-contracts.sh
+++ b/tools/validate-workflow-contracts.sh
@@ -476,6 +476,10 @@ require_line_mutation_sensitive "$orchestrator" \
   "chunk, finding, and execution level. Run it repeatedly on the integrated" \
   "native cadence avoids repeated full runs"
 require_line_mutation_sensitive "$orchestrator" \
+  'On the profile path, the full non-race lane runs against the first tree where all sibling chunks actually coexist. A documentation or unrelated metadata-only change does not invalidate a code lane unless `.dm/verification.json` explicitly includes that path. A failed required profile level lane blocks dependent levels. Record the profile-path result:' \
+  'On every path, the full non-race lane runs against the first tree where all sibling chunks actually coexist. A documentation or unrelated metadata-only change does not invalidate a code lane unless `.dm/verification.json` explicitly includes that path. A failed required level lane blocks dependent levels. Record:' \
+  "execution-level full lane remains profile-only"
+require_line_mutation_sensitive "$orchestrator" \
   "   relevance is uncertain, rerun the canonical native command once and bind the" \
   "relevance is uncertain, reuse stale evidence without proof." \
   "native repair cadence binds relevant or uncertain reruns to the new SHA"

--- a/tools/validate-workflow-contracts.sh
+++ b/tools/validate-workflow-contracts.sh
@@ -426,6 +426,104 @@ require_text "$assembly_sec_checks" "Public/Private URL Boundary" "security-audi
 require_text "$assembly_sec_checks" "Update / Release Preflight" "security-auditor checks update/release preflight"
 require_text "$assembly_sec_checks" "Responder-side share transport" "security-auditor reviews the federation responder side"
 
+printf "\nRepository-native verification contract:\n"
+
+# These exact-line checks mutate each normative anchor before accepting it. A
+# broad keyword match would stay green when one side of the decision gate was
+# weakened, which is the regression this contract is intended to prevent.
+require_line_mutation_sensitive "$orchestrator" \
+  "planning contract. A valid profile remains authoritative for planning, cadence," \
+  "planning contract. A valid profile may be bypassed." \
+  "valid profile remains authoritative"
+require_line_mutation_sensitive "$orchestrator" \
+  '`human_help_required` and preserves the exact validation evidence; never fall' \
+  '`human_help_required` and may discard validation evidence.' \
+  "malformed profile blocks with exact evidence"
+require_line_mutation_sensitive "$orchestrator" \
+  "type, including Assembly, does not change it. Applicable root repository" \
+  "type, including Assembly, selects a different policy." \
+  "no-profile policy is repository-type neutral"
+require_line_mutation_sensitive "$orchestrator" \
+  "instructions must designate exactly one canonical full repository-owned" \
+  "instructions may imply several full repository-owned commands." \
+  "root policy designates one canonical full entrypoint"
+require_line_mutation_sensitive "$orchestrator" \
+  "instruction file. Separately scoped focused or pre-push commands do not conflict" \
+  "instruction file. Every focused or pre-push command conflicts" \
+  "narrower commands do not conflict with the canonical designation"
+require_line_mutation_sensitive "$orchestrator" \
+  "entrypoint's directly named checked-in target or script exists and that it does" \
+  "named target or script need not exist." \
+  "native target exists and has its repository configuration"
+require_line_mutation_sensitive "$orchestrator" \
+  '`verificationPlanner: unavailable` and preserve the exact command and root' \
+  '`verificationPlanner: available` and omit command provenance.' \
+  "native evidence retains planner state command and policy source"
+require_line_mutation_sensitive "$orchestrator" \
+  "entrypoint names a nonexistent target or script or depends on missing repository" \
+  "entrypoint may name a nonexistent target or script." \
+  "invalid native policy blocks narrowly"
+require_line_mutation_sensitive "$orchestrator" \
+  "policy evidence. Never invent raw Go, Docker, package, build-tag, race, service," \
+  "Invent missing verification commands when convenient." \
+  "native policy forbids invented commands"
+require_line_mutation_sensitive "$orchestrator" \
+  'remote-CI, or other commands. Never synthesize or commit' \
+  'Synthesize `.dm/verification.json` when absent.' \
+  "native policy does not synthesize a profile"
+require_line_mutation_sensitive "$orchestrator" \
+  "chunk, finding, or execution level. Run it exactly once on the integrated" \
+  "chunk, finding, and execution level. Run it repeatedly on the integrated" \
+  "native cadence avoids repeated full runs"
+require_line_mutation_sensitive "$orchestrator" \
+  "   relevance is uncertain, rerun the canonical native command once and bind the" \
+  "relevance is uncertain, reuse stale evidence without proof." \
+  "native repair cadence binds relevant or uncertain reruns to the new SHA"
+require_line_mutation_sensitive "$orchestrator" \
+  "Contract specimen: root \`AGENTS.md\` designates \`make verify\` as canonical full" \
+  "Contract specimen: root instructions do not name a command." \
+  "Governance specimen designates make verify canonical"
+require_line_mutation_sensitive "$orchestrator" \
+  "verification and names \`make conformance\` as narrower and \`make survivor\` as" \
+  "verification and treats every narrower command as conflicting." \
+  "Governance specimen preserves narrower and pre-push commands"
+require_line_mutation_sensitive "$orchestrator" \
+  "current candidate SHA or carried-forward passing evidence plus bounded diff" \
+  "any prior candidate SHA without additional evidence" \
+  "native merge gate accepts current-SHA or proof-bound carry-forward evidence"
+
+require_line_mutation_sensitive "$codex_native_parity" \
+  "fix. With no profile, apply the same repository-native policy as the Claude" \
+  "fix. With no profile, apply a Codex-specific repository-native policy." \
+  "Claude and Codex native policies remain equivalent"
+require_line_mutation_sensitive "$codex_native_parity" \
+  "evidence may be carried forward only with bounded diff proof that no relevant" \
+  "evidence may be carried forward without proof." \
+  "Codex preserves proof-bound evidence carry-forward"
+require_absent "$orchestrator" "an Assembly target (Go+Templ+Datastar) without" \
+  "orchestrator removes unconditional Assembly-profile refusal"
+require_absent "$codex_native_parity" 'Assembly target without `.dm/verification.json`' \
+  "Codex adapter removes unconditional Assembly-profile refusal"
+
+# The profile-aware cadence is deliberately unchanged while the native path is
+# introduced beside it.
+require_line_mutation_sensitive "$verification_planner" \
+  '| `chunk` | Worker completed one chunk | Doctor, fast, focused |' \
+  '| `chunk` | Worker completed one chunk | Full suite |' \
+  "profile chunk cadence remains focused"
+require_line_mutation_sensitive "$verification_planner" \
+  '| `revision_batch` | All fixes from one review pass are applied | Affected doctor, fast, focused |' \
+  '| `revision_batch` | Each finding is applied | Full suite |' \
+  "profile revision cadence remains batch-scoped"
+require_line_mutation_sensitive "$verification_planner" \
+  '| `execution_level` | Every chunk in one dependency level is merged | Integrated full non-race once |' \
+  '| `execution_level` | Every chunk is merged | Repeated full suite |' \
+  "profile execution-level cadence remains integrated once"
+require_line_mutation_sensitive "$verification_planner" \
+  '| `merge_candidate` | All levels are merged and before final review | Fresh exact-candidate run; remote lanes explicit |' \
+  '| `merge_candidate` | Before every chunk | Cached candidate run |' \
+  "profile merge-candidate cadence remains fresh"
+
 printf "\nAssembly release invocation-authority contract:\n"
 for release_surface in "$assembly_release" "$assembly_release_skill"; do
   release_rel="${release_surface#$REPO_ROOT/}"


### PR DESCRIPTION
## Summary

- let no-profile Assembly and non-Assembly repositories use one explicit canonical repository-native verification entrypoint
- preserve valid-profile authority and malformed-profile fail-closed behavior
- preserve focused chunk cadence and run the canonical native command once on the integrated candidate, with proof-bound carry-forward after irrelevant repairs
- repair Pipeline canonical version drift and release the bug fix as 1.61.2

Closes #115

## Governance consumer proof

Read-only proof against Governance origin/main at 3ef12c12152f47c274220c5878bd45b210fbd6ce confirms root AGENTS.md designates make verify as canonical, root CLAUDE.md delegates without conflict, the checked-in Makefile owns verify:, and make conformance / make survivor are explicitly narrower and pre-push commands.

## Verification

Passing:

- generated Codex manifests regenerated and current
- generated Codex command skills current
- Pipeline repository-native contract assertions
- dm-review Codex perspective
- dual compatibility
- dependency validation
- git diff check
- final quick review: clean after two supported repairs

The repository-wide composition command was run on the integrated candidate and once after relevant review repairs. It remains non-zero only in unrelated untouched baseline areas: Workflow Kernel and OpenRouter marketplace drift, Workflow Kernel behavioral fixture drift, model-router economics/provider-neutral fixtures, benchmark evidence, and model-intelligence tests. This PR does not modify those plugins or tests.

## Scope

No Governance changes, verification profile synthesis, command-discovery framework, release tag, plugin-cache update, or unrelated plugin bump.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Design-Machines-Studio/codesmith/depot/pr/116"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790670932&installation_model_id=428410&pr_number=116&repository=Design-Machines-Studio%2Fdepot&return_to=https%3A%2F%2Fgithub.com%2FDesign-Machines-Studio%2Fdepot%2Fpull%2F116&signature=69acb45737731b0efaceb27a6476fb6deec2218100bae4fb3c8911ee9bfd1783"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->