### PR TITLE
fix(workflows): make declared prototypes UI authority

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -139,7 +139,7 @@
     {
       "name": "assembly",
       "source": "./plugins/assembly",
-      "version": "3.15.0",
+      "version": "3.16.0",
       "author": {
         "name": "Design Machines"
       },
@@ -283,7 +283,7 @@
     {
       "name": "dm-review",
       "source": "./plugins/dm-review",
-      "version": "1.74.0",
+      "version": "1.75.0",
       "author": {
         "name": "Design Machines",
         "url": "https://designmachines.studio"
@@ -361,7 +361,7 @@
     {
       "name": "pipeline",
       "source": "./plugins/pipeline",
-      "version": "1.61.2",
+      "version": "1.62.0",
       "author": {
         "name": "Design Machines",
         "url": "https://designmachines.studio"

--- a/docs/dependency-graph.md
+++ b/docs/dependency-graph.md
@@ -74,12 +74,12 @@ graph LR
 | model-router | openrouter | optional | `>=1.19.0` |
 | model-router | workflow-kernel | optional | `>=0.17.0` |
 | ned | superpowers | optional | `>=1.0.0` |
-| pipeline | dm-review | required | `>=1.74.0` |
+| pipeline | dm-review | required | `>=1.75.0` |
 | pipeline | model-router | required | `>=0.4.0` |
 | pipeline | workflow-kernel | required | `>=0.18.1` |
 | pipeline | ned | optional | `>=1.4.0` |
 | pipeline | design-machines | optional | `>=1.3.0` |
-| pipeline | assembly | optional | `>=3.10.1` |
+| pipeline | assembly | optional | `>=3.16.0` |
 | pipeline | live-wires | optional | `>=1.8.0` |
 | pipeline | craft-developer | optional | `>=1.0.0` |
 | pipeline | accessibility-compliance | optional | `>=1.2.0` |

--- a/plugins/assembly/.claude-plugin/plugin.json
+++ b/plugins/assembly/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "assembly",
   "description": "Assembly governance application development with Go, Templ, and Datastar",
-  "version": "3.15.0",
+  "version": "3.16.0",
   "author": {
     "name": "Design Machines"
   },

--- a/plugins/assembly/.codex-plugin/plugin.json
+++ b/plugins/assembly/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "assembly",
-  "version": "3.15.0",
+  "version": "3.16.0",
   "description": "Assembly governance application development with Go, Templ, and Datastar",
   "author": {
     "name": "Design Machines"

--- a/plugins/assembly/skills/development/SKILL.md
+++ b/plugins/assembly/skills/development/SKILL.md
@@ -713,6 +713,34 @@ Assembly follows a three-phase distribution model. See `docs/DISTRIBUTION.md` fo
 
 The production backend lives in a separate repo (`assembly-baseplate`, DM-021) and is built from first principles. The prototype (`assembly`, DM-006) is the design workspace -- patterns are validated there, then implemented properly in production. Neither blocks the other. See ADR-002.
 
+### Prototype design authority for Baseplate and Fixtures
+
+For rendered Baseplate or Fixture work with a corresponding surface in the
+canonical `Design-Machines-Studio/assembly` prototype, the exact prototype
+source and rendered page are authoritative for semantic/wrapper hierarchy,
+Live Wires classes, component choices, literal copy, and control placement.
+Resolve the prototype by canonical remote and exact commit from the user,
+current native Issue/PR, root instructions, or active plan; never hardcode a
+permanent `/Users/...` or `/home/...` path.
+
+Read the relevant prototype templates/components before planning or editing,
+and search existing production and Live Wires components before inventing one.
+Compare source after editing and compare prototype/target renders at matching
+routes, states, and viewports. Source and browser evidence are complementary;
+matching screenshots cannot prove hierarchy/classes/copy, and matching classes
+cannot prove rendered composition.
+
+This is design authority, not a byte-for-byte port. Functional behavior,
+authorization, accessibility improvements, the public Fixture SDK, production
+data, CSRF, component APIs, and Baseplate host composition may require an
+intentional difference. Name and justify every such difference; never weaken a
+production boundary to imitate prototype code. If exact source inspection
+proves no counterpart exists, record that fact and use established production
+patterns rather than inventing a counterpart from a similar page.
+
+The generic examples in `pages.md` are fallback teaching examples only. They
+never override a corresponding exact prototype surface.
+
 ### Two-Repo Model
 
 | Repo | Project | Purpose |

--- a/plugins/assembly/skills/development/pages.md
+++ b/plugins/assembly/skills/development/pages.md
@@ -2,6 +2,14 @@
 
 Page templates for Assembly. Each page type has a consistent structure.
 
+> **Fallback examples only.** For Baseplate or Fixture work with a
+> corresponding surface in the canonical Assembly prototype, inspect that
+> surface at its exact commit first. Its source and matched render override the
+> generic hierarchy, classes, components, copy, and control placement shown
+> below. Preserve and name required production differences for functionality,
+> authorization, accessibility, public APIs, data, CSRF, and host/Fixture
+> composition. Check existing components before creating one.
+
 ## Page Types
 
 | Type | Template | Purpose |

--- a/plugins/dm-review/.claude-plugin/plugin.json
+++ b/plugins/dm-review/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dm-review",
   "description": "Code review orchestrator with evidence-backed severity, minimum-adequate repairs, zero-deferral convergence, full security and browser coverage, and stable finding receipts",
-  "version": "1.74.0",
+  "version": "1.75.0",
   "author": {
     "name": "Design Machines",
     "url": "https://designmachines.io"

--- a/plugins/dm-review/.codex-plugin/plugin.json
+++ b/plugins/dm-review/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dm-review",
-  "version": "1.74.0",
+  "version": "1.75.0",
   "description": "Code review orchestrator with evidence-backed severity, minimum-adequate repairs, zero-deferral convergence, full security and browser coverage, and stable finding receipts",
   "author": {
     "name": "Design Machines",

--- a/plugins/dm-review/agents/review/ui-standards-reviewer.md
+++ b/plugins/dm-review/agents/review/ui-standards-reviewer.md
@@ -54,7 +54,11 @@ Read `${CLAUDE_PLUGIN_ROOT}/plugins/dm-review/skills/review/references/ui-design
 
 The dispatch skill injects `## Visual Finding Rules` (spec-primary evaluation, the missing-spec P2 process finding, and the mandatory citation format) plus any `## Design Spec Context`. Follow them; do not restate them.
 
-Your lens on a spec is **SaaS benchmark standards**: judge each approved decision against how Stripe, Linear, or Notion would ship it. Spec compliance is evaluated before SaaS benchmarking, and spec deviations outrank general benchmark violations.
+When a prototype parity packet covers the surface, its settled product choices
+are primary. Do not judge or replace its copy, components, hierarchy, or action
+placement by asking what Stripe, Linear, or Notion would ship. Use SaaS
+benchmarks only for uncovered choices and objective usability, accessibility,
+responsiveness, interaction, or broken-state defects.
 
 ## Live Wires Compliance
 
@@ -90,7 +94,14 @@ Registered names: `animate`, `custom-validity`, `match-media`, `on-raf`, `on-res
 
 If no bundle is vendored (CDN or asset-pipeline build), say so, downgrade to P2, and name the check the author should run. Do not guess. Do not raise either finding against Live Wires CSS, the Datastar bundle itself, or build tooling.
 
-## Phase 1: Component Quality Audit
+## Phase 1: Prototype/Spec Compliance, then Component Quality
+
+For a prototype-covered surface, compare the host-supplied source and matched
+browser packet first: semantic/wrapper hierarchy, significant component calls,
+actual Live Wires class strings, literal copy/metadata/action order, and
+rendered composition at the same states/viewports. Honor named production
+differences. Classify mismatches proportionally under the injected Visual
+Finding Rules; never apply a blanket P1.
 
 Navigate to each affected page and evaluate components against SaaS standards:
 

--- a/plugins/dm-review/agents/review/ux-quality-reviewer.md
+++ b/plugins/dm-review/agents/review/ux-quality-reviewer.md
@@ -128,7 +128,15 @@ Cite White: "readers are lazy and in a hurry -- this page doesn't pass the WIIFM
 
 Skip if no `## Design Spec Context` was provided. This runs BEFORE general heuristic evaluation.
 
-For each visual decision, locate the element, capture it (element targeting or a crop of the full-page shot), and compare against the spec: button variants (correct class AND correct visual weight relative to surrounding buttons), heading hierarchy (correct tag AND correct prominence relative to other headings), spacing (correct token AND correct visual grouping of related elements), layout (correct component AND correct composition, neither too wide nor too cramped). Flag mismatches **P1**: "[url] [element] deviates from design spec -- spec says [X], rendered shows [Y]". If ALL decisions match, note "Design spec compliance: PASS ([N] decisions checked)".
+For each visual decision, locate the element in host evidence and compare against
+the spec: button variants (correct class AND visual weight), heading hierarchy,
+spacing/grouping, and layout composition. For a prototype packet, also compare
+the supplied source hierarchy, significant components, exact classes, literal
+copy/metadata, and action order. Generic benchmarks cannot replace covered
+prototype decisions. Classify mismatches by observable impact under the
+injected Visual Finding Rules rather than assigning blanket P1. If all
+decisions match, note "Design authority compliance: PASS ([N] decisions
+checked)".
 
 ### Phase 2: Spacing & Alignment Consistency
 
@@ -248,7 +256,14 @@ Also: very long titles or names (truncation, wrapping, overflow); tables and lis
 
 A component rendering on more than one route -- a shared editor, form, or dialog -- must look and behave the same on each. Sharing a component *is* a parity claim, even when nobody wrote it down.
 
-Screenshot it on each route at the same viewport, then compare computed `font-size`, `font-weight`, `color`, `padding`, `margin`, `background-color`, and `border` across routes. Any mismatch is **P1**: a route-specific wrapper or stale override has broken the abstraction while the component source stayed identical -- exactly the failure a source-only code review cannot see. Cite both URLs and name the differing properties.
+Screenshot it on each route at the same viewport, then compare computed
+`font-size`, `font-weight`, `color`, `padding`, `margin`, `background-color`,
+and `border` across routes. Classify a mismatch by observable impact: P1 only
+when it blocks a primary task, misleads authorization/governance, hides an
+essential control, or breaks explicitly critical parity; P2 for meaningful
+confusing/rework-causing drift; P3 for minor spacing/alignment/presentation
+drift. Cite both URLs and name the differing properties. Every supported
+severity remains mandatory before clean completion.
 
 ### Phase 10: AI Output Quality Gate
 

--- a/plugins/dm-review/agents/review/visual-browser-tester.md
+++ b/plugins/dm-review/agents/review/visual-browser-tester.md
@@ -84,7 +84,13 @@ Examine both for obvious rendering problems: blank or partially loaded pages, mi
 
 The dispatch skill injects `## Visual Finding Rules` (spec-primary evaluation, the missing-spec P2 process finding, and the mandatory citation format) plus any `## Design Spec Context`. Follow them; do not restate them. The citation requirement applies to every non-spec phase here too -- responsive, interaction states, CSS compliance.
 
-Your lens is the **rendering level**, complementing the ux-quality-reviewer's design-quality lens: extract the spec's component variants, visual hierarchy, spacing choices, color treatments, and described outcomes; take an element-level `browser_take_screenshot` (CSS selector or coordinates) for each decision that maps to a visible element; state explicitly what you see; flag deviations P1. This catches cases where CSS inheritance, layout context, or scheme color differences produce a different visual result than the code suggests.
+Your lens is the **rendering level**, complementing the ux-quality-reviewer's
+design-quality lens. For a prototype packet, use host evidence captured at
+matching routes, states, and viewports and compare targeted hierarchy, actual
+classes, literal copy/action order, and computed layout/spacing alongside the
+source checklist. Exact colors/theme variables may differ when the structural
+scheme is equivalent. State explicitly what you see and classify deviations
+proportionally under the injected Visual Finding Rules; never apply blanket P1.
 
 Every retained visual P1/P2/P3 finding keeps complete evidence and provenance,
 enters the fix queue, and blocks `CLEAN` until verified. See
@@ -225,7 +231,12 @@ return JSON.stringify({ fontSize: s.fontSize, fontWeight: s.fontWeight, color: s
   padding: s.padding, margin: s.margin, backgroundColor: s.backgroundColor, border: s.border });
 ```
 
-Any mismatch across routes is **P1**. Cite both URLs and the differing properties. A shared component that renders differently per route is not a polish issue -- it is the component failing to be shared.
+Classify mismatches across routes by observable impact: P1 only for blocked
+primary work, misleading authorization/governance consequences, inaccessible
+essential controls, or explicitly critical parity; P2 for meaningful
+structure/interaction drift; P3 for minor spacing/alignment/presentation
+drift. Cite both URLs and the differing properties. Every supported severity
+must still be fixed and rechecked before clean completion.
 
 ---
 

--- a/plugins/dm-review/skills/review/SKILL.md
+++ b/plugins/dm-review/skills/review/SKILL.md
@@ -378,7 +378,13 @@ Skipping Y agents:
 
 ### Phase 3.25: Design Spec Discovery
 
-If the change includes `.templ`, `.twig`, `.html`, or `.css`, load `${CLAUDE_SKILL_DIR}/references/design-spec-discovery.md` and inject any found spec as `## Design Spec Context`.
+If the change includes `.templ`, `.twig`, `.html`, or `.css`, load
+`${CLAUDE_SKILL_DIR}/references/design-spec-discovery.md`. Prefer caller-provided
+Pipeline prototype context; otherwise resolve exact declarations from the
+current PR/Issue, root instructions, or active plan. Read external prototype
+source once at the host and inject the bounded parity packet plus matched
+browser evidence into applicable UI lanes. Use local specs/brainstorms and then
+general heuristics only as fallbacks.
 
 ### Phase 3.5: Input Guardrails
 

--- a/plugins/dm-review/skills/review/references/design-spec-discovery.md
+++ b/plugins/dm-review/skills/review/references/design-spec-discovery.md
@@ -5,27 +5,60 @@ or `.css`. A non-UI diff never loads this file.
 
 ### Phase 3.25: Design Spec Discovery
 
-Check for design specifications that browser-based agents should evaluate against. This step loads the spec ONCE and injects it into visual agents -- individual agents do not discover specs independently.
+Resolve design authority once at the host and inject a bounded packet into
+applicable UI lanes -- individual agents do not discover external source.
 
-1. Look for spec files in order of specificity:
+1. Prefer caller-provided Pipeline `prototypeReference` and `prototypeParity`
+   context. Otherwise inspect the current native PR/Issue, root instructions,
+   and active product plan for an exact declared prototype repository and
+   commit. Do not guess one.
+2. When a declared prototype covers the changed surface, read its exact
+   external templates/components once at the host and create a bounded
+   `prototype_parity_packet` containing repository + commit, authority source,
+   relevant prototype/target paths, matched route-state-viewport pairs,
+   meaningful semantic/wrapper hierarchy, significant components, exact Live
+   Wires classes, literal copy/metadata/action order, evidence status, and
+   approved intentional differences. Include short excerpts only, never whole
+   templates or permanent workstation paths.
+3. Conflicting or unresolved prototype identity/commit/route claims make
+   required UI review `human_help_required`. If exact source inspection proves
+   no counterpart exists, record `no prototype counterpart` and continue with
+   the existing heuristic path; never borrow a vaguely similar page.
+4. If no relevant prototype counterpart exists, look for local spec files in
+   order of specificity:
    - `docs/superpowers/specs/*.md` -- formal design specs (use most recently modified)
    - `.superpowers/brainstorm/` -- brainstorm mockups (HTML files with visual decisions as inline styles)
    - `plans/*/brainstorm.html` -- pipeline brainstorm output (HTML with a `visualDecisions` JSON island)
-2. If ANY spec files are found, read them and extract a structured summary:
+5. If local spec files are found, read them and extract a structured summary:
    - Visual decisions (layout choices, spacing tokens, component variants, color usage)
    - Approved design patterns (specific markup structures, class choices)
    - Visual hierarchy decisions (what should be prominent, what should be subdued)
    - Specific visual treatments called out in the approved design
-3. Store this summary as `design_spec_context` for injection into browser-based agents in Phase 4.
-4. Report to the user:
+6. Store the prototype packet (primary when present), local
+   `design_spec_context`, and already matched host browser evidence for
+   injection into rendered UI lanes in Phase 4. Source and browser proof are
+   complementary: screenshots cannot prove source hierarchy/classes/copy, and
+   source cannot prove spacing/composition. Required prototype browser evidence
+   uses matching routes, states, and viewports and cannot be replaced by a
+   target-only screenshot, curl, or `looks close`.
+7. Report to the user:
 
 ```text
 Design spec found: [path]. Will inject into visual review agents.
 ```
 
-Or: "No design spec found. Visual agents will evaluate against general heuristics only."
+Or: "No relevant prototype counterpart or local design spec found. Visual
+agents will evaluate against general heuristics."
 
-This context is injected ONLY into the browser-based agents (ux-quality-reviewer, visual-browser-tester, ui-standards-reviewer). Code-only agents do not need it.
+Prototype-covered decisions are primary. Generic Stripe/Linear/Notion/SaaS
+heuristics are secondary and cannot recommend different copy, components,
+hierarchy, or control placement solely because a benchmark differs. Objective
+usability, accessibility, responsiveness, security, and broken-state defects
+remain reviewable. When the prototype render is temporarily unavailable,
+preserve source findings but do not claim rendered parity complete.
+
+This context is injected only into applicable rendered UI lanes
+(ux-quality-reviewer, visual-browser-tester, ui-standards-reviewer). Code-only
+agents do not need it.
 
 ---
-

--- a/plugins/dm-review/skills/review/references/reviewer-prompt-template.md
+++ b/plugins/dm-review/skills/review/references/reviewer-prompt-template.md
@@ -73,5 +73,9 @@ relevant to design/CSS/typography/layout/accessibility/UX uncertainty.
 ## Rendered UI lanes
 
 For selected rendered-UI lanes only, append `## Visual Finding Rules` from
-`visual-finding-rules.md`; append discovered `design_spec_context` after caller
-context, otherwise evaluate general heuristics. Non-UI lanes never receive either.
+`visual-finding-rules.md`; append the host-resolved bounded
+`prototype_parity_packet`, matched browser evidence, and discovered
+`design_spec_context` after caller context. A prototype-covered surface uses
+that packet as primary and must check source structure/components/classes/copy
+as well as rendered appearance. Otherwise evaluate local specs or general
+heuristics. Non-UI lanes never receive these contexts.

--- a/plugins/dm-review/skills/review/references/ui-review-readiness.md
+++ b/plugins/dm-review/skills/review/references/ui-review-readiness.md
@@ -20,6 +20,13 @@ Pass invocation and T3 targets to `prepare` with `--target-url` and
 from file extensions, or guess a start command. The helper validates the URL;
 successful host navigation remains the readiness proof.
 
+"One target" applies per readiness state. When a host-resolved prototype
+parity packet supplies both an exact prototype URL and target URL, run this
+same gate for each in sequence and collect one bounded matched evidence packet;
+do not invent a broker or new transport. The prototype and target cases must
+use the same meaningful states and viewports. Required prototype evidence
+cannot be replaced by target-only navigation.
+
 ## Optional repository declaration
 
 When present, discover only `<repository>/.dm/ui-review.json`. Its closed
@@ -95,6 +102,9 @@ consumer is sufficient.
    each applicable UI analysis role. Request
    `review-deep` with `read-repository`, `long-context`, and
    `structured-output`; do not request `browser` or generic `tool-use`.
+   For a declared counterpart, include matched prototype/target route, state,
+   viewport, targeted hierarchy, actual classes, visible copy/action order, and
+   explanatory layout/spacing values. Exact theme colors are not a parity gate.
 8. Settle the public participant result through `ui-review-readiness.sh
    settle`, then clean every exact registered process or Compose resource.
    Install the same cleanup call on interruption and failure paths.

--- a/plugins/dm-review/skills/review/references/visual-finding-rules.md
+++ b/plugins/dm-review/skills/review/references/visual-finding-rules.md
@@ -1,8 +1,34 @@
 ## Visual Finding Rules
 
-When a `## Design Spec Context` section is present, it is your PRIMARY evaluation baseline. For each approved decision, locate the element on the rendered page, capture an element-level screenshot, and evaluate the match. Flag any mismatch as P1: "Implementation deviates from approved design: spec says [X], rendered shows [Y]." Spec deviations outrank general heuristic violations and are evaluated before them -- a page can be "good enough" by general standards and still wrong against the approved design.
+When a `## Prototype Parity Packet` is present, it is the PRIMARY evaluation
+baseline. Check its bounded source hierarchy, significant components, exact
+Live Wires classes, literal copy/metadata/action order, and matched rendered
+cases. Generic product heuristics are secondary and cannot redesign a settled
+prototype choice. A named functionality, authorization, accessibility, public
+API, production-data, host-composition, or Fixture-boundary difference is not a
+defect merely because it diverges.
 
-When it is absent and the diff contains template or CSS files, flag a P2 process finding: "No design spec available -- visual quality evaluation is heuristic-only, which has a documented history of missing implementation gaps (see docs/post-mortems/2026-04-07-pipeline-ui-refinement-postmortem.md). Consider running the pipeline assess phase to establish a design baseline before further UI work." This is a process finding, not a code finding: it signals that the review's ability to catch visual quality issues is degraded.
+When a `## Design Spec Context` section is present, it is also authoritative
+for covered decisions. Locate each affected element, use the host-captured
+element evidence, and evaluate the match before general heuristics. A page can
+be generally acceptable and still drift from settled product design.
+
+Classify prototype/spec mismatches by observable impact: P1 only when a primary
+task is blocked, authorization/governance consequences are misleading, an
+essential control is inaccessible, or parity is explicitly critical; P2 for a
+meaningful structure/component/copy/control-placement/responsive/interaction
+mismatch causing confusion or rework; P3 for minor spacing, alignment,
+metadata, class, or presentation drift. Every supported P1/P2/P3 remains
+mandatory before `CLEAN`.
+
+When no relevant prototype counterpart or local design spec exists and the diff
+contains template or CSS files, retain the existing P2 process finding:
+"No design spec available -- visual quality evaluation is heuristic-only, which
+has a documented history of missing implementation gaps (see
+docs/post-mortems/2026-04-07-pipeline-ui-refinement-postmortem.md). Consider
+running the pipeline assess phase to establish a design baseline before further
+UI work." This warns about degraded review coverage; it is not a product
+finding. Do not invent a counterpart or another finding from missing ceremony.
 
 Every finding, spec-derived or heuristic, MUST cite its rule source: a CLAUDE.md section ("CLAUDE.md > Spacing System > baseline rhythm"), a Live Wires skill reference ("Live Wires layouts.md: use .stack not manual margin"), a benchmark product plus pattern ("Linear uses skeleton loaders for async table loading"), a token name ("--line-2 spacing token exists for this value"), or a WCAG criterion ("WCAG 2.4.7: focus must be visible"). Format each finding as:
 

--- a/plugins/pipeline/.claude-plugin/plugin.json
+++ b/plugins/pipeline/.claude-plugin/plugin.json
@@ -1,20 +1,20 @@
 {
   "name": "pipeline",
   "description": "Autonomous feature development pipeline with approved-scope intake, minimum-adequate planning, bounded adversarial review, fresh tiered verification, browser recovery, and isolated execution",
-  "version": "1.61.2",
+  "version": "1.62.0",
   "author": {
     "name": "Design Machines",
     "url": "https://designmachines.io"
   },
   "pluginDependencies": {
-    "dm-review": ">=1.74.0",
+    "dm-review": ">=1.75.0",
     "model-router": ">=0.4.0",
     "workflow-kernel": ">=0.18.1"
   },
   "optionalPluginDependencies": {
     "ned": ">=1.4.0",
     "design-machines": ">=1.3.0",
-    "assembly": ">=3.10.1",
+    "assembly": ">=3.16.0",
     "live-wires": ">=1.8.0",
     "craft-developer": ">=1.0.0",
     "accessibility-compliance": ">=1.2.0",

--- a/plugins/pipeline/.codex-plugin/plugin.json
+++ b/plugins/pipeline/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pipeline",
-  "version": "1.61.2",
+  "version": "1.62.0",
   "description": "Autonomous feature development pipeline with approved-scope intake, minimum-adequate planning, bounded adversarial review, fresh tiered verification, browser recovery, and isolated execution",
   "author": {
     "name": "Design Machines",
@@ -163,14 +163,14 @@
     ]
   },
   "pluginDependencies": {
-    "dm-review": ">=1.74.0",
+    "dm-review": ">=1.75.0",
     "model-router": ">=0.4.0",
     "workflow-kernel": ">=0.18.1"
   },
   "optionalPluginDependencies": {
     "ned": ">=1.4.0",
     "design-machines": ">=1.3.0",
-    "assembly": ">=3.10.1",
+    "assembly": ">=3.16.0",
     "live-wires": ">=1.8.0",
     "craft-developer": ">=1.0.0",
     "accessibility-compliance": ">=1.2.0",

--- a/plugins/pipeline/agents/workflow/execution-orchestrator.md
+++ b/plugins/pipeline/agents/workflow/execution-orchestrator.md
@@ -622,12 +622,14 @@ by another repository out of the diff; report them as `Noted, not fixed`.
 
 [FULL PROMPT CONTENT INLINED HERE]
 
-For a chunk carrying `prototypeReference`, include its relevant bounded
-`prototypeParity` packet here. Require exact prototype source inspection before
-editing, existing target/Live Wires component search, post-edit source
-comparison, matched prototype/target browser comparison, and named intentional
-differences. Generic UI benchmarks remain secondary to covered prototype
-decisions.
+When the manifest carries a validated top-level `prototypeReference` with
+`status: counterpart` and this chunk carries a non-empty `prototypeParity`
+array, include that reference and only this chunk's bounded parity packet here.
+Require exact prototype source inspection before editing, existing target/Live
+Wires component search, post-edit source comparison, matched prototype/target
+browser comparison, and named intentional differences. Generic UI benchmarks
+remain secondary to covered prototype decisions. A validated
+`status: no_counterpart` reference carries no chunk parity packet.
 
 When done:
 1. Verify all acceptance criteria are met

--- a/plugins/pipeline/agents/workflow/execution-orchestrator.md
+++ b/plugins/pipeline/agents/workflow/execution-orchestrator.md
@@ -622,6 +622,13 @@ by another repository out of the diff; report them as `Noted, not fixed`.
 
 [FULL PROMPT CONTENT INLINED HERE]
 
+For a chunk carrying `prototypeReference`, include its relevant bounded
+`prototypeParity` packet here. Require exact prototype source inspection before
+editing, existing target/Live Wires component search, post-edit source
+comparison, matched prototype/target browser comparison, and named intentional
+differences. Generic UI benchmarks remain secondary to covered prototype
+decisions.
+
 When done:
 1. Verify all acceptance criteria are met
 2. State which approved Key Requirements and project outcome this chunk addresses
@@ -711,6 +718,12 @@ with `--phase "execute"`. Mark `[chunk-id] 7. Run evaluation gate` complete.
 
 When `renderedSurface: required`, load `plugins/pipeline/references/visual-verification-protocol.md` and run it. Do not emit `BROWSER_VERIFIED`, fabricate empty evidence, or skip the recovery ladder. Curl never satisfies required browser proof. Exhaustion is `human_help_required` with `stage: browser_recovery`. `not_declared` is valid only when declarations are absent; incomplete declarations block.
 
+When the chunk carries a prototype counterpart, also load
+`plugins/pipeline/references/prototype-authority.md`. Do not merge the chunk as
+rendered-parity complete until both post-edit source comparison and matched
+prototype/target browser evidence settle. A temporarily unavailable prototype
+render preserves source work but blocks the rendered-parity claim.
+
 ### 3i: Merge Back
 
 Before merging, search for `EVAL_GATE_PASSED: [chunk-id] |`. If absent: STOP, run Step 3g, then merge.
@@ -789,6 +802,12 @@ Key Requirements from the assessment `keyRequirements` island:
 
 Compact Project Alignment from the approved assessment:
 [INLINE CURRENT PROJECT GOAL, RELEVANT CONSTRAINTS/NON-GOALS, AND OWNERSHIP]
+
+Declared Prototype Context, when applicable:
+[INLINE THE CANONICAL REPOSITORY + EXACT COMMIT, RELEVANT SOURCE PATHS,
+MATCHED ROUTE/STATE/VIEWPORT CASES, BOUNDED PARITY CHECKLIST, AND INTENTIONAL
+DIFFERENCES. REQUIRE SOURCE AND RENDERED COMPARISON; TREAT GENERIC HEURISTICS AS
+SECONDARY FOR COVERED DECISIONS.]
 
 In addition to code quality, check whether the branch advances the approved
 project goal, satisfies every requirement/outcome, and stays within the approved

--- a/plugins/pipeline/agents/workflow/plan-adversary.md
+++ b/plugins/pipeline/agents/workflow/plan-adversary.md
@@ -187,6 +187,13 @@ its rendered-surface audit, visual-criteria bar, and Visual Diff Protocol. If
 nothing in scope renders, do not load it -- but confirm the plan says so with a
 non-empty `not_applicable` rationale. Mixed or uncertain scope is `required`.
 
+When a declared prototype covers the surface, verify the plan loads
+`prototype-authority.md`, reads exact source before target evaluation, carries
+the bounded parity map and intentional differences, and requires matched
+source plus browser proof. Reject a vaguely similar page as a speculative
+counterpart and reject generic benchmark redesign of settled prototype copy,
+components, hierarchy, or control placement.
+
 ## Targeted Criteria Review
 
 Do not produce a separate contract or add criteria to every chunk. Add a

--- a/plugins/pipeline/references/phase7-visual-verification.md
+++ b/plugins/pipeline/references/phase7-visual-verification.md
@@ -15,17 +15,28 @@ If all full-mode chunks have `renderedSurface: not_applicable`, or the lean plan
 records rendered verification as not applicable, record the rationale and skip
 to the requirements cross-check.
 
-1. **Discover the design spec.** Check these locations in order:
+1. **Discover the design authority.** If assessment/plan data carries a
+   declared prototype counterpart, load `prototype-authority.md`, read its exact
+   source and bounded parity map, and use it as primary. Then check:
    - `plans/<feature-slug>/brainstorm.html` (read the `visualDecisions` island with `templates/extract-json-island.sh`)
    - `docs/superpowers/specs/*.md` (most recently modified)
    - `.superpowers/brainstorm/` (HTML mockups)
    - If none exist, use the original prompt's visual requirements as the baseline.
 
-2. **Screenshot every affected page.** Navigate to each route that was touched by any chunk. Take a desktop (1440px) screenshot of each. If the design spec or original prompt mentions mobile, also take 375px screenshots.
+2. **Screenshot every affected page.** Navigate to each route that was touched
+   by any chunk. For prototype counterparts, compare prototype and target at
+   the same states and viewports and include targeted DOM/class/copy/layout
+   evidence. Take a desktop (1440px) screenshot of each. If the design spec or
+   original prompt mentions mobile, also take 375px screenshots.
 
 3. **Compare to design spec.** For each visual decision in the design spec (or each visual requirement in the original prompt), evaluate the rendered page. State explicitly what you see.
 
-4. **Present gaps to the user BEFORE claiming done.** Format:
+4. **Compare source when a prototype applies.** Recheck meaningful wrapper
+   hierarchy, components, exact Live Wires classes, literal copy/metadata, and
+   action order. Name and justify intentional production differences. Neither
+   source-only nor screenshot-only evidence completes prototype parity.
+
+5. **Present gaps to the user BEFORE claiming done.** Format:
 
 ```text
 ## Caller Visual Verification
@@ -51,4 +62,3 @@ If gaps are found, present them as part of the delivery. Do not present the bran
 Assertions without evidence are findings, not verifications. "Verified: sidebar looks good" is NOT acceptable. "Verified: sidebar headings use 0.875rem / 400 weight / var(--color-muted) per getComputedStyle" IS acceptable.
 
 If evidence is still unavailable after the required recovery ladder, emit blocked `human_help_required` with every attempt and exact missing case IDs, ask the user for help, and stop delivery. This is never a passing, skipped, or deferred verification.
-

--- a/plugins/pipeline/references/plan-visual-verification-readiness.md
+++ b/plugins/pipeline/references/plan-visual-verification-readiness.md
@@ -14,7 +14,11 @@ Apply the mode-specific rendered-surface audit:
 For required rendered work, verify the applicable prompts (full) or single-pass
 plan scope (Lean) enforce visual quality:
 
-- [ ] Cite a design spec, the `brainstorm.html` `visualDecisions` island, or approved visual requirements? With no visual baseline, flag **IMPORTANT** -- visual quality would otherwise be judged by heuristics only.
+- [ ] Resolve any conditionally declared prototype through
+  `prototype-authority.md` before local specs or heuristics. For a counterpart,
+  carry its repository/commit, source paths, matched cases, parity map, and
+  intentional differences. With no prototype, cite a local design spec, the
+  `brainstorm.html` `visualDecisions` island, or approved visual requirements.
 - [ ] Carry at least 2 visual acceptance criteria describing visual IMPRESSIONS, not just structural class names: "Block and Abstain buttons are visually smaller and lighter than the main position buttons" is an impression; "Button uses `button--outline-danger` class" is structural. Both are needed; impressions catch the gap between "correct class" and "correct visual effect."
 - [ ] Give each visual criterion a browser-verifiable test (screenshot comparison or getComputedStyle extraction): "Button has font-size < 1rem per getComputedStyle" is verifiable; "Code is clean" is not.
 - [ ] **[Full only]** Chunks modifying the same visual area (sidebar, form, card) carry aligned criteria -- not "prominent headings" in one and "subdued headings" in another.
@@ -26,6 +30,11 @@ In either case, the acceptance criteria MUST include:
 
 1. Screenshot comparison: "Screenshot of [A] and [B] at same viewport should show visually identical [component/layout]"
 2. Computed style comparison: "getComputedStyle on [selector] for [A] and [B] must match for: font-size, font-weight, color, padding, margin, background-color, border"
-3. Both criteria are **P1** -- visual parity requirements from the user are not optional polish.
+3. Classify mismatches by observable impact using `prototype-authority.md`:
+   P1 only for a blocked primary task, misleading authorization/governance
+   consequence, inaccessible essential control, or explicitly critical parity;
+   P2 for meaningful structure/component/copy/placement/interaction drift; P3
+   for minor spacing, alignment, metadata, or presentation drift. Every
+   supported severity remains mandatory before clean completion.
 
 If an approved visual-parity requirement lacks these criteria, emit one blocker scoped to the affected full-mode chunk or Lean single-pass scope.

--- a/plugins/pipeline/references/plan-visual-verification-readiness.md
+++ b/plugins/pipeline/references/plan-visual-verification-readiness.md
@@ -19,6 +19,10 @@ plan scope (Lean) enforce visual quality:
   carry its repository/commit, source paths, matched cases, parity map, and
   intentional differences. With no prototype, cite a local design spec, the
   `brainstorm.html` `visualDecisions` island, or approved visual requirements.
+- [ ] When required rendered work has neither a prototype counterpart nor a
+  local design spec, emit the explicit P2 heuristic-only coverage warning;
+  approved visual requirements may define acceptance criteria but do not prove
+  a source design baseline.
 - [ ] Carry at least 2 visual acceptance criteria describing visual IMPRESSIONS, not just structural class names: "Block and Abstain buttons are visually smaller and lighter than the main position buttons" is an impression; "Button uses `button--outline-danger` class" is structural. Both are needed; impressions catch the gap between "correct class" and "correct visual effect."
 - [ ] Give each visual criterion a browser-verifiable test (screenshot comparison or getComputedStyle extraction): "Button has font-size < 1rem per getComputedStyle" is verifiable; "Code is clean" is not.
 - [ ] **[Full only]** Chunks modifying the same visual area (sidebar, form, card) carry aligned criteria -- not "prominent headings" in one and "subdued headings" in another.

--- a/plugins/pipeline/references/promptcraft-applicability-gates.md
+++ b/plugins/pipeline/references/promptcraft-applicability-gates.md
@@ -28,12 +28,16 @@ For each Assembly mutation chunk, consult `assembly:development`'s Mutation Appl
 
 Every chunk with `renderedSurface: required` must include at least 2 visual acceptance criteria describing rendered impressions, not just structural class names, in a `### Visual Acceptance Criteria` subsection. "Uses `.button--accent` class" is structural; "Primary action button is visually dominant over secondary actions" is visual; both types are required. A chunk marked `not_applicable` must not fabricate rendered impressions.
 
-**Shared-component parity:** when one Templ component renders on two or more routes -- a shared editor, form, or dialog -- the chunk must carry a **Visual Parity Criterion** even when the prompt never says "visually identical": sharing a component is itself the parity claim, and a route-specific wrapper or stale override quietly breaks it. Detect by grepping the plan's `filesToModify` for a component invoked from more than one page package; for each, add these two **P1** criteria:
+**Shared-component parity:** when one Templ component renders on two or more routes -- a shared editor, form, or dialog -- the chunk must carry a **Visual Parity Criterion** even when the prompt never says "visually identical": sharing a component is itself the parity claim, and a route-specific wrapper or stale override quietly breaks it. Detect by grepping the plan's `filesToModify` for a component invoked from more than one page package; for each, add these two criteria:
 
 1. `Screenshot of <component> at /route-a and /route-b at the same viewport shows identical rendering.`
 2. `getComputedStyle on <selector> matches across both routes for: font-size, font-weight, color, padding, margin, background-color, border.`
 
-A shared component that renders differently per route is the component failing to be shared, not polish.
+Classify a supported mismatch by observable impact: P1 only for blocked primary
+work, misleading authorization/governance consequences, inaccessible essential
+controls, or explicitly critical parity; P2 for meaningful structural or
+interaction drift; P3 for minor spacing/alignment/presentation drift. Every
+supported severity remains mandatory before clean completion.
 
 ## Phase 3m: Fixture SDK Conformance Gate
 

--- a/plugins/pipeline/references/prototype-authority.md
+++ b/plugins/pipeline/references/prototype-authority.md
@@ -1,0 +1,106 @@
+# Declared prototype authority
+
+Load this reference only for rendered work when a prototype is declared by the
+user, the current native Issue or PR, root repository instructions, or the
+active product plan. For Assembly Baseplate or Fixture work, also load it when
+`assembly:development` identifies a corresponding surface in the canonical
+`Design-Machines-Studio/assembly` prototype. Do not guess a prototype for an
+unrelated project or infer a counterpart from a vaguely similar page.
+
+## Resolve once, source first
+
+Before planning or editing, resolve and record a compact `prototypeReference`:
+
+- canonical repository identity and exact commit;
+- authority source (user, native Issue/PR, root instructions, active plan, or
+  Assembly development guidance);
+- affected prototype source files and target source files;
+- matched prototype and target route/state pairs and viewports; and
+- already approved intentional differences.
+
+Resolve repository identity by canonical remote, never by a permanent absolute
+workstation path. Conflicting or unresolved repository, commit, route, or
+authority claims stop UI implementation with one plain `human_help_required`
+explanation. If exact source inspection proves there is no counterpart, record
+`no prototype counterpart`, name the inspected source, and fall back to the
+target's existing production patterns. A missing counterpart is not a blocker.
+
+Read the exact prototype templates and components before evaluating the target.
+Do not create a prototype database, durable registry, copied template, or
+second ledger.
+
+## Bounded parity map
+
+For each affected surface, retain one concise `prototypeParity` item in the
+existing assessment/plan data island and project only the relevant subset into
+each execution prompt or review packet:
+
+- prototype and target routes, states, viewports, and source paths;
+- semantic elements and meaningful wrapper hierarchy;
+- significant Templ/component calls;
+- exact Live Wires class strings controlling layout, spacing, schemes, and
+  components;
+- exact visible headings, labels, helper text, metadata phrasing, and action
+  order;
+- responsive and interaction decisions;
+- source evidence status and rendered evidence status; and
+- named intentional differences with their requirement or boundary.
+
+Keep exact paths, commit, short structural excerpts, and a concrete checklist.
+Do not paste complete mockups or whole templates. Distinguish `source parity`,
+`rendered parity`, `intentional divergence`, `unavailable evidence`, and
+`no prototype counterpart` rather than collapsing them into one verdict.
+
+## Authority and permitted divergence
+
+Where the prototype covers the surface, its settled structure, Live Wires
+classes, component choices, literal copy, hierarchy, and control placement are
+primary. Generic product benchmarks and design heuristics are secondary and
+must not redesign those decisions merely because Stripe, Linear, Notion, or
+another product chose differently.
+
+This authority is not a byte-for-byte port. Preserve and name required
+differences for dynamic IDs and values, URLs, authentication and CSRF,
+authorization, public component APIs, production data, Baseplate/Fixture host
+composition, Templ implementation details, and accessibility improvements.
+Never weaken functionality, authorization, accessibility, security, or Fixture
+boundaries to imitate the prototype. Theme variables and exact colors may
+differ when the structural scheme is equivalent.
+
+## Complementary source and browser proof
+
+Compare prototype and target renders at matching meaningful routes, states,
+and viewports. Capture only affected-surface evidence: screenshots,
+accessibility/DOM snapshots, targeted hierarchy, actual class lists, visible
+copy and action order, and computed layout/spacing properties when they explain
+a mismatch. Do not require global DOM equality, pixel identity, or equal CSS
+variable/color values.
+
+Source and browser proof are both required for a declared counterpart:
+screenshots cannot prove source hierarchy, components, classes, or literal
+copy; source cannot prove resulting spacing, composition, interaction, or
+responsive behavior. Matching class names never waive browser comparison, and
+a close screenshot never waives source comparison.
+
+In T3 Code, use the collaborative preview first: inspect status, open it when
+needed, then navigate and capture the matched cases. Follow the existing
+browser recovery ladder before any supported fallback. Curl, a target-only
+screenshot, or `looks close` never completes required prototype browser proof.
+If the prototype render is temporarily unavailable, preserve completed source
+work and report rendered parity `human_help_required`; do not claim rendered
+parity complete.
+
+## Findings and completion
+
+Classify observable defects by impact:
+
+- **P1:** primary task blocked, misleading authorization or governance
+  consequence, inaccessible essential control, or an explicitly critical
+  parity requirement broken;
+- **P2:** meaningful structure, component, copy, control-placement,
+  responsive, or interaction mismatch that creates confusion or rework;
+- **P3:** minor spacing, alignment, metadata formatting, or
+  class/presentation drift.
+
+Severity is proportional, never automatic. Every supported P1, P2, and P3
+still enters the fix queue and must be rechecked before clean completion.

--- a/plugins/pipeline/references/validate-role-manifest.sh
+++ b/plugins/pipeline/references/validate-role-manifest.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 [ "$#" -eq 1 ] && [ -r "$1" ] || { printf '%s\n' 'usage: validate-role-manifest.sh MANIFEST' >&2; exit 2; }
 jq -e '
+  . as $manifest |
   type == "object" and
   (.feature | type == "string" and length > 0) and
   (.workflowClass | IN("chore","bug","feature","hotfix","security","investigation","migration")) and
@@ -21,6 +22,30 @@ jq -e '
   (.finalReviewRationale | type == "string" and length > 0) and
   (.finalReviewMode != "quick" or .decisionProfile.consequence != "high") and
   (.chunks | type == "array" and length > 0) and
+  ((has("prototypeParity") | not) and
+    (if has("prototypeReference") then
+      (.prototypeReference | type == "object" and
+        (keys | sort) == (["status","canonicalRepository","commit","authoritySource","prototypeSourceFiles","targetSourceFiles","matchedCases","intentionalDifferences"] | sort) and
+        (.status | IN("counterpart","no_counterpart")) and
+        (.canonicalRepository | type == "string" and length > 0 and (startswith("/") | not)) and
+        (.commit | type == "string" and test("^[0-9a-f]{40}$")) and
+        (.authoritySource | type == "string" and length > 0) and
+        (.prototypeSourceFiles | type == "array" and length > 0 and length == (unique | length) and all(.[]; type == "string" and length > 0)) and
+        (.targetSourceFiles | type == "array" and length == (unique | length) and all(.[]; type == "string" and length > 0)) and
+        (.matchedCases | type == "array" and length == (unique | length) and all(.[];
+          type == "object" and
+          (keys | sort) == (["prototypeRoute","targetRoute","state","viewports"] | sort) and
+          (.prototypeRoute | type == "string" and length > 0) and
+          (.targetRoute | type == "string" and length > 0) and
+          (.state | type == "string" and length > 0) and
+          (.viewports | type == "array" and length > 0 and length == (unique | length) and all(.[]; type == "number" and floor == . and . > 0)))) and
+        (.intentionalDifferences | type == "array" and length == (unique | length) and all(.[]; type == "string" and length > 0)) and
+        (if .status == "counterpart" then
+          (.targetSourceFiles | length > 0) and (.matchedCases | length > 0)
+        else
+          (.targetSourceFiles | length == 0) and (.matchedCases | length == 0)
+        end))
+    else true end)) and
   ([paths(scalars) as $path
     | select($path[-1] == "executor" or $path[-1] == "model"
       or $path[-1] == "provider" or $path[-1] == "transport")]
@@ -42,6 +67,33 @@ jq -e '
     (.companionSkills | type == "array" and all(.[]; type == "string" and length > 0)) and
     (.estimatedComplexity | IN("low","medium","high")) and
     (.executor? == null) and (.model? == null) and (.provider? == null) and (.transport? == null) and
+    (.prototypeReference? == null) and
+    (if has("prototypeParity") then
+      ($manifest.prototypeReference.status == "counterpart") and
+      (.renderedSurface == "required") and
+      (.prototypeParity | type == "array" and length > 0 and all(.[];
+        type == "object" and
+        (keys | sort) == (["surface","prototypeSourcePaths","targetSourcePaths","prototypeRoute","targetRoute","state","viewports","sourceDecisions","sourceEvidenceStatus","renderedEvidenceStatus","intentionalDifferences"] | sort) and
+        (.surface | type == "string" and length > 0) and
+        (.prototypeSourcePaths | type == "array" and length > 0 and length == (unique | length) and all(.[]; type == "string" and length > 0 and IN($manifest.prototypeReference.prototypeSourceFiles[]) )) and
+        (.targetSourcePaths | type == "array" and length > 0 and length == (unique | length) and all(.[]; type == "string" and length > 0 and IN($manifest.prototypeReference.targetSourceFiles[]) )) and
+        (.prototypeRoute | type == "string" and length > 0) and
+        (.targetRoute | type == "string" and length > 0) and
+        (.state | type == "string" and length > 0) and
+        (.viewports | type == "array" and length > 0 and length == (unique | length) and all(.[]; type == "number" and floor == . and . > 0)) and
+        (. as $parity | any($manifest.prototypeReference.matchedCases[];
+          .prototypeRoute == $parity.prototypeRoute and
+          .targetRoute == $parity.targetRoute and
+          .state == $parity.state and
+          .viewports == $parity.viewports)) and
+        (.sourceDecisions | type == "object" and
+          (keys | sort) == (["structure","classes","copy","actions"] | sort) and
+          all(.[]; type == "array" and length == (unique | length) and all(.[]; type == "string" and length > 0))) and
+        (.sourceEvidenceStatus | IN("pending","complete","unavailable")) and
+        (.renderedEvidenceStatus | IN("pending","complete","unavailable")) and
+        (.intentionalDifferences | type == "array" and length == (unique | length) and all(.[];
+          type == "string" and length > 0 and IN($manifest.prototypeReference.intentionalDifferences[]) ))))
+    else true end) and
     ((.routingOverride? // {}) | type == "object" and
       (keys - ["executorRole","executorCapabilities","executorEffort","reasonCode","reason"] | length) == 0 and
       (if length == 0 then true else
@@ -53,4 +105,13 @@ jq -e '
           (.executorCapabilities | type == "array" and length > 0 and length == (unique | length) and
             all(.[]; IN("read-repository","write-repository","tool-use","browser","long-context","structured-output","independent-family"))))
        end))
-  )' "$1" >/dev/null
+  ) and
+  (if has("prototypeReference") then
+    if .prototypeReference.status == "counterpart" then
+      any(.chunks[]; (.prototypeParity? | type == "array" and length > 0))
+    else
+      all(.chunks[]; has("prototypeParity") | not)
+    end
+  else
+    all(.chunks[]; has("prototypeParity") | not)
+  end)' "$1" >/dev/null

--- a/plugins/pipeline/references/visual-verification-protocol.md
+++ b/plugins/pipeline/references/visual-verification-protocol.md
@@ -5,7 +5,9 @@ Loaded at orchestrator Step 3h only for a chunk with
 
 #### Step 1: Design Spec Discovery
 
-Before taking screenshots, check for design specifications:
+Before taking screenshots, load `prototype-authority.md` when the chunk carries
+a declared prototype counterpart. Its exact source and bounded parity map are
+the primary baseline. Then check for additional local design specifications:
 
 1. `plans/<feature-slug>/brainstorm.html` -- pipeline brainstorm output (read the `visualDecisions` island with `${CLAUDE_PLUGIN_ROOT}/plugins/pipeline/skills/promptcraft/references/templates/extract-json-island.sh`)
 2. `docs/superpowers/specs/*.md` -- formal design specs (use most recent)
@@ -20,7 +22,7 @@ If found, read the spec and extract visual decisions relevant to this chunk's fi
 
 Store these as the **chunk's visual baseline** for evaluation in steps 4 and 5.
 
-#### Step 2: Page-Level Screenshots
+#### Step 2: Matched Page-Level Evidence
 
 1. Detect the dev server URL (try `http://localhost:8080`, `http://localhost:3000`, project-specific URLs)
 2. Navigate to each route affected by this chunk's `filesToModify` list
@@ -28,6 +30,13 @@ Store these as the **chunk's visual baseline** for evaluation in steps 4 and 5.
 4. Verify the page loads without errors (check `browser_console_messages` for errors)
 5. For interactive elements (forms, buttons, modals), click/hover to verify they respond
 6. If the project declares UX personas/tasks, execute every selected case from the verification profile at its declared engine and viewport. Do not fabricate personas or silently sample only two.
+
+For a declared counterpart, navigate prototype and target at the same
+meaningful routes, states, and viewports. Capture affected screenshots,
+accessibility/DOM snapshots, targeted hierarchy, actual class lists, visible
+copy/action order, and only the computed layout/spacing values needed to explain
+a mismatch. Use T3 collaborative preview first in T3 Code. A target-only
+screenshot, curl, or `looks close` is incomplete prototype evidence.
 
 #### Step 3: Element-Level Screenshots
 
@@ -50,7 +59,9 @@ Visual Spec Check:
 - Spec: "Natural-width buttons, not full-width" -> MATCH / MISMATCH (actual: [describe])
 ```
 
-Spec deviations are P1 findings -- the implementation does not match the approved design. Add them to the review fix queue.
+Classify prototype/spec deviations by observable impact per
+`prototype-authority.md`; do not make every mismatch P1. Add every supported
+P1/P2/P3 to the review fix queue.
 
 #### Step 5: Visual Evaluation Against Acceptance Criteria
 
@@ -87,7 +98,12 @@ When the chunk's acceptance criteria include a parity requirement ("visually ide
    PARITY MISMATCH: font-weight -- reference: 400, target: 700
    PARITY MISMATCH: background-color -- reference: rgb(240,248,240), target: rgb(220,240,220)
    ```
-4. **Severity:** Parity mismatches are **P1 findings** when the user explicitly requested visual identity. These are not optional polish.
+4. **Severity:** Use proportional observable impact: P1 for blocked primary
+   work, misleading authorization/governance consequences, inaccessible
+   essential controls, or explicitly critical parity; P2 for meaningful
+   structural/component/copy/placement/responsive/interaction drift; P3 for
+   minor spacing, alignment, metadata, or presentation drift. Severity never
+   permits deferral.
 5. **Unavailable evaluation:** If `browser_evaluate` cannot run, preserve the failed attempt and run the same primary-quit, fresh-primary, different-browser recovery ladder. If still unavailable, emit blocked `human_help_required`, ask the user for help, and stop. Never skip or defer a required parity diff.
 
 **Baseline comparison:** If `plans/<feature-slug>/baselines/` exists (created by the assess phase), also compare post-implementation screenshots against the baseline:
@@ -95,6 +111,20 @@ When the chunk's acceptance criteria include a parity requirement ("visually ide
 1. Take a new screenshot of the same route/viewport as each baseline file
 2. Note visual differences between baseline and current state
 3. Expected differences (the feature being built) are fine; unexpected regressions are P2 findings
+
+#### Step 5c: Prototype source comparison (when applicable)
+
+Re-read the affected prototype and target source after editing. Compare the
+bounded parity map's semantic/wrapper hierarchy, significant components, exact
+Live Wires class strings, literal copy/metadata, and action order. Record named
+intentional divergences for functionality, authorization, accessibility,
+public APIs, production data, and host/Fixture composition. A matching
+screenshot cannot complete this step, just as matching source cannot complete
+the browser step.
+
+If the prototype render is temporarily unavailable after the recovery ladder,
+preserve completed source work but return `human_help_required` for rendered
+parity. Do not substitute target-only evidence or claim completion.
 
 #### Step 6: Verification Receipt
 
@@ -104,7 +134,14 @@ After completing all checks, output this structured receipt:
 BROWSER_VERIFIED: [chunk-id] | screenshots: [N] | element_screenshots: [N] | spec_checks: [N passed]/[N total] | visual_criteria: [N passed]/[N total] | issues: [list or "none"]
 ```
 
-Report all findings as P1 (spec deviation, page doesn't load), P2 (visual criterion failure, console errors, broken interactions), or P3 (observable minor visual defect). Add every retained finding to the review fix queue. Reject taste-only preferences that lack an observable defect.
+Classify every finding by observable impact under `prototype-authority.md`: P1
+only for a blocked primary task, misleading authorization/governance
+consequence, inaccessible essential control, or explicitly critical parity; P2
+for meaningful structure, component, copy, placement, responsive, or
+interaction failure; P3 for minor spacing, alignment, metadata, class, or
+presentation drift. A page-load failure takes the severity supported by its
+actual task impact. Add every retained P1/P2/P3 to the review fix queue and
+reject taste-only preferences without an observable defect.
 
 For required browser-tooling failure, first persist safe attempt evidence, then quit the primary browser process/engine session (closing a tab is insufficient), launch a fresh primary profile with a changed session identity and retry once, then recheck the target and try a genuinely different configured engine. If restart or alternate launch cannot be proved, record that explicitly. Exhaustion ends `human_help_required` with all attempts and exact missing case IDs; it is never skipped, approved, empty coverage, or curl-verified. Product/application assertion failures are terminal findings and do not trigger browser restart. Curl and reachability are diagnostics only and never satisfy `BROWSER_VERIFIED`.
 
@@ -127,4 +164,3 @@ recovered alternate-engine pass remains degraded recovery evidence, not
 first-pass clean.
 
 Mark `[chunk-id] 8. Run visual verification` complete only with complete required evidence. Otherwise mark it `blocked: human_help_required` and stop for user help; never mark it skipped or deferred.
-

--- a/plugins/pipeline/skills/assess/SKILL.md
+++ b/plugins/pipeline/skills/assess/SKILL.md
@@ -71,6 +71,15 @@ Produce a file list of 5-20 key files to examine. Prioritize:
 - Configuration
 - Tests
 
+For rendered work, resolve declared prototype authority before target UX
+evaluation. Load `plugins/pipeline/references/prototype-authority.md` when its
+conditional trigger applies. Read the exact prototype templates/components
+first and produce only the affected-surface `prototypeReference` and
+`prototypeParity` map defined there. Conflicting or unresolved repository,
+commit, route, or authority declarations stop UI implementation with
+`human_help_required`; a source-proven missing counterpart is recorded and
+falls back to existing production patterns.
+
 ### Phase 2: Parallel Assessment
 
 Launch two agents simultaneously:
@@ -121,10 +130,16 @@ Run discovery whenever the feature is UI/integration work. Execute browser proof
 when a dev server is detected or a URL is provided. Read
 `references/ux-assessment-protocol.md` for the full protocol. In summary:
 
-- Use Playwright MCP tools to navigate and screenshot the affected area
+- In T3 Code, use collaborative preview first; otherwise use configured
+  Playwright MCP tools and the existing recovery fallback
 - Evaluate: visual hierarchy, spacing, typography, interaction states, responsiveness
 - Apply the same UX principles as dm-review's ux-quality-reviewer
 - Check at 3 viewports: mobile (375px), tablet (768px), desktop (1440px)
+
+When a declared counterpart exists, capture prototype and target evidence at
+matching routes, states, and viewports. Source inspection and browser evidence
+are complementary; neither a target-only screenshot nor matching class names
+completes parity. Use T3 collaborative preview first when running in T3 Code.
 
 Produce a **Current UX Report** covering:
 - Screenshots at each viewport
@@ -178,7 +193,7 @@ Intake and Project Alignment, rewrites the `keyRequirements` island with the
 approved scope, and makes that cache authoritative. Before then the island is
 provisional even though the file exists.
 
-The brief is written as **HTML with a JSON data island**, not markdown -- assemble `templates/base.html` + `templates/sections/assessment.html` per `${CLAUDE_PLUGIN_ROOT}/plugins/pipeline/skills/promptcraft/references/templates/README.md`. The content outline below maps to the section's slots; the `keyRequirements`, `testPersonas`, `recentLessons`, and `baselineScreenshots` arrays also populate the `#pipeline-data` island so later phases read them with `extract-json-island.sh` instead of grepping prose.
+The brief is written as **HTML with a JSON data island**, not markdown -- assemble `templates/base.html` + `templates/sections/assessment.html` per `${CLAUDE_PLUGIN_ROOT}/plugins/pipeline/skills/promptcraft/references/templates/README.md`. The content outline below maps to the section's slots; the `keyRequirements`, `testPersonas`, `recentLessons`, and `baselineScreenshots` arrays also populate the `#pipeline-data` island so later phases read them with `extract-json-island.sh` instead of grepping prose. When prototype authority applies, add the compact optional `prototypeReference` object and affected-surface `prototypeParity` collection from `prototype-authority.md`; do not add a separate artifact or durable schema.
 
 ```markdown
 # Assessment: [Area Name]
@@ -210,6 +225,11 @@ The brief is written as **HTML with a JSON data island**, not markdown -- assemb
 ## UX State
 [From UX Assessment agent; use "Skipped" only for no UI/integration surface.
 For an unavailable required target, record blocked `human_help_required`.]
+
+## Prototype Parity
+[Source-first parity map for affected counterparts, including matched browser
+evidence and intentional differences; otherwise "No prototype counterpart"
+with inspected evidence, or "No declared prototype".]
 
 ## Test Personas
 [From Fixture Discovery, or "No dev-mode auth bypass detected."]
@@ -253,9 +273,11 @@ pause. If running standalone via `/pipeline-assess`, present it and stop.
 
 ## Graceful Degradation
 
-- No Playwright MCP: discovery may continue, but required UI/integration browser
-  coverage is blocked. Follow the shared recovery ladder and return
-  `human_help_required`; never mark required proof skipped or curl-verified.
+- No browser transport: when neither T3 collaborative preview in T3 Code nor a
+  configured fallback browser is available after the shared recovery ladder,
+  discovery may continue but required UI/integration browser coverage is
+  blocked. Return `human_help_required`; never mark required proof skipped or
+  curl-verified. Missing Playwright alone is not blocking when T3 preview works.
 - Optional personal sources: detect them only from callable-tool inventory or
   tool search. If ai-memory is not callable, omit the lookup and any mention of
   its absence; repository history still supplies the project-history evidence.

--- a/plugins/pipeline/skills/assess/references/ux-assessment-protocol.md
+++ b/plugins/pipeline/skills/assess/references/ux-assessment-protocol.md
@@ -18,7 +18,11 @@ Check for a running dev server:
 1. Try common ports: 8080, 3000, 4000, 5173, 1313
 2. Check for `docker compose` services
 3. Look for `Procfile`, `Makefile`, or scripts that start dev servers
-4. If no server found, skip UX assessment with note
+4. If no server is found and a declared prototype counterpart or another
+   approved requirement makes rendered evidence mandatory, preserve completed
+   source evidence and return `human_help_required` naming the unavailable
+   prototype or target render. Otherwise skip UX assessment with a note for
+   genuinely non-rendered scope.
 
 ## Step 1: Navigate to Affected Area
 

--- a/plugins/pipeline/skills/assess/references/ux-assessment-protocol.md
+++ b/plugins/pipeline/skills/assess/references/ux-assessment-protocol.md
@@ -1,10 +1,15 @@
 # UX Assessment Protocol
 
-Browser-based evaluation of current UX state using Playwright MCP tools. Evaluates what exists now, not what changed.
+Browser-based evaluation of current UX state. In T3 Code, use the collaborative
+preview first; otherwise use the configured browser tools and existing recovery
+fallbacks. Evaluate what exists now, not what changed.
 
 ## Prerequisites
 
-- Playwright MCP tools available (primary: `mcp__plugin_compound-engineering_pw__browser_*`, fallback: `mcp__plugin_playwright_playwright__browser_*`)
+- T3 collaborative preview available in T3 Code, or configured Playwright MCP
+  tools elsewhere (primary:
+  `mcp__plugin_compound-engineering_pw__browser_*`, fallback:
+  `mcp__plugin_playwright_playwright__browser_*`)
 - Dev server running and accessible
 
 ### Dev Server Detection
@@ -21,6 +26,12 @@ Check for a running dev server:
 2. If the area has multiple pages, prioritize: index/list page, detail/show page, form/create page
 3. Wait for full page load (no pending network requests)
 
+When the assessment carries a declared prototype counterpart, load
+`plugins/pipeline/references/prototype-authority.md`. Navigate prototype and
+target route/state pairs at the same viewports after the exact prototype source
+has been inspected. Record unavailable prototype rendering separately from
+target availability; never substitute a target-only capture.
+
 ## Step 2: Viewport Screenshots
 
 Capture screenshots at three breakpoints:
@@ -33,6 +44,11 @@ For each viewport, take a full-page screenshot and note:
 - Does the layout adapt properly?
 - Is content readable at this size?
 - Are touch targets adequate on mobile (min 44x44px)?
+
+For a matched counterpart, also capture the affected element hierarchy, actual
+class lists, visible copy/action order, and only the computed layout/spacing
+properties needed to explain a mismatch. Exact colors and CSS variables may
+differ when the project theme intentionally differs.
 
 ## Step 3: Visual Hierarchy Assessment
 

--- a/plugins/pipeline/skills/promptcraft/SKILL.md
+++ b/plugins/pipeline/skills/promptcraft/SKILL.md
@@ -124,9 +124,25 @@ during decomposition.
 
 ### Phase 2.5: Visual Reference Extraction
 
-For chunks with `renderedSurface: required`, check for brainstorm outputs that define the approved visual design: read the `visualDecisions` island of `plans/<feature-slug>/brainstorm.html` with `references/templates/extract-json-island.sh`, and check `.superpowers/brainstorm/` for HTML mockups (styling decisions as inline styles). If found, extract a **Visual Reference Summary** -- key styling decisions (component variants, tokens, layout patterns), visual hierarchy, and the specific visual treatments called out in the approved design -- plus the mockup file PATH. Extract decisions, not markup: do NOT embed full HTML mockups in prompts.
+For chunks with `renderedSurface: required`, first read any applicable
+`prototypeReference` and `prototypeParity` entries from the assessment/plan
+island. Load `plugins/pipeline/references/prototype-authority.md` when a declared
+counterpart exists. Then check for brainstorm outputs that define additional
+approved visual design: read the `visualDecisions` island of
+`plans/<feature-slug>/brainstorm.html` with
+`references/templates/extract-json-island.sh`, and check
+`.superpowers/brainstorm/` for HTML mockups (styling decisions as inline
+styles).
 
-This summary feeds each rendered-surface chunk's prompt as a `## Visual References` section and shapes `### Visual Acceptance Criteria`.
+Extract a **Visual Reference Summary** plus paths. Do not paste complete
+mockups or whole templates, but retain the exact short structural excerpts,
+component calls, Live Wires class strings, literal copy, metadata phrasing, and
+action order needed to prevent drift. For every chunk with a counterpart,
+carry the canonical prototype repository and exact commit, relevant prototype
+source files under `Files to Read`, prototype/target route-state-viewports,
+intentional differences, and both source and browser acceptance criteria.
+This summary feeds each rendered-surface chunk's prompt as a
+`## Visual References` section and shapes `### Visual Acceptance Criteria`.
 
 ### Phase 3: Overlap Analysis
 
@@ -177,6 +193,15 @@ Applies only when the chunk is an Assembly mutation, or actually alters authenti
 ### Phase 3i: Visual Acceptance Criteria Gate
 
 Applies only to chunks with `renderedSurface: required`; load `plugins/pipeline/references/promptcraft-applicability-gates.md` for the rendered-impression bar and the shared-component Visual Parity Criterion. A chunk marked `not_applicable` must not fabricate rendered impressions.
+
+When a prototype counterpart applies, acceptance criteria also require the
+builder to inspect prototype source before editing; search existing target and
+Live Wires components before creating one; preserve settled hierarchy,
+wrappers, classes, copy, action order, and control placement unless a named
+approved requirement requires divergence; compare source after editing; compare
+matched renders; and record intentional production differences rather than
+silently redesigning. Matching screenshots never waive source comparison, and
+matching classes never waive browser comparison.
 
 ### Phase 3j: UX Task Selection Gate
 
@@ -249,6 +274,11 @@ Missing, ambiguous, malformed, multiple, or conflicting plan data blocks
 generation and returns to the user gate.
 
 Each chunk object in the manifest MUST include `kind`, `renderedSurface`, `renderedSurfaceRationale`, `executorRole`, `executorCapabilities`, and `executorEffort` fields (classified independently in Phase 1, step 7). An approved deviation carries the closed `routingOverride` object described in Phase 1. The manifest encodes chunk ordering and dependencies, parallel groups, overlap analysis results, feature branch naming, branch creation or exact-head reuse semantics, execution metadata, and the approved workflow-class, decision-profile, final-review-mode, and rendered-surface controls.
+
+When prototype authority applies, copy the compact optional
+`prototypeReference` and only each chunk's relevant `prototypeParity` entries
+into the manifest. These are projections of the existing assessment/plan data
+island, not a new registry or evidence store.
 
 ### Phase 6: Requirements Coverage Check
 

--- a/plugins/pipeline/skills/promptcraft/references/manifest-schema.md
+++ b/plugins/pipeline/skills/promptcraft/references/manifest-schema.md
@@ -78,15 +78,81 @@ this field or weaken its browser/persona evidence.
 
 ## Optional Declared Prototype Context
 
-When a declared prototype covers a rendered chunk, the manifest carries the
-compact `prototypeReference` resolved during assessment and the chunk's
-relevant `prototypeParity` collection. They retain canonical repository + exact
-commit, authority source, relevant prototype/target files and route-state-
-viewport pairs, concise structural/class/copy/action decisions, evidence
-status, and intentional differences. They never embed complete templates or
-create a durable registry. Conflicting references block UI implementation;
-source-proven absence records `no prototype counterpart` and uses existing
-production patterns.
+When a prototype is declared, the manifest carries exactly one top-level
+`prototypeReference`. A counterpart-covered rendered chunk carries its own
+non-empty `prototypeParity` array; `prototypeReference` is forbidden inside a
+chunk and `prototypeParity` is forbidden at the top level. Both objects are
+closed shapes validated by `validate-role-manifest.sh`.
+
+```json
+{
+  "prototypeReference": {
+    "status": "counterpart",
+    "canonicalRepository": "Design-Machines-Studio/assembly",
+    "commit": "0123456789abcdef0123456789abcdef01234567",
+    "authoritySource": "current PR",
+    "prototypeSourceFiles": ["prototype/templates/positions.html"],
+    "targetSourceFiles": ["internal/positions/index.templ"],
+    "matchedCases": [
+      {
+        "prototypeRoute": "/prototype/positions",
+        "targetRoute": "/positions",
+        "state": "default",
+        "viewports": [375, 1440]
+      }
+    ],
+    "intentionalDifferences": ["Production keeps its authenticated shell."]
+  },
+  "chunks": [
+    {
+      "id": "01-positions-ui",
+      "renderedSurface": "required",
+      "prototypeParity": [
+        {
+          "surface": "positions index",
+          "prototypeSourcePaths": ["prototype/templates/positions.html"],
+          "targetSourcePaths": ["internal/positions/index.templ"],
+          "prototypeRoute": "/prototype/positions",
+          "targetRoute": "/positions",
+          "state": "default",
+          "viewports": [375, 1440],
+          "sourceDecisions": {
+            "structure": ["Heading precedes the position list."],
+            "classes": ["cluster cluster--spread"],
+            "copy": ["Positions"],
+            "actions": ["Create position is the first action."]
+          },
+          "sourceEvidenceStatus": "complete",
+          "renderedEvidenceStatus": "pending",
+          "intentionalDifferences": ["Production keeps its authenticated shell."]
+        }
+      ]
+    }
+  ]
+}
+```
+
+| Field | Contract |
+|---|---|
+| `prototypeReference.status` | Required enum: `counterpart` or `no_counterpart`. |
+| `canonicalRepository` | Required non-empty canonical remote identity, never a workstation path. |
+| `commit` | Required exact 40-character lowercase Git commit. |
+| `authoritySource` | Required non-empty source of the declaration. |
+| `prototypeSourceFiles` | Required non-empty unique list of inspected prototype paths. |
+| `targetSourceFiles` | Unique target paths; non-empty for `counterpart`. |
+| `matchedCases` | Closed route/state/viewport objects; non-empty for `counterpart` and empty for `no_counterpart`. |
+| `intentionalDifferences` | Unique concise approved differences; may be empty. |
+| `chunks[].prototypeParity` | Closed affected-surface items. Allowed only on `renderedSurface: required` chunks when status is `counterpart`; every route/state/viewport tuple and source path must agree with the top-level reference. |
+
+Each parity item requires non-empty prototype and target source paths, matched
+routes/state/viewports, closed `sourceDecisions` arrays for `structure`,
+`classes`, `copy`, and `actions`, `sourceEvidenceStatus` and
+`renderedEvidenceStatus` from `pending|complete|unavailable`, plus a unique
+intentional-differences list. A `counterpart` reference requires at least one
+chunk parity item. A source-proven `no_counterpart` reference requires empty
+target files and matched cases and forbids chunk parity. When no prototype was
+declared, omit both fields. These compact objects never embed complete
+templates or create a durable registry.
 
 ## Role fields
 

--- a/plugins/pipeline/skills/promptcraft/references/manifest-schema.md
+++ b/plugins/pipeline/skills/promptcraft/references/manifest-schema.md
@@ -76,6 +76,18 @@ include a planning/report `.html` artifact that is never mounted by the product
 and a non-HTTP CLI `main.go` with no rendered output. Role routing cannot change
 this field or weaken its browser/persona evidence.
 
+## Optional Declared Prototype Context
+
+When a declared prototype covers a rendered chunk, the manifest carries the
+compact `prototypeReference` resolved during assessment and the chunk's
+relevant `prototypeParity` collection. They retain canonical repository + exact
+commit, authority source, relevant prototype/target files and route-state-
+viewport pairs, concise structural/class/copy/action decisions, evidence
+status, and intentional differences. They never embed complete templates or
+create a durable registry. Conflicting references block UI implementation;
+source-proven absence records `no prototype counterpart` and uses existing
+production patterns.
+
 ## Role fields
 
 | Field | Contract |

--- a/plugins/pipeline/skills/promptcraft/references/prompt-template.md
+++ b/plugins/pipeline/skills/promptcraft/references/prompt-template.md
@@ -36,6 +36,11 @@ Do not paste the full roadmap, assessment, research brief, or Project snapshot.]
 | path/to/similar.go | Follow this handler's pattern |
 | path/to/types.go | DTO definitions to reuse |
 
+[For a declared prototype counterpart, list every relevant prototype template
+or component here with its canonical repository and exact commit. Paths may be
+resolved in a temporary/available checkout, but never hardcode a permanent
+workstation path.]
+
 ## Patterns to Follow
 
 [Specific patterns extracted from the assessment. Include actual code snippets where helpful.]
@@ -56,12 +61,25 @@ Load these skills for domain-specific guidance:
 
 Approved design: [path to brainstorm.html or mockup file]
 
+Prototype authority (when applicable):
+- Repository + exact commit: [canonical identity @ commit]
+- Authority source: [user, Issue/PR, root instructions, plan, or Assembly skill]
+- Prototype -> target cases: [route, state, viewport pairs]
+- Relevant source: [paths and concise structural excerpts]
+- Intentional differences: [approved production constraints]
+
 Key visual decisions:
 - [Decision 1: e.g., "Sidebar headings use h4 with font-medium, not h3"]
 - [Decision 2: e.g., "Block/Abstain buttons use button--outline-danger, visually smaller than position buttons"]
 - [Decision 3: e.g., "Natural-width buttons, not full-width"]
 
 The rendered result must match these visual treatments. If you cannot determine the visual intent from these descriptions, read the mockup file at the path above.
+
+When the prototype covers this surface, it is primary. Inspect its exact source
+before editing, then search existing target and Live Wires components before
+creating anything. Preserve its settled structure, class vocabulary, copy,
+action order, and control placement unless an approved requirement names a
+divergence. Generic SaaS heuristics cannot redesign a settled prototype choice.
 
 ## Acceptance Criteria
 
@@ -79,6 +97,18 @@ The rendered result must match these visual treatments. If you cannot determine 
 - [ ] [E.g., "Sidebar headings create a clear hierarchy -- h4 muted style, not competing with page heading"]
 
 Visual criteria describe the IMPRESSION, not the implementation. "Uses button--outline-danger" is structural. "Block button is visually subordinate to the Accept button" is visual. Include both types.
+
+For a declared prototype counterpart, include both kinds of parity proof:
+
+- [ ] Source comparison confirms the significant semantic/wrapper hierarchy,
+  component calls, exact Live Wires class strings, visible copy/metadata, and
+  action order, with every intentional difference named and justified.
+- [ ] Browser comparison covers prototype and target at matching routes,
+  states, and viewports with screenshots plus targeted DOM/accessibility/class
+  and computed layout evidence. Do not require global DOM, pixel, theme-token,
+  or exact-color equality.
+- [ ] If the prototype render is unavailable after browser recovery, preserve
+  source work and return `human_help_required`; do not claim rendered parity.
 
 ## Tool-Call Exploration Checkpoint & Delivery Contract
 
@@ -114,6 +144,11 @@ If the Task or Acceptance Criteria allow more than one reasonable interpretation
   of the diff; report them as "Noted, not fixed."
 - Do not reformat, rewrite comments, tighten types, or adjust imports on lines you are not otherwise changing for this chunk.
 - Do not create or modify `*_templ.go` files. Run `docker compose exec app templ generate` to regenerate them after editing `.templ` source files.
+- For a declared prototype counterpart, inspect the exact prototype source
+  before editing and compare both source and matched renders after editing.
+  Required functionality, authorization, accessibility, public APIs,
+  production data, and Baseplate/Fixture boundaries override imitation and
+  must be recorded as intentional differences.
 - When adding database migrations, verify the next sequence number: `ls migrations/*.sql | sort | tail -1`. Use the next consecutive number.
 - When this chunk actually changes authentication, middleware, an Authorizer action/resource, a privileged read/write, a role/member/account/install/module permission, or a privileged UI capability in Assembly code, the final acceptance criterion must include an Auth Boundary Map receipt covering: surfaces mapped, middleware gates, Authorizer action/resource pairs, default-deny UI capabilities, stale-session/operator/install edge cases, test coverage, and residual risk. A matching path name is a review hint, not proof of a boundary change.
 - [Any additional constraints specific to this chunk]

--- a/tests/test_workflow_contracts_validator.py
+++ b/tests/test_workflow_contracts_validator.py
@@ -1,0 +1,74 @@
+import shutil
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+VALIDATOR = Path("tools/validate-workflow-contracts.sh")
+PROTOTYPE_FILES = (
+    Path("plugins/pipeline/references/prototype-authority.md"),
+    Path("plugins/pipeline/skills/assess/references/ux-assessment-protocol.md"),
+    Path("plugins/pipeline/skills/assess/SKILL.md"),
+    Path("plugins/pipeline/skills/promptcraft/SKILL.md"),
+    Path("plugins/pipeline/skills/promptcraft/references/prompt-template.md"),
+    Path("plugins/pipeline/skills/promptcraft/references/manifest-schema.md"),
+    Path("plugins/pipeline/references/visual-verification-protocol.md"),
+    Path("plugins/pipeline/references/phase7-visual-verification.md"),
+    Path("plugins/dm-review/skills/review/references/design-spec-discovery.md"),
+    Path("plugins/dm-review/skills/review/references/reviewer-prompt-template.md"),
+    Path("plugins/dm-review/skills/review/references/visual-finding-rules.md"),
+    Path("plugins/dm-review/skills/review/references/ui-review-readiness.md"),
+    Path("plugins/dm-review/agents/review/ui-standards-reviewer.md"),
+    Path("plugins/dm-review/agents/review/ux-quality-reviewer.md"),
+    Path("plugins/dm-review/agents/review/visual-browser-tester.md"),
+    Path("plugins/assembly/skills/development/SKILL.md"),
+    Path("plugins/assembly/skills/development/pages.md"),
+)
+
+
+class WorkflowContractsValidatorTests(unittest.TestCase):
+    def fixture(self, directory):
+        destination = Path(directory) / "depot"
+        for relative in (VALIDATOR, *PROTOTYPE_FILES):
+            target = destination / relative
+            target.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(ROOT / relative, target)
+        return destination
+
+    def run_validator(self, root, *arguments):
+        return subprocess.run(
+            (str(root / VALIDATOR), *arguments),
+            cwd=root,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+    def test_focused_prototype_contract_succeeds(self):
+        with tempfile.TemporaryDirectory() as directory:
+            result = self.run_validator(self.fixture(directory), "--prototype-parity")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("Prototype authority contract intact", result.stdout)
+
+    def test_focused_prototype_contract_detects_missing_anchor(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = self.fixture(directory)
+            authority = root / "plugins/pipeline/references/prototype-authority.md"
+            original = authority.read_text()
+            mutated = original.replace("Resolve once, source first", "Resolve source later", 1)
+            self.assertNotEqual(mutated, original)
+            authority.write_text(mutated)
+            result = self.run_validator(root, "--prototype-parity")
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("prototype identity and exact commit", result.stdout)
+
+    def test_unsupported_argument_exits_two_with_usage(self):
+        result = self.run_validator(ROOT, "--unknown")
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("usage:", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/check-dependencies.sh
+++ b/tools/check-dependencies.sh
@@ -275,8 +275,8 @@ for consumer, expected in consumer_floors.items():
 
 pipeline = manifests.get("pipeline")
 dm_review_floor = None if pipeline is None else pipeline.get("pluginDependencies", {}).get("dm-review")
-if dm_review_floor != ">=1.74.0":
-    errors.append("pipeline must require dm-review >=1.74.0")
+if dm_review_floor != ">=1.75.0":
+    errors.append("pipeline must require dm-review >=1.75.0")
 
 if errors:
     for error in errors:

--- a/tools/validate-dm-review-codex-perspective.sh
+++ b/tools/validate-dm-review-codex-perspective.sh
@@ -393,10 +393,10 @@ for zero_deferral_surface in \
   reject_text "$zero_deferral_surface" 'P3 advisories' "${zero_deferral_surface#$REPO_ROOT/} rejects deferred P3 evidence"
   reject_text "$zero_deferral_surface" 'P3 stays advisory' "${zero_deferral_surface#$REPO_ROOT/} rejects clean-with-P3 policy"
 done
-require_text "$REPO_ROOT/plugins/dm-review/.claude-plugin/plugin.json" '"version": "1.74.0"' "canonical dm-review version is 1.74.0"
-require_text "$REPO_ROOT/plugins/dm-review/.codex-plugin/plugin.json" '"version": "1.74.0"' "generated dm-review version is 1.74.0"
-require_text "$REPO_ROOT/plugins/pipeline/.claude-plugin/plugin.json" '"version": "1.61.2"' "canonical Pipeline version is 1.61.2"
-require_text "$REPO_ROOT/plugins/pipeline/.codex-plugin/plugin.json" '"dm-review": ">=1.74.0"' "generated Pipeline dependency floor is current"
+require_text "$REPO_ROOT/plugins/dm-review/.claude-plugin/plugin.json" '"version": "1.75.0"' "canonical dm-review version is 1.75.0"
+require_text "$REPO_ROOT/plugins/dm-review/.codex-plugin/plugin.json" '"version": "1.75.0"' "generated dm-review version is 1.75.0"
+require_text "$REPO_ROOT/plugins/pipeline/.claude-plugin/plugin.json" '"version": "1.62.0"' "canonical Pipeline version is 1.62.0"
+require_text "$REPO_ROOT/plugins/pipeline/.codex-plugin/plugin.json" '"dm-review": ">=1.75.0"' "generated Pipeline dependency floor is current"
 
 printf "Synthesis identity fixtures\n"
 base_id=$(fixture_finding_id \

--- a/tools/validate-provider-neutral-routing.sh
+++ b/tools/validate-provider-neutral-routing.sh
@@ -147,6 +147,26 @@ done < <(find "$ROOT/plugins/pipeline/agents" "$ROOT/plugins/dm-review/agents" "
 # New Pipeline manifests accept roles and reject model/provider keys.
 jq -n '{feature:"fixture",workflowClass:"feature",decisionProfile:{uncertainty:"medium",consequence:"medium",rationale:"Bounded fixture."},renderedSurface:"not_applicable",baseBranch:"main",featureBranch:"feat/fixture",branchMode:"create",expectedFeatureHead:null,finalReviewMode:"full",finalReviewRationale:"Full review for fixture.",chunks:[{id:"a",level:0,title:"Fixture",prompt:"prompts/a.md",kind:"docs",renderedSurface:"not_applicable",renderedSurfaceRationale:"Unserved documentation.",executorRole:"builder-fast",executorCapabilities:["read-repository","write-repository","structured-output"],executorEffort:"medium",filesToModify:["docs/a.md"],dependsOn:[],companionSkills:[],estimatedComplexity:"low"}]}' > "$TMP/valid.json"
 "$ROOT/plugins/pipeline/references/validate-role-manifest.sh" "$TMP/valid.json" || fail 'valid role manifest rejected'
+jq '.renderedSurface="required" |
+  .prototypeReference={status:"counterpart",canonicalRepository:"Design-Machines-Studio/assembly",commit:"0123456789abcdef0123456789abcdef01234567",authoritySource:"current PR",prototypeSourceFiles:["prototype/a.html"],targetSourceFiles:["templates/a.templ"],matchedCases:[{prototypeRoute:"/prototype/a",targetRoute:"/a",state:"default",viewports:[375,1440]}],intentionalDifferences:[]} |
+  .chunks[0].kind="ui" |
+  .chunks[0].renderedSurface="required" |
+  .chunks[0].renderedSurfaceRationale="Declared prototype counterpart." |
+  .chunks[0].prototypeParity=[{surface:"fixture",prototypeSourcePaths:["prototype/a.html"],targetSourcePaths:["templates/a.templ"],prototypeRoute:"/prototype/a",targetRoute:"/a",state:"default",viewports:[375,1440],sourceDecisions:{structure:["Heading precedes content."],classes:["stack"],copy:["Fixture"],actions:["Save is primary."]},sourceEvidenceStatus:"complete",renderedEvidenceStatus:"pending",intentionalDifferences:[]}]' \
+  "$TMP/valid.json" > "$TMP/valid-prototype.json"
+"$ROOT/plugins/pipeline/references/validate-role-manifest.sh" "$TMP/valid-prototype.json" || fail 'valid prototype manifest rejected'
+jq '.prototypeReference={}' "$TMP/valid.json" > "$TMP/invalid.json"
+if "$ROOT/plugins/pipeline/references/validate-role-manifest.sh" "$TMP/invalid.json"; then fail 'malformed prototype reference accepted'; fi
+jq '.chunks[0].prototypeReference=.prototypeReference | del(.prototypeReference)' "$TMP/valid-prototype.json" > "$TMP/invalid.json"
+if "$ROOT/plugins/pipeline/references/validate-role-manifest.sh" "$TMP/invalid.json"; then fail 'chunk-level prototype reference accepted'; fi
+jq 'del(.chunks[0].prototypeParity)' "$TMP/valid-prototype.json" > "$TMP/invalid.json"
+if "$ROOT/plugins/pipeline/references/validate-role-manifest.sh" "$TMP/invalid.json"; then fail 'prototype counterpart without chunk parity accepted'; fi
+jq '.chunks[0].prototypeParity[0].targetRoute="/different"' "$TMP/valid-prototype.json" > "$TMP/invalid.json"
+if "$ROOT/plugins/pipeline/references/validate-role-manifest.sh" "$TMP/invalid.json"; then fail 'conflicting prototype route accepted'; fi
+jq '.prototypeReference.status="no_counterpart" | .prototypeReference.targetSourceFiles=[] | .prototypeReference.matchedCases=[] | del(.chunks[0].prototypeParity)' "$TMP/valid-prototype.json" > "$TMP/valid-no-counterpart.json"
+"$ROOT/plugins/pipeline/references/validate-role-manifest.sh" "$TMP/valid-no-counterpart.json" || fail 'source-proven no-counterpart manifest rejected'
+jq '.chunks[0].prototypeParity=[]' "$TMP/valid-no-counterpart.json" > "$TMP/invalid.json"
+if "$ROOT/plugins/pipeline/references/validate-role-manifest.sh" "$TMP/invalid.json"; then fail 'no-counterpart manifest with chunk parity accepted'; fi
 jq '.chunks[0].provider="example"' "$TMP/valid.json" > "$TMP/invalid.json"
 if "$ROOT/plugins/pipeline/references/validate-role-manifest.sh" "$TMP/invalid.json"; then fail 'provider-bearing manifest accepted'; fi
 for field in feature workflowClass decisionProfile renderedSurface baseBranch featureBranch branchMode expectedFeatureHead finalReviewMode finalReviewRationale; do

--- a/tools/validate-workflow-contracts.sh
+++ b/tools/validate-workflow-contracts.sh
@@ -1,11 +1,13 @@
 #!/usr/bin/env bash
 #
-# validate-workflow-contracts.sh -- Guard the two prose contracts that pipeline
-# and dm-review depend on but that nothing else enforces:
+# validate-workflow-contracts.sh -- Guard the prose contracts that pipeline and
+# dm-review depend on but that nothing else enforces:
 #
-#   1. Repository cleanup contract -- worktree/branch registry, safe-to-delete
+#   1. Prototype authority contract -- source-first resolution, bounded parity,
+#      complementary source/browser proof, and proportional findings.
+#   2. Repository cleanup contract -- worktree/branch registry, safe-to-delete
 #      decision table, feature-branch protection, honest inventory reporting.
-#   2. Datastar-first contract -- Datastar/Datastar Pro before hand-rolled JS,
+#   3. Datastar-first contract -- Datastar/Datastar Pro before hand-rolled JS,
 #      plus the bundle-presence rule that keeps agents from emitting inert
 #      Pro attributes.
 #
@@ -2031,4 +2033,4 @@ if [ "$failures" -ne 0 ]; then
   exit 1
 fi
 
-printf "OK    Workflow contracts intact (repository cleanup, two-gate Pipeline planning/alignment, Datastar-first, Baseplate gates, workflow kernel, pipeline performance, cost-summary emission, routing invariants, configured-key OpenRouter authorization)\n"
+printf "OK    Workflow contracts intact (prototype authority, repository cleanup, two-gate Pipeline planning/alignment, Datastar-first, Baseplate gates, workflow kernel, pipeline performance, cost-summary emission, routing invariants, configured-key OpenRouter authorization)\n"

--- a/tools/validate-workflow-contracts.sh
+++ b/tools/validate-workflow-contracts.sh
@@ -16,6 +16,14 @@
 
 set -euo pipefail
 
+prototype_parity_only=false
+if [ "${1:-}" = "--prototype-parity" ]; then
+  prototype_parity_only=true
+elif [ "$#" -gt 0 ]; then
+  printf "usage: %s [--prototype-parity]\n" "$0" >&2
+  exit 2
+fi
+
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
@@ -197,12 +205,14 @@ assembly_test_runner="$REPO_ROOT/plugins/assembly/agents/workflow/go-test-runner
 assembly_go_tests="$REPO_ROOT/plugins/assembly/agents/workflow/go-test-runner.md"
 assembly_verification_profile="$REPO_ROOT/plugins/assembly/references/repository-verification-profile.example.json"
 assembly_development="$REPO_ROOT/plugins/assembly/skills/development/SKILL.md"
+assembly_pages="$REPO_ROOT/plugins/assembly/skills/development/pages.md"
 assembly_nats_reviewer="$REPO_ROOT/plugins/assembly/agents/review/nats-reviewer.md"
 assembly_nats_skill="$REPO_ROOT/plugins/assembly/skills/nats-jetstream/SKILL.md"
 assembly_workflows="$REPO_ROOT/plugins/assembly/skills/development/workflows.md"
 promptcraft="$REPO_ROOT/plugins/pipeline/skills/promptcraft/SKILL.md"
 promptcraft_contract="$REPO_ROOT/plugins/pipeline/references/promptcraft-behavioral-contract.md"
 assess_skill="$REPO_ROOT/plugins/pipeline/skills/assess/SKILL.md"
+ux_protocol="$REPO_ROOT/plugins/pipeline/skills/assess/references/ux-assessment-protocol.md"
 research_skill="$REPO_ROOT/plugins/pipeline/skills/research/SKILL.md"
 prompt_template="$REPO_ROOT/plugins/pipeline/skills/promptcraft/references/prompt-template.md"
 assessment_template="$REPO_ROOT/plugins/pipeline/skills/promptcraft/references/templates/sections/assessment.html"
@@ -214,6 +224,16 @@ security_mapping="$REPO_ROOT/plugins/dm-review/skills/review/references/severity
 simplicity="$REPO_ROOT/plugins/dm-review/agents/review/code-simplicity-reviewer.md"
 postmortem_schema="$REPO_ROOT/plugins/pipeline/references/run-postmortem-schema.md"
 manifest_schema="$REPO_ROOT/plugins/pipeline/skills/promptcraft/references/manifest-schema.md"
+prototype_authority="$REPO_ROOT/plugins/pipeline/references/prototype-authority.md"
+visual_verification="$REPO_ROOT/plugins/pipeline/references/visual-verification-protocol.md"
+phase7_visual="$REPO_ROOT/plugins/pipeline/references/phase7-visual-verification.md"
+design_spec_discovery="$REPO_ROOT/plugins/dm-review/skills/review/references/design-spec-discovery.md"
+reviewer_prompt="$REPO_ROOT/plugins/dm-review/skills/review/references/reviewer-prompt-template.md"
+visual_finding_rules="$REPO_ROOT/plugins/dm-review/skills/review/references/visual-finding-rules.md"
+ui_readiness="$REPO_ROOT/plugins/dm-review/skills/review/references/ui-review-readiness.md"
+ui_standards="$REPO_ROOT/plugins/dm-review/agents/review/ui-standards-reviewer.md"
+ux_quality="$REPO_ROOT/plugins/dm-review/agents/review/ux-quality-reviewer.md"
+visual_browser="$REPO_ROOT/plugins/dm-review/agents/review/visual-browser-tester.md"
 verification_contract="$REPO_ROOT/plugins/workflow-kernel/skills/workflow-kernel/references/verification-contract.md"
 behavioral_schema="$REPO_ROOT/plugins/workflow-kernel/skills/workflow-kernel/references/behavioral-verification-contract-schema.json"
 quality_pulse_command="$REPO_ROOT/plugins/dm-review/commands/dm-review-quality-pulse.md"
@@ -222,6 +242,65 @@ quality_pulse_profile="$REPO_ROOT/plugins/dm-review/skills/quality-pulse/referen
 quality_pulse_output="$REPO_ROOT/plugins/dm-review/skills/quality-pulse/references/output-contract.md"
 quality_pulse_trust="$REPO_ROOT/plugins/dm-review/skills/quality-pulse/references/trust-boundary.md"
 quality_pulse_degradation="$REPO_ROOT/plugins/dm-review/skills/quality-pulse/references/graceful-degradation.md"
+
+printf "Prototype authority contract:\n"
+require_text "$prototype_authority" "Resolve once, source first" "prototype identity and exact commit resolve before UI work"
+require_text "$prototype_authority" "Conflicting or unresolved repository, commit, route, or" "conflicting and unresolved prototype references stop UI work"
+require_text "$prototype_authority" "no prototype counterpart" "source-proven missing counterparts fall back without invention"
+require_text "$prototype_authority" "source parity" "parity map distinguishes source evidence"
+require_text "$prototype_authority" "rendered parity" "parity map distinguishes rendered evidence"
+require_text "$prototype_authority" "intentional divergence" "parity map preserves approved production differences"
+require_text "$prototype_authority" "T3 Code" "prototype browser proof prefers T3 collaborative preview"
+require_text "$ux_protocol" "In T3 Code, use the collaborative" "assessment protocol selects T3 collaborative preview first"
+require_text "$prototype_authority" "a target-only" "prototype render cannot be replaced by target-only evidence"
+require_text "$prototype_authority" "screenshots cannot prove source hierarchy" "browser and source evidence are complementary"
+require_text "$prototype_authority" "Theme variables and exact colors may" "theme parity avoids exact-color policing"
+require_text "$prototype_authority" "Severity is proportional, never automatic" "prototype mismatches use proportional severity"
+require_text "$prototype_authority" "must be rechecked before clean completion" "all supported P1/P2/P3 remain zero-deferral"
+require_text "$assess_skill" "prototype-authority.md" "assessment loads prototype authority conditionally"
+require_text "$assess_skill" "Read the exact prototype templates/components" "assessment is source-first"
+require_text "$assess_skill" "Conflicting or unresolved repository" "assessment stops on unresolved prototype references"
+require_text "$assess_skill" "Missing Playwright alone is not blocking when T3 preview works" "assessment degradation accepts the preferred T3 transport"
+require_text "$assess_skill" 'prototypeReference' "assessment retains compact prototype identity"
+require_text "$assess_skill" 'prototypeParity' "assessment retains affected-surface parity map"
+require_text "$promptcraft" "exact short structural excerpts" "promptcraft retains bounded structure rather than whole mockups"
+require_text "$promptcraft" 'source files under `Files to Read`' "promptcraft carries exact prototype source into execution"
+require_text "$prompt_template" "Generic SaaS heuristics cannot redesign" "builder prompts subordinate heuristics to settled prototype design"
+require_text "$prompt_template" "Source comparison confirms" "builder prompts require post-edit source comparison"
+require_text "$prompt_template" "Browser comparison covers prototype and target" "builder prompts require matched rendered comparison"
+require_text "$manifest_schema" "Optional Declared Prototype Context" "manifest documents compact optional prototype projection"
+require_text "$visual_verification" "Prototype source comparison" "chunk verification checks source after editing"
+require_text "$visual_verification" "do not make every mismatch P1" "Pipeline removes blanket parity P1"
+require_text "$visual_verification" "A page-load failure takes the severity supported" "verification receipt preserves proportional severity"
+require_text "$phase7_visual" "source-only nor screenshot-only evidence completes prototype parity" "caller verifies both evidence types"
+require_text "$design_spec_discovery" "Prefer caller-provided Pipeline" "dm-review reuses Pipeline prototype context first"
+require_text "$design_spec_discovery" "current native PR/Issue, root instructions" "dm-review discovers exact declarations without Pipeline context"
+require_text "$design_spec_discovery" "external templates/components once at the host" "dm-review host owns external prototype source read"
+require_text "$design_spec_discovery" "heuristics are secondary and cannot recommend different copy" "dm-review benchmarks cannot redesign settled prototype surfaces"
+require_text "$reviewer_prompt" 'prototype_parity_packet' "applicable UI lanes receive bounded prototype context"
+require_text "$visual_finding_rules" "Classify prototype/spec mismatches by observable impact" "dm-review uses proportional parity severity"
+require_text "$ui_readiness" '"One target" applies per readiness state' "existing readiness gate compares exact prototype and target serially"
+require_text "$ui_standards" "Do not judge or replace its copy" "UI standards reviewer preserves settled prototype decisions"
+require_text "$ux_quality" "Generic benchmarks cannot replace covered" "UX reviewer preserves settled prototype decisions"
+require_text "$visual_browser" "never apply blanket P1" "visual browser reviewer uses proportional parity severity"
+require_text "$assembly_development" "Prototype design authority for Baseplate and Fixtures" "Assembly guidance declares prototype design authority"
+require_text "$assembly_development" "search existing production and Live Wires components" "Assembly checks components before invention"
+require_text "$assembly_pages" "Fallback examples only" "generic Assembly page examples cannot override prototype counterparts"
+if [ -e "$REPO_ROOT/.dm/prototype.json" ]; then
+  printf "  FAIL  prototype contract adds no repository registry\n"
+  failures=1
+else
+  printf "  OK    prototype contract adds no repository registry\n"
+fi
+
+if [ "$prototype_parity_only" = true ]; then
+  if [ "$failures" -ne 0 ]; then
+    printf "FIX  restore the missing prototype-authority anchors\n"
+    exit 1
+  fi
+  printf "OK    Prototype authority contract intact\n"
+  exit 0
+fi
 
 printf "Repository cleanup contract:\n"
 
@@ -708,7 +787,7 @@ require_text "$review_skill" "references/selective-lane-allowlist.md" "review re
 require_text "$selective_allowlist" "never relax this equality check to a subset check" "allowlist contract requires exact selected_full_set equality"
 require_text "$selective_allowlist" "Any validation failure discards the entire selective input and dispatches the unfiltered recomputed selected full set. Never drop invalid members and honor the remainder." "allowlist contract fails open without partially honoring invalid input"
 require_text "$REPO_ROOT/plugins/dm-review/.claude-plugin/plugin.json" '"workflow-kernel": ">=0.17.0"' "dm-review requires the exact-owned cleanup kernel release"
-require_text "$REPO_ROOT/plugins/pipeline/.claude-plugin/plugin.json" '"dm-review": ">=1.74.0"' "pipeline requires the exact-owned dm-review release"
+require_text "$REPO_ROOT/plugins/pipeline/.claude-plugin/plugin.json" '"dm-review": ">=1.75.0"' "pipeline requires the exact-owned dm-review release"
 require_text "$REPO_ROOT/plugins/dm-review/.claude-plugin/plugin.json" '"name": "Second Perspective Reviewer"' "dm-review manifest names the provider-neutral perspective lane"
 require_text "$REPO_ROOT/plugins/dm-review/.claude-plugin/plugin.json" 'family-independent second-opinion review' "dm-review manifest describes family-independent perspective resolution"
 require_text "$REPO_ROOT/plugins/dm-review/skills/review/references/agent-registry.md" 'Full mode only.' "migration-validator registry limits the lane to full mode"


### PR DESCRIPTION
Closes #117

## Summary

- Adds one Pipeline-owned conditional prototype-authority contract.
- Makes Pipeline assessment source-first and carries bounded source/render parity context through promptcraft and execution verification.
- Makes dm-review discover declared external prototypes once at the host, inject bounded parity evidence into UI lanes, subordinate generic SaaS heuristics, and use proportional P1/P2/P3 severity with zero deferral.
- Makes the Assembly prototype authoritative for matching Baseplate/Fixture surfaces while preserving named production, authorization, accessibility, SDK, data, CSRF, and host-composition differences.
- Bumps Pipeline 1.61.2 → 1.62.0, dm-review 1.74.0 → 1.75.0, and Assembly 3.15.0 → 3.16.0. Live Wires and Workflow Kernel are unchanged.

Before, workflow inputs could omit exact prototype source and rely on target-only visual judgment or generic design heuristics. After, a declared counterpart is pinned by canonical repository and commit, inspected before target evaluation, carried as a compact parity map, and verified through complementary source and matched browser evidence. Conflicting or unresolved references stop UI work; a source-proven absent counterpart falls back without invention.

## Governance forward canary (read-only)

Reacquired heads immediately before delivery:

- Prototype: `Design-Machines-Studio/assembly@115a24c4e843a16bcc4edfaf6b3661f91da4f8cc`
- Target: draft `Design-Machines-Studio/assembly-governance#31@0571829b30e360298d52cef1c53795eb537d1d23` (required checks green)

The new packet would carry and evaluate:

1. Board header hierarchy `section section-snug prose cluster cluster-between items-baseline`, the `Proposals`/lead structure, and right-side `Share an idea` CTA.
2. Form `sidebar sidebar-reverse sidebar-loose`, `About ideas` aside, field/textarea structure, and Cancel-before-submit action order.
3. Exact prototype form/helper and metadata copy, surfacing target differences such as the target's `Share` submit label and altered `About ideas` sentence instead of silently accepting them.
4. Detail `proposal-header`, `eyebrow`, and `text-sm text-muted mb-1` metadata using `Created by … on …` and `Edited by … on …`.
5. Meaningful wrapper nesting and layout/component calls rather than class-name-only or screenshot-only parity.
6. Chart ownership: prototype `PositionDistribution` emits its own `position-distribution` container, so a target implementation must inspect that component before adding another presentation box. The refreshed target currently renders its positions presentation in its own `box scheme-subtle rounded`; the workflow must compare ownership for the matched state rather than infer from names.
7. Prototype and target browser cases at the same meaningful routes, states, and viewports, with screenshots plus targeted DOM/classes/copy/layout evidence.
8. Named Fixture differences: permission-gated create CTA, typed components/APIs, member links/readers, CSRF, dynamic values, and host composition remain permitted when justified.

Neither consumer repository, PR #31, deployment, nor dm027 was modified.

## Pressure tests

- “Looks close; skip source” → rejected: exact source is read first and rechecked after editing.
- “Production is cleaner; change copy/button placement” → rejected unless an approved requirement names the divergence.
- Prototype temporarily unreachable → completed source work is preserved, but rendered parity returns `human_help_required`.
- Matching classes → browser comparison still required.
- Matching screenshot → source hierarchy/wrapper comparison still required.
- Stripe would use another component → generic benchmark remains secondary on a covered surface.
- Theme colors differ → structural scheme may match without exact computed-color/token equality.
- No counterpart → exact source records absence; no similar page is invented.
- Authorization/accessibility conflict → production constraint wins and is recorded as intentional divergence.
- P3 spacing drift → proportional P3, still fixed and rechecked before clean completion.

## Validation

Passed on final content:

- `./tools/validate-workflow-contracts.sh --prototype-parity`
- `./tools/validate-workflow-contracts.sh`
- `./tools/validate-dm-review-codex-perspective.sh`
- `./tools/generate-codex-manifests.py --check`
- `./tools/generate-codex-command-skills.py --check`
- `./tools/validate-dual-compat.sh`
- `./tools/check-dependencies.sh`
- `git diff --check`
- shell syntax checks for the changed validators

`./tools/validate-composition.sh --all` completed the affected contract, description, dependency, quality-pulse, manifest, dual-compatibility, UI-readiness, and portability sections, but the overall repository-wide command remained non-green in untouched model-router/model-intelligence fixtures (served-model policy/economics and benchmark evidence tests). `tools/validate-workflow-kernel.py` likewise reached an untouched `test_model_intelligence` unittest failure. No model-routing or Workflow Kernel behavior was changed for PROTO-01.

## dm-review-quick

Exact two-core quick review on the candidate/final amendments found three supported P2 consistency defects and no P1/P3:

1. Pipeline stopped conflicting but not unresolved prototype references — fixed and asserted.
2. A verification receipt still mapped all spec deviations to P1 — replaced with proportional observable-impact severity and asserted.
3. Assessment browser guidance still preferred/required Playwright despite T3-first policy — made transport-neutral, including graceful degradation, and asserted.

Both affected lanes verified the repairs; final quick-review result is clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Design-Machines-Studio/codesmith/depot/pr/118"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790724215&installation_model_id=428410&pr_number=118&repository=Design-Machines-Studio%2Fdepot&return_to=https%3A%2F%2Fgithub.com%2FDesign-Machines-Studio%2Fdepot%2Fpull%2F118&signature=59189273edf293feb981d63d08112bece6868ee718c3b50e95e14093a1f25931"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->