### PR TITLE
UI-READY-03: discover documented repository browser targets

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -283,7 +283,7 @@
     {
       "name": "dm-review",
       "source": "./plugins/dm-review",
-      "version": "1.79.1",
+      "version": "1.80.0",
       "author": {
         "name": "Design Machines",
         "url": "https://designmachines.studio"

--- a/plugins/dm-review/.claude-plugin/plugin.json
+++ b/plugins/dm-review/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dm-review",
   "description": "Code review orchestrator with evidence-backed severity, minimum-adequate repairs, zero-deferral convergence, full security and browser coverage, and stable finding receipts",
-  "version": "1.79.1",
+  "version": "1.80.0",
   "author": {
     "name": "Design Machines",
     "url": "https://designmachines.io"

--- a/plugins/dm-review/.codex-plugin/plugin.json
+++ b/plugins/dm-review/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dm-review",
-  "version": "1.79.1",
+  "version": "1.80.0",
   "description": "Code review orchestrator with evidence-backed severity, minimum-adequate repairs, zero-deferral convergence, full security and browser coverage, and stable finding receipts",
   "author": {
     "name": "Design Machines",

--- a/plugins/dm-review/agents/review/visual-browser-tester.md
+++ b/plugins/dm-review/agents/review/visual-browser-tester.md
@@ -28,7 +28,7 @@ accessibility. You complement static code analysis with what actually rendered.
 
 ## Precondition
 
-A `## Host Browser Evidence` section must bind the invocation-selected target,
+A `## Host Browser Evidence` section must bind the review-selected target,
 real local interactive transport, screenshots, accessibility snapshots,
 console summary, route/viewport case IDs, interaction observations, and
 computed-style results. The host has already completed the app/browser

--- a/plugins/dm-review/commands/dm-review-visual.md
+++ b/plugins/dm-review/commands/dm-review-visual.md
@@ -20,7 +20,9 @@ the policy.
 1. Load the visual-test skill from `plugins/dm-review/skills/visual-test/SKILL.md`
 2. Execute with the provided argument:
    - No argument: use an attached automation-capable T3 preview or optional
-     tracked `.dm/ui-review.json`; never scan localhost ports
+     tracked `.dm/ui-review.json`, then the shared bounded repository
+     author-loop discovery when neither supplies usable evidence; never scan
+     localhost ports
    - URL: test that specific URL
    - `--states`: focus on interactive state testing
    - `--a11y`: focus on runtime accessibility checks

--- a/plugins/dm-review/skills/dm-review-visual/SKILL.md
+++ b/plugins/dm-review/skills/dm-review-visual/SKILL.md
@@ -35,7 +35,9 @@ the policy.
 1. Load the visual-test skill from `plugins/dm-review/skills/visual-test/SKILL.md`
 2. Execute with the provided argument:
    - No argument: use an attached automation-capable T3 preview or optional
-     tracked `.dm/ui-review.json`; never scan localhost ports
+     tracked `.dm/ui-review.json`, then the shared bounded repository
+     author-loop discovery when neither supplies usable evidence; never scan
+     localhost ports
    - URL: test that specific URL
    - `--states`: focus on interactive state testing
    - `--a11y`: focus on runtime accessibility checks

--- a/plugins/dm-review/skills/review/SKILL.md
+++ b/plugins/dm-review/skills/review/SKILL.md
@@ -283,6 +283,7 @@ DM_REVIEW_REQUIRED_ASSETS=(
   "skills/review/references/reviewer-output-contract.md"
   "skills/review/references/host-verification-evidence.md"
   "skills/review/references/ui-review-readiness.md"
+  "skills/review/references/repository-browser-target-discovery.md"
   "skills/review/references/ui-review-readiness.sh"
   "skills/review/references/ui-review-contract.sh"
   "skills/review/references/ui-case-selection.md"
@@ -471,6 +472,18 @@ resources this invocation created. Never infer readiness from changed file
 extensions or interpret supported viewport/engine declarations as a full
 matrix requirement.
 
+If those sources and accepted exact-head packet reuse supply no usable
+evidence, load
+`${CLAUDE_SKILL_DIR}/references/repository-browser-target-discovery.md` and run
+its one bounded host-interpreted pass. Inspect only the current root
+instructions, directly named development runbooks, relevant declared Makefile
+and Compose declarations, `tests/ux/verification.json`, and directly named
+browser handoffs. Preserve bounded source lines and exact command/URL
+provenance in the existing readiness evidence. Never guess ports, scan
+localhost, synthesize commands, require a new checked-in declaration when the
+repository already documents an adequate author loop, or label a discovered
+target as user-supplied.
+
 Verify application reachability and actual local interactive browser
 navigation independently. OpenRouter web search and generic `tool-use` never
 satisfy local browser readiness. Current browser interaction is host-owned;
@@ -487,7 +500,7 @@ never create that requirement. If readiness succeeds but an analysis role is
 unavailable, report `model_participant_unavailable` distinctly.
 
 When Pipeline passes an explicit exact packet path, validate it with
-`browser-evidence-packet.sh` before readiness. Reuse it only for exact matching
+`browser-evidence-packet.sh` at the packet-reuse precedence point. Reuse it only for exact matching
 repository/prototype commits, clean/dirty state, selected case set, successful
 completion, and artifact hashes. Never discover a packet by latest file or
 timestamp. On rejection, attempt normal current target readiness; a required
@@ -677,7 +690,7 @@ invocation.
 
 ## Reference Files
 
-Loaded on demand during review: `reviewer-prompt-template.md` (common reviewer prompt contract, loaded before dispatch in both modes), `ui-case-selection.md` (affected/full UI case boundary), `ui-review-readiness.md` (shared source/rendered readiness gate), `selective-lane-allowlist.md` (only when `review_lane_allowlist` input is present), `severity-mapping.md` (P1/P2/P3 mapping), `agent-registry.md` (agent catalog and triggers), `output-format.md` (report template), `issue-tracking.md` (todo template and GitHub conventions), `guardrails.md` (input/output validation, failure policies), `graceful-degradation.md` (failure classification and merge overrides), `ai-slop-detector.md` (25-point AI output checklist), `ui-design-patterns.md`, `token-discovery.md`, `repo-cleanup-contract.md` (exact worktree/branch registry, safe-to-delete table, feature-branch protection, inventory; shared with pipeline), and `datastar-pro.md` (Pro attributes/actions, substitution table, bundle-presence rule). All under `${CLAUDE_SKILL_DIR}/references/`.
+Loaded on demand during review: `reviewer-prompt-template.md` (common reviewer prompt contract, loaded before dispatch in both modes), `ui-case-selection.md` (affected/full UI case boundary), `ui-review-readiness.md` (shared source/rendered readiness gate), `repository-browser-target-discovery.md` (bounded host interpretation of repository author loops after ordinary target/evidence sources fail), `selective-lane-allowlist.md` (only when `review_lane_allowlist` input is present), `severity-mapping.md` (P1/P2/P3 mapping), `agent-registry.md` (agent catalog and triggers), `output-format.md` (report template), `issue-tracking.md` (todo template and GitHub conventions), `guardrails.md` (input/output validation, failure policies), `graceful-degradation.md` (failure classification and merge overrides), `ai-slop-detector.md` (25-point AI output checklist), `ui-design-patterns.md`, `token-discovery.md`, `repo-cleanup-contract.md` (exact worktree/branch registry, safe-to-delete table, feature-branch protection, inventory; shared with pipeline), and `datastar-pro.md` (Pro attributes/actions, substitution table, bundle-presence rule). All under `${CLAUDE_SKILL_DIR}/references/`.
 
 ## Agent Definition Paths
 

--- a/plugins/dm-review/skills/review/references/full-lane-dispatch.md
+++ b/plugins/dm-review/skills/review/references/full-lane-dispatch.md
@@ -63,7 +63,9 @@ Before any selected UI lane is dispatched, load `ui-case-selection.md` and
 `ui-review-readiness.md`. Select the affected case set once, then run the
 ordered application/browser gate once. Prefer an explicit invocation URL, then
 an attached automation-capable T3 preview, then optional tracked
-`.dm/ui-review.json`. A declared Compose consumer uses
+`.dm/ui-review.json`, then accepted exact-head packet reuse. If none supplies
+usable evidence, load `repository-browser-target-discovery.md` for the one
+bounded host-interpreted author-loop pass. A declared Compose consumer uses
 the existing review Docker creation/cleanup contracts; an exact declared
 process uses `ui-review-readiness.sh`. Verify reachability independently, then
 prove actual local browser navigation independently.
@@ -94,7 +96,8 @@ Validate it with `browser-evidence-packet.sh`; do not discover a latest packet.
 Only an exact repository/prototype commit, dirty state, selected-case, artifact
 hash, and successful completion match replaces current host capture. On
 rejection, attempt the ordinary readiness path and never report rendered
-success from the rejected packet.
+success from the rejected packet. The ordinary path includes bounded
+repository discovery; Pipeline does not create a separate fallback ladder.
 
 The terminal report owner supplies this exact private directory and its
 `terminal-receipt-index.json`. After a parallel fan-out joins, extend the index

--- a/plugins/dm-review/skills/review/references/repository-browser-target-discovery.md
+++ b/plugins/dm-review/skills/review/references/repository-browser-target-discovery.md
@@ -1,0 +1,174 @@
+# Repository browser-target discovery
+
+Load this host contract only after the ordinary UI target/evidence choices have
+failed to supply usable rendered evidence. It lets dm-review use an existing
+repository author loop without guessing a port or requiring a new checked-in
+declaration. It does not extend `ui-review-readiness.sh` into a runbook parser.
+
+## Entry and precedence
+
+Keep the shared readiness order intact:
+
+1. explicit invocation URL;
+2. attached automation-capable T3 preview and its current URL;
+3. valid tracked `.dm/ui-review.json`;
+4. accepted exact-head browser packet reuse; then
+5. this bounded repository discovery pass.
+
+A present higher-precedence source that is malformed, ambiguous, unsafe, or
+actually fails does not authorize blind fallback. Preserve its precise failure
+and required repair. Use repository discovery after a higher-precedence source
+is absent or after rejected stale/mismatched packet evidence leaves no usable
+target. A repository-discovered URL has
+`targetSource: repository-declaration`; after host validation, pass the bounded
+private evidence file to the readiness helper with that source. Do not also
+pass `--target-url`, pass it as `explicit`, describe it as user-supplied, or
+imply that the user started it.
+
+Full, quick, and standalone visual entry points all use this same pass. An
+enclosing Pipeline final review passes its exact packet through the shared
+contract; if packet validation rejects it, the nested dm-review may continue to
+this pass without Pipeline inventing a separate discovery ladder.
+
+## Closed inspection boundary
+
+The host, not a generalized parser, interprets human-authored declarations.
+Inspect only these files in the selected checkout:
+
+- root `AGENTS.md` and root `CLAUDE.md` that apply to the current checkout;
+- a development runbook directly named by one of those two root files;
+- the relevant checked-in `Makefile` target and Compose service/configuration
+  directly named by an accepted declaration;
+- `tests/ux/verification.json`, when present; and
+- a browser handoff directly named by one of the accepted sources above.
+
+Do not recursively search documentation, inspect package scripts by
+convention, scan processes or localhost, try common ports, or synthesize a
+command from project type. An example command, example port, supported engine
+or viewport, production URL, deployment URL, and prose that merely says a dev
+server exists are context, not declarations.
+
+An accepted declaration must identify all of:
+
+- the affected application or Compose consumer;
+- the selected checkout/worktree that supplies its source;
+- either a suitable current target URL or an exact status/readiness command
+  that can report it;
+- an exact start or rebuild procedure when the target may be stopped; and
+- the ownership-safe cleanup procedure for every resource that procedure may
+  create.
+
+The start procedure is optional only when the declaration explicitly says the
+target must already be running. A missing application, checkout binding,
+status identity, start command, or cleanup/ownership declaration is an
+incomplete declaration, not permission to guess.
+
+## Host execution and evidence
+
+Record discovery in dm-review's existing private readiness evidence. Do not
+create a second durable report or a new checked-in configuration file. Retain:
+
+- bounded repository-relative source path plus one-based start/end lines for
+  every accepted declaration;
+- the exact argv array for each status/readiness, start/rebuild, and cleanup
+  command considered or attempted;
+- exit status and redacted final 8,192 UTF-8 bytes of stdout/stderr for every
+  attempted command;
+- the selected application/consumer, physical checkout root, `git rev-parse
+  HEAD`, and clean/dirty checkout state;
+- the exact target URL and whether it came from declaration text, status
+  output, or start/rebuild output; and
+- `pre-existing` or the existing resource-registry reference for every
+  relevant process/Compose resource.
+
+For a ready process target, project those fields into the helper's closed
+`--repository-evidence-file`: application, physical checkout root, exact commit
+and checkout state, one to eight bounded tracked source ranges, up to six exact
+attempt records (`kind`, argv, exit, and redacted 8,192-byte output tail), URL
+and provenance, ownership, and cleanup argv/timeout when review-created. The
+helper embeds that object in its existing readiness state and rechecks checkout
+identity plus a helper-computed content fingerprint before browser
+confirmation. Command output tails stay private; the helper's public result
+contains only source ranges, argv/exit summaries, provenance, and ownership.
+The repository-derived target URL also stays in private readiness/browser
+evidence because a valid local URL may still carry sensitive path or query
+material. Public helper results use `targetRef: private-readiness-state`.
+Compose ownership remains in the existing Workflow Kernel registry; do not
+duplicate it in this process input.
+
+Redaction happens before the host writes the private evidence. Remove request
+authorization, bearer material, cookies, API keys, passwords, client secrets,
+access tokens, private keys, and URL userinfo. The helper rejects those common
+secret shapes, limits each output tail to 8,192 characters, and caps all tails
+at 24,576 characters; rejection is a backstop, not a replacement for host
+redaction.
+
+Ordinary dirty root checkouts are supported because the helper fingerprints
+their status, tracked diff, and untracked content. Dirty initialized submodules
+are rejected: the parent repository's dirty marker cannot bind changing nested
+content without a second snapshot contract.
+
+Source lines are evidence locators, not executable authority. Preserve argv as
+an array and execute it directly from the selected checkout; never turn
+declaration prose into `sh -c`. Redact credentials and private endpoint
+material using the existing evidence rules.
+
+Run a documented status/readiness command first when one exists. A zero exit
+is not enough by itself: interpret its bounded output and declaration to bind
+the affected application, selected checkout, source commit, checkout state,
+and target identity. Reachability or `curl` alone proves none of those.
+
+If the declared target is stopped or unsuitable for the exact head, reuse a
+suitable exact-head target only when the identity fields agree. Otherwise
+attempt the one documented start/rebuild procedure from the selected checkout.
+Accept a syntactically valid HTTP(S) URL printed by that exact procedure or its
+documented follow-up status command; record `start-output` or `status-output`
+URL provenance. Do not replace it with an example port from the runbook.
+
+Before browser navigation, confirm again that:
+
+1. the selected checkout is still the recorded physical root and state;
+2. its current commit is the recorded commit;
+3. status/readiness identifies the selected application/consumer and that
+   checkout/commit; and
+4. the exact URL belongs to that identified target.
+
+Only then may host-owned T3-first automation navigate and create exact-head
+browser proof. Browser transport failure remains
+`browser_transport_unavailable`; it never changes a successful dev-server
+attempt into `dev_server_unavailable`.
+
+## Ownership and cleanup
+
+Inventory before creation. A suitable target that was already running is
+`pre-existing`: do not register, rebuild, stop, or clean it. Before attempting
+a process start, record its exact declared cleanup argv in the review-owned
+state so interruption can use that immutable snapshot. For Docker/Compose,
+load `review-docker-create.md` before execution; use its labelled creation plan
+and registry, then `review-docker-cleanup.md` on every terminal path. An
+incomplete or ambiguous ownership declaration blocks the attempt.
+
+Success, command failure, browser failure, analysis failure, and
+`SIGINT`/`SIGTERM` all clean only resources positively recorded as created by
+this review. Reused resources remain untouched. Never run a cleanup command
+for a failed start unless the before/after evidence and existing registry show
+that the attempt created the exact resource.
+
+## Outcomes
+
+- No repository-owned declaration in the closed inspection boundary:
+  `visual_target_unavailable`, with bounded inspected-source evidence.
+- A declared status/start/readiness command is actually attempted and fails:
+  `dev_server_unavailable`, with source path/lines, exact attempted argv, exit
+  status, and one bounded failure reason.
+- A declaration is incomplete, conflicting, unsafe, or cannot bind the
+  selected checkout/application/ownership: `dev_server_unavailable`, naming
+  the exact missing prerequisite; do not execute an unsafe procedure or fall
+  through to guesses.
+- Application identity is sound but local browser navigation cannot run:
+  `browser_transport_unavailable`.
+
+These remain one aggregate rendered-coverage gap. Source-capable UI analysis
+continues in labelled `source-only` mode; visual-browser is `NOT RUN`. Required
+rendering keeps the review `REVIEW INCOMPLETE`. Never claim an unavailable or
+skipped case passed.

--- a/plugins/dm-review/skills/review/references/ui-review-readiness.md
+++ b/plugins/dm-review/skills/review/references/ui-review-readiness.md
@@ -36,15 +36,38 @@ Select exactly one target in this order:
 1. an explicit URL supplied by the current invocation;
 2. an already attached, automation-capable T3 preview and its current URL;
 3. the optional tracked `<repository>/.dm/ui-review.json` declaration;
-4. otherwise no rendered target is available.
+4. an accepted exact-head browser packet explicitly passed by an enclosing
+   Pipeline; then
+5. the bounded repository author-loop discovery in
+   `repository-browser-target-discovery.md`.
 
 Pass invocation and T3 targets to `prepare` with `--target-url` and
-`--target-source explicit|t3-preview`. Every `prepare` call also passes the
+`--target-source explicit|t3-preview`. After the host validates and attempts a
+bounded repository declaration, materialize its existing private readiness
+evidence and pass it with `--target-source repository-declaration
+--repository-evidence-file <path>`; do not repeat its URL as an invocation
+input. The helper does not discover or interpret the declaration. It validates
+the evidence against the physical checkout, commit, clean/dirty state, tracked
+bounded source lines, target URL provenance, attempted argv/output, and
+pre-existing or review-created process ownership. Every `prepare` call also passes the
 exact nonempty selected UI lane set as `--applicable-lanes-json`; the helper
 binds it into state so settlement cannot omit a planned participant. Do not
 scan localhost ports, infer a URL from file extensions, or guess a start
-command. The helper validates the URL; successful host navigation remains the
-readiness proof.
+command. The helper validates the strict URL/declaration inputs it owns;
+successful host navigation remains the readiness proof. Repository author-loop
+discovery remains host-interpreted and records
+`targetSource: repository-declaration` in the existing readiness evidence;
+never relabel its URL as explicit or user-supplied. A review-created process
+includes its recorded repository-owned cleanup argv and timeout so the helper
+can snapshot and execute only that cleanup. Repository-discovered Compose
+resources stay under the existing Workflow Kernel Docker registry.
+The helper keeps redacted command tails only in private readiness state, emits
+only their argv/exit summary, and binds a checkout-content fingerprint so a
+dirty tree cannot change while remaining merely labelled `dirty`.
+Repository-derived URLs likewise remain private; public helper output carries
+only `targetRef: private-readiness-state`. Dirty initialized submodules are an
+honest `dev_server_unavailable` prerequisite because the root fingerprint does
+not bind their nested content.
 
 "One target" applies per readiness state. When a host-resolved prototype
 parity packet supplies both an exact prototype URL and target URL, run this
@@ -101,11 +124,20 @@ consumer is sufficient.
    or stopped.
 3. For declared Compose, follow the existing Docker creation contract, then
    rerun the independent readiness check.
-4. On the host, inspect actual callable browser tools. In T3 Code, call
+4. If the preceding sources and accepted packet reuse supply no usable
+   evidence, load `repository-browser-target-discovery.md`. Inspect only its
+   closed source set, retain exact source-line and command/URL provenance, and
+   use the documented application/checkout identity and ownership-safe author
+   loop. Materialize the bounded source/attempt/output and ownership result in
+   the repository evidence file. No declaration yields
+   `visual_target_unavailable`; an actual declared command failure yields
+   `dev_server_unavailable` with that evidence and does not proceed to
+   `prepare` as a ready target.
+5. On the host, inspect actual callable browser tools. In T3 Code, call
    `preview_status`; if no automation-capable preview is attached, call
    `preview_open`, then navigate the exact declared target. A tool name or
    generic `tool-use` is not readiness evidence.
-5. Materialize one private bounded browser evidence file only after successful
+6. Materialize one private bounded browser evidence file only after successful
    local navigation:
 
    ```json
@@ -119,11 +151,11 @@ consumer is sufficient.
    }
    ```
 
-6. Run `ui-review-readiness.sh confirm-browser` with that evidence and the
+7. Run `ui-review-readiness.sh confirm-browser` with that evidence and the
    exact state file created by `prepare`. It rechecks the registered target and
    consumes the browser proof. Only `dispatchAllowed: true` permits a
    participant call.
-7. Keep browser interaction host-owned. Collect screenshots, accessibility
+8. Keep browser interaction host-owned. Collect screenshots, accessibility
    snapshots, console summary, route/viewport IDs, interaction observations,
    and computed-style results once. Give the same bounded evidence packet to
    each applicable UI analysis role. Request
@@ -132,7 +164,7 @@ consumer is sufficient.
    For a declared counterpart, include matched prototype/target route, state,
    viewport, targeted hierarchy, actual classes, visible copy/action order, and
    explanatory layout/spacing values. Exact theme colors are not a parity gate.
-8. Dispatch each applicable analysis lane once with the same packet reference.
+9. Dispatch each applicable analysis lane once with the same packet reference.
    Settle the aggregate analysis result once through `ui-review-readiness.sh
    settle`; settlement requires the result lane set to equal the set bound by
    `prepare`. Then clean every exact registered process or Compose resource.
@@ -175,7 +207,7 @@ probe that proves local navigation.
 | Reason | Review state | One next action |
 |---|---|---|
 | `visual_target_unavailable` | `NOT RUN` ordinarily; `REVIEW INCOMPLETE` when required | Supply an explicit URL, attach T3 preview, or add the optional declaration when coverage is required. |
-| `dev_server_unavailable` | `NOT RUN` ordinarily; `REVIEW INCOMPLETE` when required | Declare or recover the exact repository-owned consumer when rendered coverage is required. |
+| `dev_server_unavailable` | `NOT RUN` ordinarily; `REVIEW INCOMPLETE` when required | Repair the exact failed or incomplete repository-owned author-loop prerequisite when rendered coverage is required. |
 | `browser_transport_unavailable` | `NOT RUN` ordinarily; `REVIEW INCOMPLETE` when required | Attach a local interactive browser or pass exact matching evidence when rendered coverage is required. |
 | `model_participant_unavailable` | `REVIEW INCOMPLETE` | Restore an eligible provider-neutral analysis participant and rerun the lane. |
 | `resource_cleanup_failed` | `REVIEW INCOMPLETE` | Run only the recorded repository-owned cleanup and inspect that resource. |

--- a/plugins/dm-review/skills/review/references/ui-review-readiness.sh
+++ b/plugins/dm-review/skills/review/references/ui-review-readiness.sh
@@ -9,6 +9,7 @@
 # Usage:
 #   ui-review-readiness.sh prepare --repository-root ROOT --state-file FILE
 #     [--target-url URL --target-source explicit|t3-preview]
+#     [--target-source repository-declaration --repository-evidence-file FILE]
 #     --applicable-lanes-json JSON
 #     [--visual-required true|false]
 #   ui-review-readiness.sh confirm-browser --repository-root ROOT \
@@ -30,6 +31,7 @@ BROWSER_EVIDENCE_FILE=""
 ANALYSIS_RESULT_FILE=""
 TARGET_URL_INPUT=""
 TARGET_SOURCE_INPUT=""
+REPOSITORY_EVIDENCE_FILE=""
 VISUAL_REQUIRED=false
 APPLICABLE_LANES_JSON=""
 
@@ -46,6 +48,7 @@ while [ "$#" -gt 0 ]; do
     --analysis-result-file|--participant-result-file) [ "$#" -ge 2 ] || usage; ANALYSIS_RESULT_FILE="$2"; shift 2 ;;
     --target-url) [ "$#" -ge 2 ] || usage; TARGET_URL_INPUT="$2"; shift 2 ;;
     --target-source) [ "$#" -ge 2 ] || usage; TARGET_SOURCE_INPUT="$2"; shift 2 ;;
+    --repository-evidence-file) [ "$#" -ge 2 ] || usage; REPOSITORY_EVIDENCE_FILE="$2"; shift 2 ;;
     --visual-required) [ "$#" -ge 2 ] || usage; VISUAL_REQUIRED="$2"; shift 2 ;;
     --applicable-lanes-json) [ "$#" -ge 2 ] || usage; APPLICABLE_LANES_JSON="$2"; shift 2 ;;
     *) usage ;;
@@ -61,6 +64,7 @@ git -C "$REPOSITORY_ROOT" rev-parse --show-toplevel >/dev/null 2>&1 || usage
 case "$VISUAL_REQUIRED" in true|false) ;; *) usage ;; esac
 [ -z "$TARGET_URL_INPUT" ] || [ "$ACTION" = prepare ] || usage
 [ -z "$TARGET_SOURCE_INPUT" ] || [ "$ACTION" = prepare ] || usage
+[ -z "$REPOSITORY_EVIDENCE_FILE" ] || [ "$ACTION" = prepare ] || usage
 if [ "$ACTION" = prepare ]; then
   printf '%s' "$APPLICABLE_LANES_JSON" | jq -e '
     type == "array" and length > 0 and length <= 3 and length == (unique | length) and
@@ -99,6 +103,39 @@ valid_selected_target_url() {
   ' >/dev/null 2>&1
 }
 
+hash_file() {
+  if command -v sha256sum >/dev/null 2>&1; then sha256sum "$1" | awk '{print $1}'
+  else shasum -a 256 "$1" | awk '{print $1}'
+  fi
+}
+
+checkout_fingerprint() {
+  local snapshot path digest
+  snapshot="$(mktemp "${TMPDIR:-/tmp}/dm-review-ui-checkout.XXXXXX")" || return 1
+  git -C "$REPOSITORY_ROOT" status --porcelain=v1 -z --untracked-files=all > "$snapshot" || {
+    rm -f "$snapshot"; return 1;
+  }
+  git -C "$REPOSITORY_ROOT" diff --binary --no-ext-diff HEAD -- >> "$snapshot" || {
+    rm -f "$snapshot"; return 1;
+  }
+  while IFS= read -r -d '' path; do
+    printf '\0%s\0' "$path" >> "$snapshot"
+    if [ -f "$REPOSITORY_ROOT/$path" ] && [ ! -L "$REPOSITORY_ROOT/$path" ]; then
+      digest="$(git -C "$REPOSITORY_ROOT" hash-object --no-filters -- "$path")" || {
+        rm -f "$snapshot"; return 1;
+      }
+      printf '%s\0' "$digest" >> "$snapshot"
+    elif [ -L "$REPOSITORY_ROOT/$path" ]; then
+      printf 'symlink:%s\0' "$(readlink "$REPOSITORY_ROOT/$path")" >> "$snapshot"
+    else
+      printf 'unsupported\0' >> "$snapshot"
+    fi
+  done < <(git -C "$REPOSITORY_ROOT" ls-files --others --exclude-standard -z)
+  digest="$(hash_file "$snapshot")" || { rm -f "$snapshot"; return 1; }
+  rm -f "$snapshot"
+  printf '%s\n' "$digest"
+}
+
 load_argv() {
   local source="$1" query="$2" arg
   UI_ARGV=()
@@ -115,6 +152,88 @@ validate_repo_executable() {
   physical="$(cd "$(dirname "$REPOSITORY_ROOT/${relative#./}")" && pwd -P)/$(basename "$relative")"
   case "$physical" in "$REPOSITORY_ROOT"/*) ;; *) return 1 ;; esac
   git -C "$REPOSITORY_ROOT" ls-files --error-unmatch -- "${relative#./}" >/dev/null 2>&1
+}
+
+REPOSITORY_EVIDENCE_REASON=""
+validate_repository_evidence() {
+  local evidence="$1" current_commit current_state source_path line_end line_count source_physical
+  REPOSITORY_EVIDENCE_REASON="repository_evidence_invalid"
+  [ -f "$evidence" ] && [ ! -L "$evidence" ] || return 1
+  jq -e '
+    type == "object" and
+    (keys | sort) == (["application","attempts","checkoutRoot","checkoutState","cleanupArgv","cleanupTimeoutSeconds","repositoryCommit","resourceOwnership","schemaVersion","sources","status","targetSource","targetUrl","targetUrlProvenance"] | sort) and
+    .schemaVersion == 1 and .status == "ready" and
+    .targetSource == "repository-declaration" and
+    (.application | type == "string" and length > 0 and length <= 128) and
+    (.checkoutRoot | type == "string" and length > 0 and length <= 4096) and
+    (.repositoryCommit | type == "string" and test("^[0-9a-f]{40}$")) and
+    (.checkoutState == "clean" or .checkoutState == "dirty") and
+    (.sources | type == "array" and length > 0 and length <= 8 and all(.[];
+      type == "object" and (keys | sort) == (["lineEnd","lineStart","path"] | sort) and
+      (.path | type == "string" and test("^[A-Za-z0-9._/-]{1,255}$") and (contains("..") | not)) and
+      (.lineStart | type == "number" and floor == . and . >= 1) and
+      (.lineEnd | type == "number" and floor == . and . >= 1) and
+      .lineEnd >= .lineStart and (.lineEnd - .lineStart) <= 80)) and
+    (.attempts | type == "array" and length <= 6 and all(.[];
+      type == "object" and (keys | sort) == (["argv","exitStatus","kind","outputTail"] | sort) and
+      (.kind == "status" or .kind == "readiness" or .kind == "start" or .kind == "rebuild") and
+      (.argv | type == "array" and length > 0 and length <= 32 and all(.[]; type == "string" and length > 0 and length <= 4096)) and
+      (.exitStatus | type == "number" and floor == . and . >= 0 and . <= 255) and
+      (.outputTail | type == "string" and length <= 8192 and
+        (test("(?i)(authorization:|bearer[[:space:]]|cookie:|set-cookie:|x-api-key:|password=|secret=|client[_-]?secret=|api[_-]?key=|access[_-]?token=|private[_-]?key=|https?://[^[:space:]/:@]+:[^[:space:]@]+@)") | not)))) and
+    (([.attempts[].outputTail | length] | add // 0) <= 24576) and
+    (.targetUrl | type == "string") and
+    (.targetUrlProvenance == "declaration-text" or .targetUrlProvenance == "status-output" or .targetUrlProvenance == "start-output" or .targetUrlProvenance == "rebuild-output") and
+    (.resourceOwnership == "pre-existing" or .resourceOwnership == "review-created-process") and
+    (.cleanupArgv | type == "array" and length <= 32 and all(.[]; type == "string" and length > 0 and length <= 4096)) and
+    (.cleanupTimeoutSeconds | type == "number" and floor == . and . >= 0 and . <= 300) and
+    (if .resourceOwnership == "pre-existing" then
+      .cleanupArgv == [] and .cleanupTimeoutSeconds == 0
+     else
+      (.cleanupArgv | length) > 0 and .cleanupTimeoutSeconds >= 1
+     end)
+  ' "$evidence" >/dev/null 2>&1 || return 1
+  [ "$(jq -r '.checkoutRoot' "$evidence")" = "$REPOSITORY_ROOT" ] || {
+    REPOSITORY_EVIDENCE_REASON="checkout_root_mismatch"; return 1;
+  }
+  current_commit="$(git -C "$REPOSITORY_ROOT" rev-parse HEAD)" || return 1
+  [ "$(jq -r '.repositoryCommit' "$evidence")" = "$current_commit" ] || {
+    REPOSITORY_EVIDENCE_REASON="repository_commit_mismatch"; return 1;
+  }
+  if ! git -C "$REPOSITORY_ROOT" submodule foreach --recursive --quiet '
+    test -z "$(git status --porcelain=v1 --untracked-files=all)"
+  ' >/dev/null 2>&1; then
+    REPOSITORY_EVIDENCE_REASON="dirty_submodule_unsupported"; return 1
+  fi
+  current_state=clean
+  [ -z "$(git -C "$REPOSITORY_ROOT" status --porcelain)" ] || current_state=dirty
+  [ "$(jq -r '.checkoutState' "$evidence")" = "$current_state" ] || {
+    REPOSITORY_EVIDENCE_REASON="checkout_state_mismatch"; return 1;
+  }
+  valid_selected_target_url "$(jq -r '.targetUrl' "$evidence")" || {
+    REPOSITORY_EVIDENCE_REASON="target_url_invalid"; return 1;
+  }
+  while IFS=$'\t' read -r source_path line_end; do
+    [ -f "$REPOSITORY_ROOT/$source_path" ] && [ ! -L "$REPOSITORY_ROOT/$source_path" ] &&
+      git -C "$REPOSITORY_ROOT" ls-files --error-unmatch -- "$source_path" >/dev/null 2>&1 || {
+        REPOSITORY_EVIDENCE_REASON="source_untracked_or_unavailable"; return 1;
+      }
+    source_physical="$(cd "$(dirname "$REPOSITORY_ROOT/$source_path")" && pwd -P)/$(basename "$source_path")" || return 1
+    case "$source_physical" in "$REPOSITORY_ROOT"/*) ;; *)
+      REPOSITORY_EVIDENCE_REASON="source_path_unsafe"; return 1 ;;
+    esac
+    line_count="$(awk 'END { print NR }' "$source_physical")" || return 1
+    [ "$line_end" -le "$line_count" ] || {
+      REPOSITORY_EVIDENCE_REASON="source_line_out_of_range"; return 1;
+    }
+  done < <(jq -r '.sources[] | [.path, .lineEnd] | @tsv' "$evidence")
+  if [ "$(jq -r '.resourceOwnership' "$evidence")" = review-created-process ]; then
+    load_argv "$evidence" '.cleanupArgv' || return 1
+    validate_repo_executable "${UI_ARGV[0]}" || {
+      REPOSITORY_EVIDENCE_REASON="cleanup_command_unsafe"; return 1;
+    }
+  fi
+  REPOSITORY_EVIDENCE_REASON=""
 }
 
 run_bounded_argv() {
@@ -173,7 +292,7 @@ write_state() {
   local target_url="$1" stage="$2" dispatch_allowed="$3" created="$4" cleanup_pending="$5"
   local readiness_argv="$6" readiness_attempts="$7" readiness_timeout="$8"
   local cleanup_argv="$9" cleanup_timeout="${10}" target_source="${11:-declaration}" visual_required="${12:-false}"
-  local applicable_lanes="${13}" tmp
+  local applicable_lanes="${13}" repository_evidence="${14:-null}" checkout_digest="${15:-null}" tmp
   tmp="$(mktemp "$(dirname "$STATE_FILE")/.ui-review-state.XXXXXX")" || return 1
   jq -cn --arg target_url "$target_url" --arg stage "$stage" \
     --argjson dispatch_allowed "$dispatch_allowed" --argjson created "$created" \
@@ -181,13 +300,15 @@ write_state() {
     --argjson readiness_attempts "$readiness_attempts" --argjson readiness_timeout "$readiness_timeout" \
     --argjson cleanup_argv "$cleanup_argv" --argjson cleanup_timeout "$cleanup_timeout" \
     --arg target_source "$target_source" --argjson visual_required "$visual_required" \
-    --argjson applicable_lanes "$applicable_lanes" \
+    --argjson applicable_lanes "$applicable_lanes" --argjson repository_evidence "$repository_evidence" \
+    --argjson checkout_digest "$checkout_digest" \
     '{schemaVersion:1,targetUrl:$target_url,stage:$stage,dispatchAllowed:$dispatch_allowed,
       targetSource:$target_source,visualRequired:$visual_required,applicableLanes:$applicable_lanes,
       createdByReview:$created,cleanupPending:$cleanup_pending,
       readinessArgv:$readiness_argv,readinessAttempts:$readiness_attempts,
       readinessTimeoutSeconds:$readiness_timeout,cleanupArgv:$cleanup_argv,
-      cleanupTimeoutSeconds:$cleanup_timeout}' > "$tmp" || { rm -f "$tmp"; return 1; }
+      cleanupTimeoutSeconds:$cleanup_timeout,repositoryEvidence:$repository_evidence,
+      repositoryCheckoutFingerprint:$checkout_digest}' > "$tmp" || { rm -f "$tmp"; return 1; }
   mv "$tmp" "$STATE_FILE"
 }
 
@@ -195,9 +316,10 @@ validate_state() {
   [ -f "$STATE_FILE" ] && [ ! -L "$STATE_FILE" ] || return 1
   jq -e '
     type == "object" and
-    (keys | sort) == (["applicableLanes","cleanupArgv","cleanupPending","cleanupTimeoutSeconds","createdByReview","dispatchAllowed","readinessArgv","readinessAttempts","readinessTimeoutSeconds","schemaVersion","stage","targetSource","targetUrl","visualRequired"] | sort) and
+    (keys | sort) == (["applicableLanes","cleanupArgv","cleanupPending","cleanupTimeoutSeconds","createdByReview","dispatchAllowed","readinessArgv","readinessAttempts","readinessTimeoutSeconds","repositoryCheckoutFingerprint","repositoryEvidence","schemaVersion","stage","targetSource","targetUrl","visualRequired"] | sort) and
     .schemaVersion == 1 and (.targetUrl | type) == "string" and
-    (.targetSource == "explicit" or .targetSource == "t3-preview" or .targetSource == "declaration") and
+    (.targetSource == "explicit" or .targetSource == "t3-preview" or
+     .targetSource == "repository-declaration" or .targetSource == "declaration") and
     (.visualRequired | type) == "boolean" and
     (.applicableLanes | type == "array" and length > 0 and length <= 3 and length == (unique | length) and
       all(.[]; . == "visual-browser-tester" or . == "ux-quality-reviewer" or . == "ui-standards-reviewer")) and
@@ -211,7 +333,17 @@ validate_state() {
     (.readinessTimeoutSeconds | type) == "number" and (.readinessTimeoutSeconds | floor) == .readinessTimeoutSeconds and .readinessTimeoutSeconds >= 1 and .readinessTimeoutSeconds <= 60 and
     (.cleanupArgv | type) == "array" and all(.cleanupArgv[]; type == "string" and length > 0 and length <= 4096) and
     (.cleanupTimeoutSeconds | type) == "number" and (.cleanupTimeoutSeconds | floor) == .cleanupTimeoutSeconds and .cleanupTimeoutSeconds >= 0 and .cleanupTimeoutSeconds <= 300 and
-    (if .createdByReview then (.cleanupArgv | length) > 0 and .cleanupTimeoutSeconds >= 1 else true end)
+    (if .createdByReview then (.cleanupArgv | length) > 0 and .cleanupTimeoutSeconds >= 1 else true end) and
+    (if .targetSource == "repository-declaration" then
+      (.repositoryEvidence | type == "object") and
+      .repositoryEvidence.targetSource == "repository-declaration" and
+      .repositoryEvidence.status == "ready" and
+      .repositoryEvidence.targetUrl == .targetUrl and
+      ((.repositoryEvidence.resourceOwnership == "review-created-process") == .createdByReview) and
+      .repositoryEvidence.cleanupArgv == .cleanupArgv and
+      .repositoryEvidence.cleanupTimeoutSeconds == .cleanupTimeoutSeconds and
+      (.repositoryCheckoutFingerprint | type == "string" and test("^[0-9a-f]{64}$"))
+     else .repositoryEvidence == null and .repositoryCheckoutFingerprint == null end)
   ' "$STATE_FILE" >/dev/null 2>&1
 }
 
@@ -328,16 +460,56 @@ cleanup_on_unexpected_exit() {
 }
 
 if [ "$ACTION" = prepare ]; then
+  if [ "$TARGET_SOURCE_INPUT" = repository-declaration ]; then
+    [ -z "$TARGET_URL_INPUT" ] && [ -n "$REPOSITORY_EVIDENCE_FILE" ] || usage
+    if ! validate_repository_evidence "$REPOSITORY_EVIDENCE_FILE"; then
+      emit_rendered_gap dev_server_unavailable "repair the repository target evidence prerequisite: $REPOSITORY_EVIDENCE_REASON"
+    fi
+    [ ! -e "$STATE_FILE" ] || usage
+    TARGET_URL="$(jq -r '.targetUrl' "$REPOSITORY_EVIDENCE_FILE")"
+    REPOSITORY_EVIDENCE_JSON="$(jq -c . "$REPOSITORY_EVIDENCE_FILE")"
+    CHECKOUT_FINGERPRINT="$(checkout_fingerprint)" || exit 76
+    CHECKOUT_FINGERPRINT_JSON="$(printf '%s' "$CHECKOUT_FINGERPRINT" | jq -R .)" || exit 76
+    CLEANUP_ARGV_JSON="$(jq -c '.cleanupArgv' "$REPOSITORY_EVIDENCE_FILE")"
+    CLEANUP_TIMEOUT="$(jq -r '.cleanupTimeoutSeconds' "$REPOSITORY_EVIDENCE_FILE")"
+    CREATED=false
+    CLEANUP_PENDING=false
+    if [ "$(jq -r '.resourceOwnership' "$REPOSITORY_EVIDENCE_FILE")" = review-created-process ]; then
+      CREATED=true
+      CLEANUP_PENDING=true
+    fi
+    write_state "$TARGET_URL" app_ready false "$CREATED" "$CLEANUP_PENDING" '[]' 1 1 \
+      "$CLEANUP_ARGV_JSON" "$CLEANUP_TIMEOUT" repository-declaration "$VISUAL_REQUIRED" \
+      "$APPLICABLE_LANES_JSON" "$REPOSITORY_EVIDENCE_JSON" "$CHECKOUT_FINGERPRINT_JSON" || exit 76
+    jq -cn --argjson created "$CREATED" \
+      --arg application "$(jq -r '.application' "$REPOSITORY_EVIDENCE_FILE")" \
+      --arg repository_commit "$(jq -r '.repositoryCommit' "$REPOSITORY_EVIDENCE_FILE")" \
+      --arg checkout_state "$(jq -r '.checkoutState' "$REPOSITORY_EVIDENCE_FILE")" \
+      --arg provenance "$(jq -r '.targetUrlProvenance' "$REPOSITORY_EVIDENCE_FILE")" \
+      --arg ownership "$(jq -r '.resourceOwnership' "$REPOSITORY_EVIDENCE_FILE")" \
+      --argjson sources "$(jq -c '.sources' "$REPOSITORY_EVIDENCE_FILE")" \
+      --argjson attempts "$(jq -c '[.attempts[] | {kind,argv,exitStatus}]' "$REPOSITORY_EVIDENCE_FILE")" \
+      '{state:"app_ready",dispatchAllowed:false,reason:"browser_evidence_required",
+        targetRef:"private-readiness-state",targetSource:"repository-declaration",
+        repositoryEvidence:{application:$application,repositoryCommit:$repository_commit,
+          checkoutState:$checkout_state,sources:$sources,attempts:$attempts,
+          targetUrlProvenance:$provenance,resourceOwnership:$ownership,
+          privateOutputTails:"readiness-state-only"},
+        createdResources:(if $created then 1 else 0 end),
+        nextAction:"navigate the repository-declared target with the host local browser, then run confirm-browser"}'
+    exit 0
+  fi
+  [ -z "$REPOSITORY_EVIDENCE_FILE" ] || usage
   if [ -n "$TARGET_URL_INPUT" ]; then
     case "$TARGET_SOURCE_INPUT" in explicit|t3-preview) ;; *) usage ;; esac
     valid_selected_target_url "$TARGET_URL_INPUT" || usage
     [ ! -e "$STATE_FILE" ] || usage
     write_state "$TARGET_URL_INPUT" app_ready false false false '[]' 1 1 '[]' 0 \
-      "$TARGET_SOURCE_INPUT" "$VISUAL_REQUIRED" "$APPLICABLE_LANES_JSON" || exit 76
+      "$TARGET_SOURCE_INPUT" "$VISUAL_REQUIRED" "$APPLICABLE_LANES_JSON" null || exit 76
     jq -cn --arg target_url "$TARGET_URL_INPUT" --arg source "$TARGET_SOURCE_INPUT" \
       '{state:"app_ready",dispatchAllowed:false,reason:"browser_evidence_required",
         targetUrl:$target_url,targetSource:$source,createdResources:0,
-        nextAction:"navigate the invocation-selected target with the host local browser, then run confirm-browser"}'
+        nextAction:"navigate the selected target with the host local browser, then run confirm-browser"}'
     exit 0
   fi
   if ! validate_declaration "$DECLARATION"; then
@@ -374,7 +546,7 @@ if [ "$ACTION" = prepare ]; then
     CREATED="$(jq -r '.createdByReview' "$STATE_FILE")"
   elif run_bounded_argv "$READINESS_TIMEOUT" "${READINESS_ARGV[@]}"; then
     write_state "$TARGET_URL" app_ready false false false "$READINESS_ARGV_JSON" \
-      "$READINESS_ATTEMPTS" "$READINESS_TIMEOUT" '[]' 0 declaration "$VISUAL_REQUIRED" "$APPLICABLE_LANES_JSON" || exit 76
+      "$READINESS_ATTEMPTS" "$READINESS_TIMEOUT" '[]' 0 declaration "$VISUAL_REQUIRED" "$APPLICABLE_LANES_JSON" null || exit 76
   else
     if [ "$(jq -r '.start == null' "$DECLARATION")" = true ]; then
       emit_rendered_gap dev_server_unavailable 'run the repository-declared application consumer and rerun'
@@ -394,7 +566,7 @@ if [ "$ACTION" = prepare ]; then
     }
     CREATED=true
     write_state "$TARGET_URL" app_ready false true true "$READINESS_ARGV_JSON" \
-      "$READINESS_ATTEMPTS" "$READINESS_TIMEOUT" "$CLEANUP_ARGV_JSON" "$START_TIMEOUT" declaration "$VISUAL_REQUIRED" "$APPLICABLE_LANES_JSON" || exit 76
+      "$READINESS_ATTEMPTS" "$READINESS_TIMEOUT" "$CLEANUP_ARGV_JSON" "$START_TIMEOUT" declaration "$VISUAL_REQUIRED" "$APPLICABLE_LANES_JSON" null || exit 76
     trap cleanup_on_unexpected_exit EXIT
     trap 'exit 130' HUP INT TERM
     if ! run_bounded_argv "$START_TIMEOUT" "${UI_ARGV[@]}"; then
@@ -436,6 +608,18 @@ if [ "$(jq -r '.targetSource' "$STATE_FILE")" = declaration ]; then
     close_registered_state dev_server_unavailable 'inspect the registered application readiness command and rerun'
   fi
 fi
+if [ "$(jq -r '.targetSource' "$STATE_FILE")" = repository-declaration ]; then
+  [ "$(jq -r '.repositoryEvidence.checkoutRoot' "$STATE_FILE")" = "$REPOSITORY_ROOT" ] ||
+    close_registered_state dev_server_unavailable 'restore the repository-declared checkout identity and rerun discovery'
+  [ "$(jq -r '.repositoryEvidence.repositoryCommit' "$STATE_FILE")" = "$(git -C "$REPOSITORY_ROOT" rev-parse HEAD)" ] ||
+    close_registered_state dev_server_unavailable 'rerun repository target discovery for the current source commit'
+  CURRENT_STATE=clean
+  [ -z "$(git -C "$REPOSITORY_ROOT" status --porcelain)" ] || CURRENT_STATE=dirty
+  [ "$(jq -r '.repositoryEvidence.checkoutState' "$STATE_FILE")" = "$CURRENT_STATE" ] ||
+    close_registered_state dev_server_unavailable 'rerun repository target discovery for the current checkout state'
+  [ "$(jq -r '.repositoryCheckoutFingerprint' "$STATE_FILE")" = "$(checkout_fingerprint)" ] ||
+    close_registered_state dev_server_unavailable 'rerun repository target discovery after checkout content changed'
+fi
 if [ ! -f "$BROWSER_EVIDENCE_FILE" ] || [ -L "$BROWSER_EVIDENCE_FILE" ] ||
    ! jq -e --arg target_url "$TARGET_URL" '
      type == "object" and
@@ -451,8 +635,16 @@ update_state ready true || exit 76
 trap - EXIT HUP INT TERM
 CREATED="$(jq -r '.createdByReview' "$STATE_FILE")"
 EVIDENCE_REF="$(jq -r '.evidenceRef' "$BROWSER_EVIDENCE_FILE")"
-jq -cn --arg target_url "$TARGET_URL" --arg evidence_ref "$EVIDENCE_REF" --argjson created "$CREATED" \
-  '{state:"ready",dispatchAllowed:true,reason:"available",targetUrl:$target_url,
-    browserTransport:"local-interactive",browserEvidence:"bounded-host-evidence",evidenceRef:$evidence_ref,
-    createdResources:(if $created then 1 else 0 end),
-    nextAction:"dispatch provider-neutral UI analysis without browser capability"}'
+if [ "$(jq -r '.targetSource' "$STATE_FILE")" = repository-declaration ]; then
+  jq -cn --arg evidence_ref "$EVIDENCE_REF" --argjson created "$CREATED" \
+    '{state:"ready",dispatchAllowed:true,reason:"available",targetRef:"private-readiness-state",
+      browserTransport:"local-interactive",browserEvidence:"bounded-host-evidence",evidenceRef:$evidence_ref,
+      createdResources:(if $created then 1 else 0 end),
+      nextAction:"dispatch provider-neutral UI analysis without browser capability"}'
+else
+  jq -cn --arg target_url "$TARGET_URL" --arg evidence_ref "$EVIDENCE_REF" --argjson created "$CREATED" \
+    '{state:"ready",dispatchAllowed:true,reason:"available",targetUrl:$target_url,
+      browserTransport:"local-interactive",browserEvidence:"bounded-host-evidence",evidenceRef:$evidence_ref,
+      createdResources:(if $created then 1 else 0 end),
+      nextAction:"dispatch provider-neutral UI analysis without browser capability"}'
+fi

--- a/plugins/dm-review/skills/visual-test/SKILL.md
+++ b/plugins/dm-review/skills/visual-test/SKILL.md
@@ -26,7 +26,8 @@ Standalone visual testing that loads pages in a real browser, screenshots at mul
 ## Usage
 
 - `/dm-review-visual` -- use an attached T3 preview or optional tracked
-  `.dm/ui-review.json`, then test the affected selected cases
+  `.dm/ui-review.json`, then bounded repository author-loop discovery, and test
+  the affected selected cases
 - `/dm-review-visual <url>` -- test a specific URL
 - `/dm-review-visual --states` -- focus on interactive state testing only
 - `/dm-review-visual --a11y` -- focus on runtime accessibility checks only
@@ -41,8 +42,10 @@ Standalone visual testing that loads pages in a real browser, screenshots at mul
 **If no URL provided:** first use an already attached, automation-capable T3
 preview and its exact current URL. Otherwise use optional tracked
 `.dm/ui-review.json` through the shared `ui-review-readiness.md` start/readiness
-contract. Do not scan localhost ports, infer a target from the project type, or
-guess a mutating start command.
+contract. If neither supplies usable evidence, load the review skill's
+`repository-browser-target-discovery.md` and run its host-interpreted bounded
+pass before declaring the target unavailable. Do not scan localhost ports,
+infer a target from the project type, or guess a mutating start command.
 
 This command explicitly requires rendered evidence. Run the shared helper with
 `--visual-required true`. If neither source exists or navigation cannot be

--- a/tools/test-dm-review-repository-target-discovery.sh
+++ b/tools/test-dm-review-repository-target-discovery.sh
@@ -1,0 +1,243 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CONTRACT="$ROOT/plugins/dm-review/skills/review/references/repository-browser-target-discovery.md"
+READINESS="$ROOT/plugins/dm-review/skills/review/references/ui-review-readiness.md"
+REVIEW_SKILL="$ROOT/plugins/dm-review/skills/review/SKILL.md"
+VISUAL_SKILL="$ROOT/plugins/dm-review/skills/visual-test/SKILL.md"
+FULL_LANES="$ROOT/plugins/dm-review/skills/review/references/full-lane-dispatch.md"
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/dm-review-repository-target.XXXXXX")"
+trap 'rm -rf "$TMP"' EXIT
+
+pass=0
+assert() { "$@" >/dev/null || { printf 'FAIL: %s\n' "$*" >&2; exit 1; }; pass=$((pass + 1)); }
+
+# Contract anchors prove the three entry points share one host-owned pass. The
+# scenarios below separately execute fixture commands; these grep checks are
+# not treated as proof that a declared command was attempted.
+assert grep -Fq 'The host, not a generalized parser, interprets human-authored declarations.' "$CONTRACT"
+assert grep -Fq 'root `AGENTS.md` and root `CLAUDE.md`' "$CONTRACT"
+assert grep -Fq '`tests/ux/verification.json`' "$CONTRACT"
+assert grep -Fq 'targetSource:' "$CONTRACT"
+assert grep -Fq 'repository-declaration' "$CONTRACT"
+assert grep -Fq 'accepted exact-head browser packet reuse' "$CONTRACT"
+assert grep -Fq 'A suitable target that was already running is' "$CONTRACT"
+assert grep -Fq '`pre-existing`' "$CONTRACT"
+assert grep -Fq 'repository-browser-target-discovery.md' "$READINESS"
+assert grep -Fq 'repository-browser-target-discovery.md' "$REVIEW_SKILL"
+assert grep -Fq 'repository-browser-target-discovery.md' "$VISUAL_SKILL"
+assert grep -Fq 'repository-browser-target-discovery.md' "$FULL_LANES"
+
+ABSENT="$TMP/absent"
+mkdir -p "$ABSENT/tests/ux"
+git -C "$ABSENT" init -q
+cat > "$ABSENT/AGENTS.md" <<'EOF'
+# Project instructions
+
+Run the existing development loop when one is documented.
+EOF
+cat > "$ABSENT/CLAUDE.md" <<'EOF'
+# Claude instructions
+
+Follow AGENTS.md.
+EOF
+cat > "$ABSENT/README.md" <<'EOF'
+Example only: browse http://localhost:3000 and run ./not-a-declaration.
+EOF
+cat > "$ABSENT/package.json" <<'EOF'
+{"scripts":{"dev":"./not-a-declaration"}}
+EOF
+cat > "$ABSENT/tests/ux/verification.json" <<'EOF'
+{"schemaVersion":1,"viewports":["example-only"]}
+EOF
+git -C "$ABSENT" add .
+git -C "$ABSENT" -c user.name=test -c user.email=test@example.invalid commit -qm fixture
+
+# The host inspection fixture names every inspected path explicitly. README and
+# package scripts remain outside the closed boundary and cannot become a target.
+printf '%s\n' AGENTS.md CLAUDE.md tests/ux/verification.json > "$TMP/absent-inspected.log"
+assert test "$(wc -l < "$TMP/absent-inspected.log" | tr -d ' ')" -eq 3
+assert grep -Fxq AGENTS.md "$TMP/absent-inspected.log"
+assert grep -Fxq CLAUDE.md "$TMP/absent-inspected.log"
+assert grep -Fxq tests/ux/verification.json "$TMP/absent-inspected.log"
+assert sh -c '! grep -Eq "README|package.json" "$1"' sh "$TMP/absent-inspected.log"
+assert grep -Fq 'No repository-owned declaration in the closed inspection boundary:' "$CONTRACT"
+assert grep -Fq '`visual_target_unavailable`' "$CONTRACT"
+
+REPO="$TMP/repository"
+mkdir -p "$REPO/docs" "$REPO/tools"
+git -C "$REPO" init -q
+cat > "$REPO/AGENTS.md" <<'EOF'
+# Project instructions
+
+The storefront author loop is declared in docs/development.md.
+EOF
+cat > "$REPO/CLAUDE.md" <<'EOF'
+# Claude instructions
+
+Follow AGENTS.md for the selected checkout.
+EOF
+cat > "$REPO/docs/development.md" <<'EOF'
+# Development
+
+Application: storefront-web from the current physical checkout and HEAD.
+Status/readiness argv: ["./tools/dev-status"]
+Start/rebuild argv: ["./tools/dev-start"]
+Cleanup argv: ["./tools/dev-stop"]
+Target URL: accept the HTTP(S) URL printed by status or start.
+Production example only: https://storefront.example.com
+Port example only: 3000
+EOF
+cat > "$REPO/tools/dev-status" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' status >> "$TARGET_ATTEMPT_LOG"
+if [ ! -f "$TARGET_READY_MARKER" ]; then
+  printf '%s\n' 'storefront-web is stopped' >&2
+  exit 7
+fi
+printf 'application=storefront-web\ncheckout=%s\ncommit=%s\nstate=%s\nurl=%s\n' \
+  "$(pwd -P)" "$(git rev-parse HEAD)" \
+  "$(if [ -n "$(git status --porcelain)" ]; then printf dirty; else printf clean; fi)" \
+  "$TARGET_DYNAMIC_URL"
+EOF
+cat > "$REPO/tools/dev-start" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' start >> "$TARGET_ATTEMPT_LOG"
+touch "$TARGET_READY_MARKER"
+printf '%s\n' "$TARGET_DYNAMIC_URL"
+EOF
+cat > "$REPO/tools/dev-stop" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' cleanup >> "$TARGET_ATTEMPT_LOG"
+rm -f "$TARGET_READY_MARKER"
+EOF
+cat > "$REPO/tools/dev-fail" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' failed-start >> "$TARGET_ATTEMPT_LOG"
+printf '%s\n' 'fixture start failed before target creation' >&2
+exit 42
+EOF
+chmod +x "$REPO"/tools/dev-*
+git -C "$REPO" add .
+git -C "$REPO" -c user.name=test -c user.email=test@example.invalid commit -qm fixture
+
+export TARGET_ATTEMPT_LOG="$TMP/attempts.log"
+export TARGET_READY_MARKER="$TMP/target-ready"
+export TARGET_DYNAMIC_URL="http://127.0.0.1:49173/review"
+: > "$TARGET_ATTEMPT_LOG"
+
+run_attempt() {
+  local name="$1"
+  shift
+  set +e
+  (cd "$REPO" && "$@") > "$TMP/$name.stdout" 2> "$TMP/$name.stderr"
+  local rc=$?
+  set -e
+  printf '%s\n' "$rc" > "$TMP/$name.rc"
+}
+
+# A documented-but-stopped target performs status, the exact start procedure,
+# and status again. The URL is taken from actual command output, not port 3000.
+run_attempt stopped-status ./tools/dev-status
+assert test "$(cat "$TMP/stopped-status.rc")" -eq 7
+assert grep -Fq 'storefront-web is stopped' "$TMP/stopped-status.stderr"
+run_attempt stopped-start ./tools/dev-start
+assert test "$(cat "$TMP/stopped-start.rc")" -eq 0
+discovered_url="$(tail -n 1 "$TMP/stopped-start.stdout")"
+assert test "$discovered_url" = "$TARGET_DYNAMIC_URL"
+assert sh -c '! grep -Fq "3000" "$1"' sh "$TMP/stopped-start.stdout"
+run_attempt started-status ./tools/dev-status
+assert test "$(cat "$TMP/started-status.rc")" -eq 0
+assert grep -Fq "application=storefront-web" "$TMP/started-status.stdout"
+assert grep -Fq "checkout=$(cd "$REPO" && pwd -P)" "$TMP/started-status.stdout"
+assert grep -Fq "commit=$(git -C "$REPO" rev-parse HEAD)" "$TMP/started-status.stdout"
+assert grep -Fq "url=$TARGET_DYNAMIC_URL" "$TMP/started-status.stdout"
+assert test "$(grep -c '^start$' "$TARGET_ATTEMPT_LOG")" -eq 1
+start_line="$(grep -nF 'Start/rebuild argv:' "$REPO/docs/development.md" | cut -d: -f1)"
+target_line="$(grep -nF 'Target URL:' "$REPO/docs/development.md" | cut -d: -f1)"
+assert test "$start_line" -gt 0
+jq -cn --arg url "$discovered_url" --arg checkout "$(cd "$REPO" && pwd -P)" \
+  --arg head "$(git -C "$REPO" rev-parse HEAD)" --argjson start_line "$start_line" \
+  --argjson target_line "$target_line" \
+  '{targetSource:"repository-declaration",source:{path:"docs/development.md",lineStart:$start_line,lineEnd:$target_line},
+    application:"storefront-web",checkoutRoot:$checkout,repositoryCommit:$head,checkoutState:"clean",
+    statusAttempt:{commandArgv:["./tools/dev-status"],initialExitStatus:7,finalExitStatus:0},
+    startAttempt:{commandArgv:["./tools/dev-start"],exitStatus:0},
+    targetUrl:$url,targetUrlProvenance:"start-output",resourceOwnership:"review-created"}' \
+  > "$TMP/stopped-evidence.json"
+assert jq -e --arg url "$TARGET_DYNAMIC_URL" '
+  .targetSource == "repository-declaration" and .source.path == "docs/development.md" and
+  .source.lineStart > 0 and .source.lineEnd >= .source.lineStart and
+  .statusAttempt.commandArgv == ["./tools/dev-status"] and
+  .statusAttempt.initialExitStatus == 7 and .statusAttempt.finalExitStatus == 0 and
+  .startAttempt == {commandArgv:["./tools/dev-start"],exitStatus:0} and
+  .targetUrl == $url and .targetUrlProvenance == "start-output" and
+  .resourceOwnership == "review-created"' "$TMP/stopped-evidence.json"
+
+# Review-created resources use the recorded cleanup; this successful fixture
+# cleans once and proves the marker is gone.
+run_attempt started-cleanup ./tools/dev-stop
+assert test "$(cat "$TMP/started-cleanup.rc")" -eq 0
+assert test ! -e "$TARGET_READY_MARKER"
+assert test "$(grep -c '^cleanup$' "$TARGET_ATTEMPT_LOG")" -eq 1
+
+# An actual failed declared command is executed once and preserves its real
+# exit/failure evidence. A token assertion alone cannot satisfy this case.
+: > "$TARGET_ATTEMPT_LOG"
+run_attempt actual-failure ./tools/dev-fail
+assert test "$(cat "$TMP/actual-failure.rc")" -eq 42
+assert grep -Fxq failed-start "$TARGET_ATTEMPT_LOG"
+assert grep -Fq 'fixture start failed before target creation' "$TMP/actual-failure.stderr"
+assert test ! -e "$TARGET_READY_MARKER"
+failure_reason="$(tail -c 8192 "$TMP/actual-failure.stderr")"
+jq -cn --arg reason "$failure_reason" \
+  '{reason:"dev_server_unavailable",source:{path:"docs/development.md",lineStart:5,lineEnd:5},
+    attemptedCommand:{argv:["./tools/dev-fail"],exitStatus:42,failureReason:$reason}}' \
+  > "$TMP/actual-failure-evidence.json"
+assert jq -e '.reason == "dev_server_unavailable" and
+  .attemptedCommand.argv == ["./tools/dev-fail"] and
+  .attemptedCommand.exitStatus == 42 and
+  (.attemptedCommand.failureReason | contains("fixture start failed"))' \
+  "$TMP/actual-failure-evidence.json"
+assert grep -Fq 'A declared status/start/readiness command is actually attempted and fails:' "$CONTRACT"
+assert grep -Fq '`dev_server_unavailable`' "$CONTRACT"
+
+# Stale exact-head evidence is rejected by the host identity check before the
+# repository author loop is attempted for the new head.
+recorded_head="$(git -C "$REPO" rev-parse HEAD)"
+git -C "$REPO" -c user.name=test -c user.email=test@example.invalid commit --allow-empty -qm newer-head
+current_head="$(git -C "$REPO" rev-parse HEAD)"
+assert test "$recorded_head" != "$current_head"
+: > "$TARGET_ATTEMPT_LOG"
+run_attempt stale-status ./tools/dev-status
+assert test "$(cat "$TMP/stale-status.rc")" -eq 7
+run_attempt stale-start ./tools/dev-start
+assert test "$(cat "$TMP/stale-start.rc")" -eq 0
+assert grep -Fxq "$TARGET_DYNAMIC_URL" "$TMP/stale-start.stdout"
+assert test "$(grep -c '^start$' "$TARGET_ATTEMPT_LOG")" -eq 1
+run_attempt stale-cleanup ./tools/dev-stop
+assert test ! -e "$TARGET_READY_MARKER"
+
+# A suitable pre-existing exact-head target runs status only. It is neither
+# started nor cleaned, and remains available after the scenario.
+touch "$TARGET_READY_MARKER"
+: > "$TARGET_ATTEMPT_LOG"
+run_attempt preexisting-status ./tools/dev-status
+assert test "$(cat "$TMP/preexisting-status.rc")" -eq 0
+assert grep -Fq "commit=$current_head" "$TMP/preexisting-status.stdout"
+assert test "$(grep -c '^status$' "$TARGET_ATTEMPT_LOG")" -eq 1
+assert test "$(grep -Ec '^(start|cleanup)$' "$TARGET_ATTEMPT_LOG" || true)" -eq 0
+assert test -e "$TARGET_READY_MARKER"
+jq -cn --arg head "$current_head" --arg url "$TARGET_DYNAMIC_URL" \
+  '{targetSource:"repository-declaration",repositoryCommit:$head,targetUrl:$url,
+    targetUrlProvenance:"status-output",resourceOwnership:"pre-existing"}' \
+  > "$TMP/preexisting-evidence.json"
+assert jq -e '.resourceOwnership == "pre-existing" and
+  .targetUrlProvenance == "status-output"' "$TMP/preexisting-evidence.json"
+
+printf 'dm-review-repository-target-discovery: %d assertions passed\n' "$pass"

--- a/tools/test-dm-review-ui-readiness.sh
+++ b/tools/test-dm-review-ui-readiness.sh
@@ -31,7 +31,13 @@ cat > "$REPO/tools/ui-review-wrong-stop" <<'STUB'
 printf '%s\n' wrong-cleanup >> "$TEST_RESOURCE_LOG"
 STUB
 chmod +x "$REPO"/tools/ui-review-*
-git -C "$REPO" add tools
+cat > "$REPO/AGENTS.md" <<'EOF'
+# UI development
+
+Application: fixture-ui in this checkout. Use ./tools/ui-review-ready for
+status. The owned process cleanup is ./tools/ui-review-stop.
+EOF
+git -C "$REPO" add AGENTS.md tools
 git -C "$REPO" -c user.name=test -c user.email=test@example.invalid commit -qm fixture
 
 export TEST_SERVER_MARKER="$TMP/server-ready"
@@ -97,6 +103,129 @@ assert test "$remote_ready_rc" -eq 0
 assert jq -e '.state == "ready" and .dispatchAllowed == true' "$TMP/remote-explicit.confirmed"
 "$HELPER" cleanup --repository-root "$REPO" --state-file "$TMP/remote-explicit.state" > "$TMP/remote-explicit-cleanup.json"
 assert jq -e '.state == "already_clean" and .removedCount == 0' "$TMP/remote-explicit-cleanup.json"
+
+cat > "$TMP/browser-repository.json" <<'JSON'
+{"schemaVersion":1,"status":"ready","transportClass":"local-interactive","localNavigation":"confirmed","targetUrl":"http://127.0.0.1:49173/review","evidenceRef":"review/browser/repository.json"}
+JSON
+
+# Host interpretation remains distinct from helper discovery. The helper
+# consumes the bounded ready evidence and preserves exact provenance.
+jq -cn --arg checkout "$(cd "$REPO" && pwd -P)" \
+  --arg head "$(git -C "$REPO" rev-parse HEAD)" \
+  '{schemaVersion:1,status:"ready",targetSource:"repository-declaration",
+    application:"fixture-ui",checkoutRoot:$checkout,repositoryCommit:$head,checkoutState:"clean",
+    sources:[{path:"AGENTS.md",lineStart:1,lineEnd:4}],
+    attempts:[{kind:"status",argv:["./tools/ui-review-ready"],exitStatus:0,outputTail:"fixture-ui ready"}],
+    targetUrl:"http://127.0.0.1:49173/review",targetUrlProvenance:"status-output",
+    resourceOwnership:"pre-existing",cleanupArgv:[],cleanupTimeoutSeconds:0}' \
+  > "$TMP/repository-evidence.json"
+repository_prepare_rc="$(run_prepare repository-declaration --target-source repository-declaration --repository-evidence-file "$TMP/repository-evidence.json")"
+assert test "$repository_prepare_rc" -eq 0
+assert jq -e '.targetSource == "repository-declaration" and .targetRef == "private-readiness-state" and
+  (has("targetUrl") | not) and .createdResources == 0 and
+  .repositoryEvidence.sources == [{path:"AGENTS.md",lineStart:1,lineEnd:4}] and
+  .repositoryEvidence.attempts[0].argv == ["./tools/ui-review-ready"] and
+  (.repositoryEvidence.attempts[0] | has("outputTail") | not) and
+  .repositoryEvidence.resourceOwnership == "pre-existing"' "$TMP/repository-declaration.result"
+repository_ready_rc="$(run_confirm repository-declaration "$TMP/browser-repository.json")"
+assert test "$repository_ready_rc" -eq 0
+assert jq -e '.state == "ready" and .dispatchAllowed == true and
+  .targetRef == "private-readiness-state" and (has("targetUrl") | not)' "$TMP/repository-declaration.confirmed"
+"$HELPER" cleanup --repository-root "$REPO" --state-file "$TMP/repository-declaration.state" > "$TMP/repository-declaration-cleanup.json"
+assert jq -e '.state == "already_clean" and .removedCount == 0' "$TMP/repository-declaration-cleanup.json"
+
+# Stale repository evidence is rejected before navigation and cannot silently
+# fall back to a guessed target.
+jq '.repositoryCommit = "0000000000000000000000000000000000000000"' \
+  "$TMP/repository-evidence.json" > "$TMP/repository-evidence-stale.json"
+stale_repository_rc="$(run_prepare stale-repository --target-source repository-declaration \
+  --repository-evidence-file "$TMP/repository-evidence-stale.json" --visual-required true)"
+assert test "$stale_repository_rc" -eq 76
+assert jq -e '.reason == "dev_server_unavailable" and
+  (.nextAction | contains("repository_commit_mismatch"))' "$TMP/stale-repository.result"
+
+jq '.sources[0].lineEnd = 50' "$TMP/repository-evidence.json" \
+  > "$TMP/repository-evidence-unbounded-line.json"
+unbounded_source_rc="$(run_prepare unbounded-source --target-source repository-declaration \
+  --repository-evidence-file "$TMP/repository-evidence-unbounded-line.json" --visual-required true)"
+assert test "$unbounded_source_rc" -eq 76
+assert jq -e '.reason == "dev_server_unavailable" and
+  (.nextAction | contains("source_line_out_of_range"))' "$TMP/unbounded-source.result"
+
+jq '.attempts[0].outputTail = "set-cookie: session=not-for-public-output"' \
+  "$TMP/repository-evidence.json" > "$TMP/repository-evidence-secret.json"
+secret_output_rc="$(run_prepare secret-output --target-source repository-declaration \
+  --repository-evidence-file "$TMP/repository-evidence-secret.json" --visual-required true)"
+assert test "$secret_output_rc" -eq 76
+assert jq -e '.reason == "dev_server_unavailable" and
+  (.nextAction | contains("repository_evidence_invalid"))' "$TMP/secret-output.result"
+
+jq '.attempts = [range(0;4) |
+  {kind:"status",argv:["./tools/ui-review-ready"],exitStatus:0,outputTail:("x" * 7000)}]' \
+  "$TMP/repository-evidence.json" > "$TMP/repository-evidence-aggregate.json"
+aggregate_output_rc="$(run_prepare aggregate-output --target-source repository-declaration \
+  --repository-evidence-file "$TMP/repository-evidence-aggregate.json" --visual-required true)"
+assert test "$aggregate_output_rc" -eq 76
+assert jq -e '.reason == "dev_server_unavailable" and
+  (.nextAction | contains("repository_evidence_invalid"))' "$TMP/aggregate-output.result"
+
+# Dirty source is bound by content, not merely by the word "dirty".
+printf '%s\n' '# dirty snapshot one' >> "$REPO/AGENTS.md"
+jq '.checkoutState = "dirty" | .sources[0].lineEnd = 5' \
+  "$TMP/repository-evidence.json" > "$TMP/repository-evidence-dirty.json"
+dirty_repository_rc="$(run_prepare dirty-repository --target-source repository-declaration \
+  --repository-evidence-file "$TMP/repository-evidence-dirty.json" --visual-required true)"
+assert test "$dirty_repository_rc" -eq 0
+printf '%s\n' '# dirty snapshot two' >> "$REPO/AGENTS.md"
+dirty_repository_browser_rc="$(run_confirm dirty-repository "$TMP/browser-repository.json")"
+assert test "$dirty_repository_browser_rc" -eq 76
+assert jq -e '.reason == "dev_server_unavailable" and
+  (.nextAction | contains("checkout content changed"))' "$TMP/dirty-repository.confirmed"
+git -C "$REPO" show HEAD:AGENTS.md > "$REPO/AGENTS.md"
+
+# A review-created discovered process keeps its immutable cleanup in readiness
+# state. Browser failure cleans that process exactly once.
+touch "$TEST_SERVER_MARKER"
+: > "$TEST_RESOURCE_LOG"
+jq '.resourceOwnership = "review-created-process" |
+  .cleanupArgv = ["./tools/ui-review-stop"] | .cleanupTimeoutSeconds = 2 |
+  .attempts += [{kind:"start",argv:["./tools/ui-review-start"],exitStatus:0,outputTail:"http://127.0.0.1:49173/review"}] |
+  .targetUrlProvenance = "start-output"' \
+  "$TMP/repository-evidence.json" > "$TMP/repository-created-evidence.json"
+created_repository_rc="$(run_prepare repository-created --target-source repository-declaration \
+  --repository-evidence-file "$TMP/repository-created-evidence.json" --visual-required true)"
+assert test "$created_repository_rc" -eq 0
+assert jq -e '.createdByReview == true and .cleanupPending == true and
+  .repositoryEvidence.resourceOwnership == "review-created-process" and
+  .cleanupArgv == ["./tools/ui-review-stop"]' "$TMP/repository-created.state"
+created_repository_browser_rc="$(run_confirm repository-created "$TMP/missing-browser.json")"
+assert test "$created_repository_browser_rc" -eq 76
+assert jq -e '.reason == "browser_transport_unavailable"' "$TMP/repository-created.confirmed"
+assert test "$(grep -c '^cleanup$' "$TEST_RESOURCE_LOG")" -eq 1
+assert test ! -e "$TEST_SERVER_MARKER"
+: > "$TEST_RESOURCE_LOG"
+
+# Dirty initialized submodules are rejected because the root dirty marker does
+# not bind their changing content.
+SUBMODULE="$TMP/source-submodule"
+mkdir -p "$SUBMODULE"
+git -C "$SUBMODULE" init -q
+printf '%s\n' initial > "$SUBMODULE/source.txt"
+git -C "$SUBMODULE" add source.txt
+git -C "$SUBMODULE" -c user.name=test -c user.email=test@example.invalid commit -qm initial
+git -C "$REPO" -c protocol.file.allow=always submodule add -q "$SUBMODULE" vendor/source
+git -C "$REPO" add .gitmodules vendor/source
+git -C "$REPO" -c user.name=test -c user.email=test@example.invalid commit -qm submodule
+printf '%s\n' changed >> "$REPO/vendor/source/source.txt"
+jq --arg head "$(git -C "$REPO" rev-parse HEAD)" \
+  '.repositoryCommit = $head | .checkoutState = "dirty"' \
+  "$TMP/repository-evidence.json" > "$TMP/repository-evidence-dirty-submodule.json"
+dirty_submodule_rc="$(run_prepare dirty-submodule --target-source repository-declaration \
+  --repository-evidence-file "$TMP/repository-evidence-dirty-submodule.json" --visual-required true)"
+assert test "$dirty_submodule_rc" -eq 76
+assert jq -e '.reason == "dev_server_unavailable" and
+  (.nextAction | contains("dirty_submodule_unsupported"))' "$TMP/dirty-submodule.result"
+git -C "$REPO/vendor/source" show HEAD:source.txt > "$REPO/vendor/source/source.txt"
 
 # Invocation targets still require a real authority/hostname.
 hostless_rc="$(run_prepare hostless-explicit --target-url 'https://?' --target-source explicit 2> "$TMP/hostless-explicit.stderr")"

--- a/tools/validate-composition.sh
+++ b/tools/validate-composition.sh
@@ -651,6 +651,11 @@ run_composition_checks() {
     any_failed=1
   fi
 
+  printf "\n${BOLD}dm-review repository browser-target discovery:${RESET}\n"
+  if ! "$SCRIPT_DIR/test-dm-review-repository-target-discovery.sh"; then
+    any_failed=1
+  fi
+
   printf "\n${BOLD}dm-review source/rendered UI contract:${RESET}\n"
   if ! "$SCRIPT_DIR/test-dm-review-ui-contract.sh"; then
     any_failed=1

--- a/tools/validate-dm-review-codex-perspective.sh
+++ b/tools/validate-dm-review-codex-perspective.sh
@@ -395,8 +395,8 @@ for zero_deferral_surface in \
   reject_text "$zero_deferral_surface" 'P3 advisories' "${zero_deferral_surface#$REPO_ROOT/} rejects deferred P3 evidence"
   reject_text "$zero_deferral_surface" 'P3 stays advisory' "${zero_deferral_surface#$REPO_ROOT/} rejects clean-with-P3 policy"
 done
-require_text "$REPO_ROOT/plugins/dm-review/.claude-plugin/plugin.json" '"version": "1.79.1"' "canonical dm-review version is 1.79.1"
-require_text "$REPO_ROOT/plugins/dm-review/.codex-plugin/plugin.json" '"version": "1.79.1"' "generated dm-review version is 1.79.1"
+require_text "$REPO_ROOT/plugins/dm-review/.claude-plugin/plugin.json" '"version": "1.80.0"' "canonical dm-review version is 1.80.0"
+require_text "$REPO_ROOT/plugins/dm-review/.codex-plugin/plugin.json" '"version": "1.80.0"' "generated dm-review version is 1.80.0"
 require_text "$REPO_ROOT/plugins/pipeline/.claude-plugin/plugin.json" '"version": "1.66.1"' "canonical Pipeline version is 1.66.1"
 require_text "$REPO_ROOT/plugins/pipeline/.codex-plugin/plugin.json" '"dm-review": ">=1.79.1"' "generated Pipeline dependency floor is current"
 


### PR DESCRIPTION
## Outcome

Adds one bounded, host-interpreted repository browser-target discovery pass to dm-review after explicit URL, attached T3 preview, structured `.dm/ui-review.json`, and accepted exact-head packet reuse provide no usable target.

The shared full, quick, standalone visual, and Pipeline final-review path now records exact source/command/URL provenance without guessing ports or relabeling a discovered target as user-supplied. Repository-derived URLs and command tails remain private. Dirty checkouts are content-bound; dirty initialized submodules are rejected. Existing process ownership and cleanup remain authoritative.

Version: dm-review `1.79.1` -> `1.80.0`. Pipeline stays at `1.66.1` with its existing `dm-review >=1.79.1` floor because this adds no newly required Pipeline interface.

## Verification

- `bash -n` on affected helpers/tests: pass
- `./tools/test-dm-review-ui-readiness.sh`: pass, 92 assertions
- `./tools/test-dm-review-repository-target-discovery.sh`: pass, 54 assertions
- `./tools/test-dm-review-ui-contract.sh`: pass, 30 assertions
- `./tools/test-pipeline-browser-evidence.sh`: pass, 12 assertions
- `./tools/validate-workflow-contracts.sh`: pass
- `./tools/validate-dual-compat.sh`: pass
- `./tools/check-dependencies.sh`: pass; only pre-existing optional `superpowers` warnings
- manifest and command-alias generators `--check`: pass
- search index regeneration/freshness: 44 skills, 38 agents, 35 commands
- `git diff --check`: pass
- `./tools/validate-composition.sh --all`: pass

## Real consumer evidence

Exact source heads reacquired before the canary:

- Depot base: `e3518a1ebef4f299fe9ca009957f15c2f10c1388`
- Governance: `4777a292bd4ea52b74bbbc0c82be1524ca0f0299`
- Fixture Jig: `50f0d47c275928953dcaa81ee15d68e05cf0a0ae`
- Baseplate main: `a8d8d39400475a8e3fe195e29c8d64638e9814df`
- Governance's documented Baseplate `v0.1.1-alpha.16`: `7fa3f108604a2e604e4dc99af5fb96d90b5ae307`

Governance's documented isolated `make dev ACTION=<action>` loop was run as review-owned instance `ui-ready-03-gov`. `ACTION=status` exited 2 with “instance has not been started”. `ACTION=start` was attempted and exited 1 after 22.5s because the documented Baseplate source lacked `internal/baseplate/install/pages` and `internal/baseplate/search/pages`. This is `dev_server_unavailable`, not `visual_target_unavailable` or a browser failure. The exact review-created run/image/network metadata was cleaned; no persistent application data was seeded.

Baseplate main's documented `make smoke-server` declaration was attempted with unique review-owned names and its declared default, not a guessed port. It printed `http://localhost:8093`, then the container exited with code 1 before readiness; `curl` exited 7. Its exact image, volumes, network, run metadata, and temporary data directory were cleaned. This proves declaration discovery/start and honest failure handling, but not browser readiness.

T3 preview status reported an available local browser transport with no attached tab. Because neither target reached application readiness, no desktop/mobile navigation or clean browser pass is claimed. Intended Governance cases remain authenticated eligible-member proposal board/detail at 1440x900 and 390x844.

## Review disposition

One proportional general-review lane was attempted and unavailable. A bounded security review found public command-tail leakage and an insufficient dirty-checkout binding; both were repaired. Its one affected-lane recheck found repository URL disclosure and dirty-submodule ambiguity; both were repaired and covered by focused tests. No P1/P2/P3 finding is retained.

This PR remains **draft / Blocked** until a compatible exact-head Governance target can start and the desktop/mobile host-browser canary plus general review can complete.

## Fixture Jig ownership handoff

Fixture Jig should own its canonical target/browser declaration through its existing isolated `make dev ACTION=status|start|rebuild|stop|clean` loop and Baseplate `scripts/fixture-dev.sh` delegation. Bind the exact Jig checkout/commit, instance/state/run/Baseplate roots, accept only the dynamic URL printed by status/start, preserve cleanup ownership, and keep concrete routes/personas/cases in the Fixture repository. Do not add a Jig-local launcher wrapper.

## Separate release authorization checklist

- validate the trusted merged-main commit;
- pass release preflight;
- publish `dm-review-v1.80.0` (or approved replacement);
- synchronize Claude and Codex caches;
- compare installed versions/files with released source; and
- repeat the real canary through the installed plugin.

Current clean-commit preflight passed version sync, generated shims, tag analysis, remote equal-version collision checks, and push auth. It is blocked only because the installed Codex cache remains `1.79.1`, as required by this execution's no-publication/no-cache-sync boundary.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Design-Machines-Studio/codesmith/depot/pr/128"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791346506&installation_model_id=428410&pr_number=128&repository=Design-Machines-Studio%2Fdepot&return_to=https%3A%2F%2Fgithub.com%2FDesign-Machines-Studio%2Fdepot%2Fpull%2F128&signature=72a4a1fa9378f34febf1d3d09227f03c432da8246a9f4c5f60254fff1f3bcded"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->