### PR TITLE
Calibrate Astra routing and plan the full Assembly development rollout

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -69,7 +69,7 @@
     {
       "name": "project-manager",
       "source": "./plugins/project-manager",
-      "version": "1.13.0",
+      "version": "1.14.0",
       "author": {
         "name": "Design Machines"
       },
@@ -361,7 +361,7 @@
     {
       "name": "pipeline",
       "source": "./plugins/pipeline",
-      "version": "1.66.1",
+      "version": "1.67.0",
       "author": {
         "name": "Design Machines",
         "url": "https://designmachines.studio"
@@ -388,7 +388,7 @@
     {
       "name": "model-router",
       "source": "./plugins/model-router",
-      "version": "0.6.2",
+      "version": "0.7.0",
       "author": {
         "name": "Design Machines",
         "url": "https://designmachines.studio"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -202,6 +202,13 @@ Use sparingly. The full validator (`bash tools/validate-composition.sh --all`) r
 
 ## Model & Effort Tuning
 
+For Codex operator sessions, default to GPT-6 Astra Low; use Medium for demanding
+work and High or above only for a named difficult problem. Bounded workers have
+separate roles and effort. The human-facing calibration and optional context
+tradeoffs live in
+`plugins/model-router/skills/model-router/references/driver-worker-guidance.md`.
+This does not change Claude host settings or select identities in agent cards.
+
 **Review origin evidence is not a prerequisite.** Ordinary review lanes must
 run without historical implementation receipts or family exclusions. Missing
 origin metadata never makes an otherwise completed review `REVIEW INCOMPLETE`.

--- a/README.md
+++ b/README.md
@@ -271,6 +271,12 @@ Plugins compose through five patterns:
 
 See [docs/orchestration-patterns.md](docs/orchestration-patterns.md) for details.
 
+## Development improvement plan
+
+The [Assembly development improvement plan](plans/astra-routing-and-system-rollout.md)
+tracks routing, project instructions, shared skills, model costs, the Pi harness,
+and workspace cleanup, with owning repositories and completion checks.
+
 ## Validation
 
 ```shell

--- a/docs/dependency-graph.md
+++ b/docs/dependency-graph.md
@@ -75,7 +75,7 @@ graph LR
 | model-router | workflow-kernel | optional | `>=0.17.0` |
 | ned | superpowers | optional | `>=1.0.0` |
 | pipeline | dm-review | required | `>=1.79.1` |
-| pipeline | model-router | required | `>=0.6.0` |
+| pipeline | model-router | required | `>=0.7.0` |
 | pipeline | workflow-kernel | required | `>=0.19.1` |
 | pipeline | ned | optional | `>=1.4.0` |
 | pipeline | design-machines | optional | `>=1.3.0` |
@@ -91,7 +91,7 @@ graph LR
 | project-manager | design-machines | required | `>=1.3.0` |
 | project-manager | ghostwriter | required | `>=3.7.0` |
 | project-manager | council | required | `>=1.5.0` |
-| project-manager | model-router | optional | `>=0.6.0` |
+| project-manager | model-router | optional | `>=0.7.0` |
 | project-scaffolder | live-wires | optional | `>=1.0.0` |
 | project-scaffolder | dm-review | optional | `>=1.0.0` |
 | project-scaffolder | pipeline | optional | `>=1.0.0` |

--- a/docs/opus-4-8-tuning.md
+++ b/docs/opus-4-8-tuning.md
@@ -1,6 +1,8 @@
 # Claude Non-Coding Tuning
 
-How depot plugins leverage Opus 4.8 and the effort levers. This is the canonical reference -- pipeline and dm-review point here instead of restating the effort model.
+Claude host effort compatibility. For current cross-harness driver/worker guidance,
+see [driver-worker guidance](../plugins/model-router/skills/model-router/references/driver-worker-guidance.md).
+Claude defaults below are not defaults for Codex or routed workers.
 
 ## What Changed in Opus 4.8
 
@@ -52,7 +54,7 @@ records any normalization privately.
 
 | Tier | Agents | Effort | Why |
 | :--- | :----- | :----- | :-- |
-| Planning decision-gate reasoning | `architect` or independent `plan-critic` role | `high` or `max` | model-router resolves the participant; callers never pin an alias. |
+| Planning decision-gate reasoning | `architect` or independent `plan-critic` role | architect `medium`; critic `high`; selective escalation | Callers name the task difficulty; model-router resolves each participant separately. |
 | Editorial/synthesis | `editorial` role | workload-controlled | Raise effort only when the writing or synthesis warrants it. |
 | Coding and review agents | `builder-fast`, `builder-deep`, `review-fast`, `review-deep`, or `security-review` role | `low` through `max` | Agent cards inherit; model-router normalizes effort for the resolved transport. |
 

--- a/plans/astra-routing-and-system-rollout.md
+++ b/plans/astra-routing-and-system-rollout.md
@@ -1,0 +1,143 @@
+# Astra routing and system rollout — 2026-09-08
+
+## Current decision
+
+Implement the focused Depot routing update from refreshed main
+`bda7cab9ddc97b1bf8746da05ce275584d281031` in
+`feat/astra-driver-routing`. Preserve the primary checkout and every existing
+worktree. No merge, tag, release, installed-harness refresh, or account changes.
+
+The user's explicit Astra Low direction supersedes the earlier planner-only
+and preserve-Sol-effort recommendations. The
+[human-facing calibration](../plugins/model-router/skills/model-router/references/driver-worker-guidance.md)
+owns the driver/worker distinction, evidence limits, and context calculations.
+This implementation is not an all-project rollout or a performance benchmark.
+
+## Focused implementation
+
+- model-router 0.7.0: native Astra first for `architect` and `builder-deep`,
+  Sol fallback, existing Luna bounded workers and Terra specialist reviewers.
+- Pipeline 1.67.0: demanding implementation defaults to medium; bounded workers
+  may use high/max with settled requirements, file ownership, and acceptance.
+  Existing lower mechanical defaults, legacy translations, review rosters,
+  security effort, browser evidence, and retained P1/P2/P3 obligations remain.
+- project-manager 1.14.0: medium architecture opinions; explicit task-based
+  worker effort; separate critic effort and independence.
+- Keep the closed role/effort schemas and existing adapters. No new service,
+  model tier, budget ledger, provider, or context override mechanism.
+- OpenRouter 1.20.2 and its August 27 catalog remain unchanged. Astra is native
+  only; missing native price estimates are reported unavailable. Price refresh
+  and long-input cost attribution are a separate bounded follow-up.
+
+Acceptance: real dispatch fixtures select Astra at low/medium, retain Luna at
+high/max, preserve quota fallback and explicit effort, and keep identities out
+of participant surfaces. Verify generated manifests, dependency floors, routing,
+recommendations, terminal receipts, and full composition. No paid sweep is needed.
+
+## Remaining sequence
+
+This carries forward the [September 8 audit](https://github.com/Design-Machines-Studio/depot/blob/docs/depot-planning-20260907/plans/astra-alignment-20260908.md).
+Reacquire each owner's current main before its chunk; the audit's source SHAs
+are evidence snapshots, not permission to modify existing working copies.
+
+| Order / owner | Bounded work | Proof required |
+|---|---|---|
+| Active separate Depot PR #129 | Complete existing browser-target/Compose proof and review | Its exact head, actual required review, and honest baseline-test disposition; no duplicate writer |
+| Current Depot branch | Driver/worker routing and effort calibration | Focused contracts and full composition; then separately authorized merge/publication/installation and a real consumer canary |
+| Depot native-cost evidence | Refresh the relevant OpenAI prices, including long-input tiers | Measured tokens vs API-equivalent estimates remain distinct from subscription billing; preserve OpenRouter catalog dates |
+| Depot INSTRUCTIONS-01 | Repair project-scaffolder templates/hooks and Depot's own docs-only workflow | Remove file-count gates, automatic doc/lesson chores, and repeated approvals; retain real release and security checks |
+| Consumer-owned instruction branches | Baseplate first, then prototype Assembly, Jig, livewires-templ, Governance, and Floor | Short shared authority with thin harness entrypoints; preserve repo runbooks, generated-code rules, auth/migrations, and prototype fidelity |
+| Depot SKILLS-01 | Assembly development authority first; then oversized or repetitive Pipeline/review entrypoints and strategy discovery | One plugin per pass; load detailed references when needed, preserve meaningful detection and portable operation |
+| Foreman / Floor | One real Astra tool, steering, and receipt canary through existing Pi; then a current work profile and progress view | Verify the pinned Pi adapter's actual request endpoint, effort and compaction behavior; reuse events/steer/abort, no browser broker or new transport service |
+| Workspace owner | Inventory and reconcile old folders/worktrees in `~/ai` and `~/assembly` | Match Git registration, remote/merged state, dirty/untracked files and evidence ownership; prepare an exact proposed removal list for authorization |
+
+Baseplate's oversized root instructions exceed the default Codex project-document
+budget. Prototype Assembly still has personal-system prerequisites and file-count
+workflow gates. Jig and livewires-templ need portable instruction entrypoints.
+Floor's advisory P3 rule conflicts with the retained-findings policy. Demo's thin
+instructions had no demonstrated model-specific defect; preserve them.
+
+Do not apply instruction rewrites to upstream checkouts, dependency caches,
+historical proof snapshots, or every registered worktree. The earlier readable
+inventory covered 61 AGENTS and 49 CLAUDE files; protected proof directories were
+unreadable. That gap prevents an “all files audited” or safe-deletion claim.
+Cleanup must preserve dirty work and unique evidence; do not infer authorization
+to delete from age or a merged branch name.
+
+R-series disposition remains: R0 aggregate acceptance uncertain; R1 comparison
+measurement blocked; R2 complete; R3 superseded; R4 complete; R5 source complete
+with live client proof unavailable. HL01/02 and capture source work are complete;
+automatic lesson application remains rejected. No speculative framework replaces
+these remaining consumer proofs.
+
+## Quality and economics
+
+Two trusted developers build self-installed, federated intranets for 5–50-person
+co-ops with internally developed trusted Fixtures. Reuse Live Wires and existing
+components; apply YAGNI and pragmatic DRY. Preserve accessibility, performance,
+maintenance and upgrades, with fail-closed authorization, credentials, destructive
+actions and release integrity. Do not model trusted developers as hostile tenants.
+
+Start validation with a few real cases: docs repair, ordinary Go/Templ work,
+authorization regression, desktop/mobile prototype surface, and bounded context
+analysis. Record retained defects, corrections, time, tokens when measurable,
+subscription calls and measured paid spend. Luna execution and larger context
+remain hypotheses until these comparisons exist. OpenRouter's goal is at most
+$50/month; no account limit or monthly headroom has been established here.
+
+Every source change still needs separate trusted-main, publication, cache and
+real-consumer proof after authorization. This branch cannot mark the system-wide
+migration complete. Its strongest verified delivery level is recorded with the
+execution result; skipped hosted checks never count as a clean CI pass.
+
+## Execution result
+
+The focused implementation passed `validate-composition.sh --all` on September
+8. The affected router suite passed 141 assertions, the recommendation suite 24,
+terminal reporting 37, and the OpenRouter noninteractive suite 41 tests. Generated
+Codex manifests and command aliases, dependency floors/graph, and the search
+index are current. One retained P2 from a bounded contract check was fixed: the
+legacy installed-router fallback now requires 0.7.0, with fail-closed coverage.
+The earlier reported five OpenRouter baseline failures did not reproduce here.
+
+Initial validation exposed old dependency/version expectations and a candidate
+count that needed updating; those were fixed. The final full run had no failures.
+Its local log is `/tmp/astra-routing-evidence/composition-final.log`. Local proof
+does not establish exact-head hosted CI, trusted-main, publication, installation,
+or consumer delivery. No native Issue/PR or Project state changed in this task.
+
+The read-only source recommendation resolves an attemptable native driver at
+low effort with the existing native baseline as fallback. It does not dispatch
+a model. Model performance, consumer execution, large-context latency/usage,
+native API-equivalent pricing, and organization monthly-budget headroom remain
+unmeasured here. User configuration and installed harnesses were not changed.
+
+Model and cost report for the bounded contract check: role `review-fast`;
+requested participant GPT-5.6 Luna, requested effort high; Codex native
+collaboration rail; completed with one retained P2 subsequently fixed. Served
+identity, effective effort, duration, tokens, and subscription charge were not
+exposed by the collaboration tool. One subscription delegation; no observed
+fallback. OpenRouter calls: 0; paid API spend: $0 because no paid API call ran.
+The existing primary driver session is separate and its usage is unavailable.
+This is not a fabricated model-router receipt or an independence claim.
+
+SIMPLICITY-CHECK: three owning plugins, existing roles/adapters and effort
+vocabulary; no new services, account controls, provider routes, context override
+mechanisms, or unrelated plugin bumps.
+
+NOT-COVERED: real worker-performance comparison, long-session context behavior,
+native price refresh, monthly budget enforcement, consumer instruction rollout,
+Pi compatibility, cleanup, release/tag/cache synchronization, and hosted CI.
+Release preflight is not a delivery pass: installed caches intentionally retain
+older versions, and its equal-version check also flags inherited dm-review 1.80.0
+against the preserved merged-PR branch. Neither condition authorizes cache
+refresh, an unrelated bump, or deletion of a worktree.
+
+COMMANDS-RUN: authenticated main fetch and GitHub reads; fresh worktree creation;
+selective Codex configuration/catalog reads; official documentation and matching
+Codex source inspection; installed and source recommendation rendering;
+`test-model-router.sh`, `test-assembly-coordinator-recommendation.sh`,
+`test-terminal-model-report.sh`, `validate-provider-neutral-routing.sh`,
+`validate-workflow-contracts.sh`, `validate-dm-review-codex-perspective.sh`,
+`check-dependencies.sh`, both Codex generators/checks, index/graph regeneration,
+`validate-composition.sh --all`, release preflight, local-link and diff checks.

--- a/plans/astra-routing-and-system-rollout.md
+++ b/plans/astra-routing-and-system-rollout.md
@@ -1,19 +1,76 @@
-# Astra routing and system rollout — 2026-09-08
+# Assembly development improvements — implementation plan
 
-## Current decision
+**Current plan, refreshed 2026-09-08.** This covers the entire instruction,
+model, skill, harness, and workspace audit. It supersedes the sequence in the
+[earlier alignment audit](https://github.com/Design-Machines-Studio/depot/blob/docs/depot-planning-20260907/plans/astra-alignment-20260908.md),
+which remains the detailed source inventory. The routing update is the first
+implemented part; the other project changes have not shipped.
 
-Implement the focused Depot routing update from refreshed main
-`bda7cab9ddc97b1bf8746da05ce275584d281031` in
-`feat/astra-driver-routing`. Preserve the primary checkout and every existing
-worktree. No merge, tag, release, installed-harness refresh, or account changes.
+**Next bounded development chunk: INSTRUCTIONS-01 — repair shared instruction
+and workflow defaults in Depot.** Fix the generator before rolling its policy
+into consumer repositories. The current routing PR needs review separately;
+PR #129 retains its own browser/Compose closeout owner. Neither the native price
+refresh nor a model benchmark tournament is a prerequisite for instruction work.
 
-The user's explicit Astra Low direction supersedes the earlier planner-only
-and preserve-Sol-effort recommendations. The
-[human-facing calibration](../plugins/model-router/skills/model-router/references/driver-worker-guidance.md)
-owns the driver/worker distinction, evidence limits, and context calculations.
-This implementation is not an all-project rollout or a performance benchmark.
+## Current status and authority
 
-## Focused implementation
+Depot main is `4c1e9590a399406876c5760374edb5a58c3e6be2` after PR #130.
+Routing branch `feat/astra-driver-routing` was implemented and locally validated
+at `0b3e84a65a1f85e8a7584f521f46540c102f9703` from main
+`bda7cab9ddc97b1bf8746da05ce275584d281031`. PR #130 advances OpenRouter to
+1.20.3; it must be retained when integrating this branch. Local source validation
+on the earlier base is not a merged-main or consumer-proof claim.
+
+| Audit gap | Current state | Owning chunk |
+|---|---|---|
+| Astra absent from routing | Implemented on source branch; review/publication/install/consumer proof pending | MODEL-01 closeout |
+| CLI still Luna/maximum | Superseded: current user config reads Astra/high, with 1,000,000/400,000 context overrides; the policy recommends low | CONFIG-01 |
+| Blanket scaffolded chores and approvals | Pending | INSTRUCTIONS-01 |
+| Baseplate root approximately 83 KB | Pending; exceeds the default project-instruction allowance | INSTRUCTIONS-02 |
+| Prototype personal Notion and file-count gates | Pending | INSTRUCTIONS-03 |
+| Floor retained P3 findings optional | Pending | INSTRUCTIONS-04 |
+| Missing portable entrypoints in Jig/component library | Pending | INSTRUCTIONS-05 |
+| Large or conflicting shared skills | Pending, one plugin per branch | SKILLS-01 onward |
+| Native price evidence and paid-budget visibility | Pending; $50/month remains the operator ceiling, not a verified configured limit | COST-01 |
+| Foreman transport, effort, compaction, progress ergonomics | Pending real Pi canary | HARNESS-01 |
+| Old folders, worktrees, and proof snapshots | Inventory/reconciliation pending; nothing authorized for deletion by this plan | CLEANUP-01 |
+
+Repository-specific findings below were inspected in the September 8 audit.
+Refresh the owning repository, instructions, open PRs and worktrees at execution;
+do not assume those snapshots are current permission to edit another session's
+files. Demo's thin instructions had no demonstrated defect and need no rewrite.
+
+## Results the whole program must achieve
+
+- Two trusted developers can finish ordinary work without repeated planning,
+  documentation-agent, lesson-update, or permission chores. Approval remains
+  necessary at real destructive, credential, authorization and release boundaries.
+- Instructions fit their harness's loading budget and point to existing topical
+  references. Shared workflows work without Notion or personal memory systems.
+- Assembly remains a self-installed, federated intranet for 5–50-person co-ops
+  using internally developed trusted Fixtures. No speculative enterprise scale,
+  hostile-Fixture infrastructure, approval platform, or additional service.
+- Reuse Live Wires and existing components. Preserve prototype structure, copy,
+  classes and meaningful states unless a divergence is deliberate. Keep
+  accessibility, performance, upgrades, maintenance and actual security tests.
+- Fix every retained P1/P2/P3 finding. Keep applicable review and rendered checks,
+  reuse still-exact evidence, and stop review churn after convergence.
+- Astra drives design and integration; bounded workers receive clear ownership
+  and acceptance. Subscription capacity and economical OpenRouter offload are
+  both useful. No worker inherits the driver model or maximum effort implicitly.
+- Human reports are brief and plain, with the result and one next action.
+  Estimates, unavailable measurements and failed lanes remain explicit.
+
+## Execution sequence
+
+Each numbered consumer row is a separate repository branch and PR. A skill pass
+changes one owning plugin at a time. Prepare one complete execution prompt for
+the selected chunk when requested; do not issue a bundle of competing prompts.
+
+### MODEL-01 — finish the existing routing change
+
+Owner: Depot, existing `feat/astra-driver-routing`; do not start a second writer.
+
 
 - model-router 0.7.0: native Astra first for `architect` and `builder-deep`,
   Sol fallback, existing Luna bounded workers and Terra specialist reviewers.
@@ -34,63 +91,181 @@ high/max, preserve quota fallback and explicit effort, and keep identities out
 of participant surfaces. Verify generated manifests, dependency floors, routing,
 recommendations, terminal receipts, and full composition. No paid sweep is needed.
 
-## Remaining sequence
+Review this exact branch, reconcile current main (including PR #130), and fix
+every retained finding. Before later authorized delivery, verify exact-head CI
+or state its absence, trusted main, plugin tags, both harness caches and one
+real consumer chunk. No merge, tag or installation refresh is authorized by the
+current planning task. Existing PR #129 remains a separate browser-review lane.
 
-This carries forward the [September 8 audit](https://github.com/Design-Machines-Studio/depot/blob/docs/depot-planning-20260907/plans/astra-alignment-20260908.md).
-Reacquire each owner's current main before its chunk; the audit's source SHAs
-are evidence snapshots, not permission to modify existing working copies.
+### INSTRUCTIONS-01 — fix the shared generator first
 
-| Order / owner | Bounded work | Proof required |
+Owner: Depot `project-scaffolder`, plus Depot's root workflow guidance.
+Likely surfaces: scaffolding SKILL.md, `references/project-configs.md`, generated
+instruction/hook templates, associated fixtures, AGENTS.md and CLAUDE.md.
+
+Remove unconditional planning for three steps/files, documentation-agent runs
+after every edit, lesson writes after every correction, and file-count-driven
+commits. Replace these with task-based workflow selection and explicit authorized
+completion. Keep real Docker, credential, authorization, destructive-action and
+release protections. State the small trusted-team scope without copying an
+entire company strategy into every generated file.
+
+Acceptance: generated examples for the supported project types have concise,
+portable instructions and no conflicting mandatory chores. A docs correction,
+ordinary Go/Templ change and authorization change each select proportional work
+and verification. Define a docs-only validation lane for Depot while retaining
+full composition for plugin changes. Check generated artifacts and affected
+fixtures; use full composition for the plugin update. Bump only the owning
+plugin and regenerate its Codex metadata. No consumer product code changes.
+
+### INSTRUCTIONS-02 through 05 — apply the policy in consumers
+
+Start with Baseplate after the generator policy is reviewed and available.
+Aim for roughly 8 KiB or less across root instruction entrypoints where practical;
+verify the actual discovered instruction stack fits the harness allowance. This
+is an editing target, not permission to remove necessary contracts or merely
+raise Codex's default 32 KiB project-document allowance.
+
+| Chunk / owner | Smallest change | Acceptance |
 |---|---|---|
-| Active separate Depot PR #129 | Complete existing browser-target/Compose proof and review | Its exact head, actual required review, and honest baseline-test disposition; no duplicate writer |
-| Current Depot branch | Driver/worker routing and effort calibration | Focused contracts and full composition; then separately authorized merge/publication/installation and a real consumer canary |
-| Depot native-cost evidence | Refresh the relevant OpenAI prices, including long-input tiers | Measured tokens vs API-equivalent estimates remain distinct from subscription billing; preserve OpenRouter catalog dates |
-| Depot INSTRUCTIONS-01 | Repair project-scaffolder templates/hooks and Depot's own docs-only workflow | Remove file-count gates, automatic doc/lesson chores, and repeated approvals; retain real release and security checks |
-| Consumer-owned instruction branches | Baseplate first, then prototype Assembly, Jig, livewires-templ, Governance, and Floor | Short shared authority with thin harness entrypoints; preserve repo runbooks, generated-code rules, auth/migrations, and prototype fidelity |
-| Depot SKILLS-01 | Assembly development authority first; then oversized or repetitive Pipeline/review entrypoints and strategy discovery | One plugin per pass; load detailed references when needed, preserve meaningful detection and portable operation |
-| Foreman / Floor | One real Astra tool, steering, and receipt canary through existing Pi; then a current work profile and progress view | Verify the pinned Pi adapter's actual request endpoint, effort and compaction behavior; reuse events/steer/abort, no browser broker or new transport service |
-| Workspace owner | Inventory and reconcile old folders/worktrees in `~/ai` and `~/assembly` | Match Git registration, remote/merged state, dirty/untracked files and evidence ownership; prepare an exact proposed removal list for authorization |
+| INSTRUCTIONS-02 / assembly-baseplate | Shorten root AGENTS/CLAUDE; remove repeated chores; move detailed reference into existing topic docs | Both harnesses find the same authority; preserve Go/Docker runbooks, auth, migrations, testing and release requirements; ordinary work has one appropriate verification path |
+| INSTRUCTIONS-03 / prototype Assembly | Remove mandatory personal Notion access and full Pipeline selected by file count | Work succeeds without personal systems; prototype remains UI authority; rendered desktop/mobile checks still apply to affected UI |
+| INSTRUCTIONS-04 / Assembly Floor | Require fixing every retained P3; make personal design context optional | All retained findings are mandatory; preserve Floor's read-only observation boundary and Live Wires design authority |
+| INSTRUCTIONS-05a / Fixture Jig | Add a thin portable AGENTS entrypoint to existing authoring authority | Codex and Claude find the same trusted-Fixture rules and documented author loop; do not duplicate a second guide |
+| INSTRUCTIONS-05b / livewires-templ | Add a thin portable entrypoint | Preserve generated Templ output rules, attribute safety and component reuse |
+| INSTRUCTIONS-05c / Governance | Consolidate only demonstrated instruction duplication | Preserve the current author loop, verification and release authority; avoid active product PRs |
 
-Baseplate's oversized root instructions exceed the default Codex project-document
-budget. Prototype Assembly still has personal-system prerequisites and file-count
-workflow gates. Jig and livewires-templ need portable instruction entrypoints.
-Floor's advisory P3 rule conflicts with the retained-findings policy. Demo's thin
-instructions had no demonstrated model-specific defect; preserve them.
+For each: inspect the exact diff and effective instruction load; run focused
+repository checks for changed instruction generators or hooks. Documentation
+alone does not require an unrelated application test sweep. If an instruction
+changes the development command path, exercise that path on a disposable target.
+Do not update old worktrees, dependency caches or upstream checkouts by grep.
 
-Do not apply instruction rewrites to upstream checkouts, dependency caches,
-historical proof snapshots, or every registered worktree. The earlier readable
-inventory covered 61 AGENTS and 49 CLAUDE files; protected proof directories were
-unreadable. That gap prevents an “all files audited” or safe-deletion claim.
-Cleanup must preserve dirty work and unique evidence; do not infer authorization
-to delete from age or a merged branch name.
+### SKILLS-01 onward — reduce loaded instructions without losing knowledge
 
-R-series disposition remains: R0 aggregate acceptance uncertain; R1 comparison
-measurement blocked; R2 complete; R3 superseded; R4 complete; R5 source complete
-with live client proof unavailable. HL01/02 and capture source work are complete;
-automatic lesson application remains rejected. No speculative framework replaces
-these remaining consumer proofs.
+Owner: Depot, one plugin per branch in this order:
 
-## Quality and economics
+1. Assembly development: separate prototype authority from production
+   Go/Templ/Datastar work; move detailed implementation references out of the
+   large entrypoint and preserve correct authoring/upgrade rules.
+2. Pipeline: remove duplicated planning and review gates; retain approved scope,
+   requirements, deterministic verification, cleanup and delivery contracts.
+3. dm-review: consolidate repeated guidance, retain applicable lanes, all retained
+   findings, repository-owned browser discovery and honest unavailable outcomes.
+   Begin after the active #129 owner has finished its shared review surfaces.
+4. Design Machines strategy/discovery: narrow the oversized trigger description
+   and load task-specific references without losing company constraints.
 
-Two trusted developers build self-installed, federated intranets for 5–50-person
-co-ops with internally developed trusted Fixtures. Reuse Live Wires and existing
-components; apply YAGNI and pragmatic DRY. Preserve accessibility, performance,
-maintenance and upgrades, with fail-closed authorization, credentials, destructive
-actions and release integrity. Do not model trusted developers as hostile tenants.
+Inspect coordinator and other relevant shared skills for conflicts as part of
+those affected paths; change them only where a reproduced conflict requires it.
+Do not rewrite unrelated domain knowledge merely because it is lengthy.
 
-Start validation with a few real cases: docs repair, ordinary Go/Templ work,
-authorization regression, desktop/mobile prototype surface, and bounded context
-analysis. Record retained defects, corrections, time, tokens when measurable,
-subscription calls and measured paid spend. Luna execution and larger context
-remain hypotheses until these comparisons exist. OpenRouter's goal is at most
-$50/month; no account limit or monthly headroom has been established here.
+Acceptance per pass: focused trigger/contract fixtures, one ordinary consumer
+example, and measured loaded context before/after. Report bytes or estimated
+context as such, not measured model tokens. Preserve canonical Claude sources,
+generated aliases/manifests, necessary dependency floors and full composition.
+No new orchestration engine, state schema or general runbook parser.
 
-Every source change still needs separate trusted-main, publication, cache and
-real-consumer proof after authorization. This branch cannot mark the system-wide
-migration complete. Its strongest verified delivery level is recorded with the
-execution result; skipped hosted checks never count as a clean CI pass.
+### CONFIG-01 and COST-01 — local defaults and economical routing
 
-## Execution result
+CONFIG-01 is an operator-local check. The saved CLI setting now reads Astra/high;
+do not claim Luna/max or overwrite a newer choice silently. The agreed default
+recommendation remains Astra/low, medium for demanding work and selective high+
+escalation. Keep current context overrides optional and local. Their catalog
+cap and source-derived calculations are recorded in
+[driver-worker guidance](../plugins/model-router/skills/model-router/references/driver-worker-guidance.md).
+Do not propagate those overrides to workers, other models or providers.
+
+COST-01 is a bounded Depot change to current native price evidence and its
+existing reporting consumers. Refresh cited OpenAI prices and long-input tiers;
+keep the OpenRouter catalog's independent evidence dates intact. Missing prices
+stay unavailable until the existing summary can represent them truthfully.
+Subscription usage is not API billing. Do not build a general pricing engine.
+
+Use existing provider budget controls and receipts for the $50/month operator
+ceiling. Verify what monthly spend/headroom the account actually exposes before
+claiming enforcement. Prefer available subscription capacity and focused cheap
+offload; avoid speculative paid sweeps. Record per-run measured spend, fallback
+and unknown usage. Account settings belong to the operator, not tracked shared
+routing policy. A missing monthly API does not justify a new budget service.
+
+Acceptance: a native call, a bounded metered call and an unavailable measurement
+are reported honestly; quota exhaustion falls back without repeated approvals.
+Validate Luna High/Max with a small real implementation and required review,
+comparing accepted outcome, retained defects, repairs, latency and measured usage.
+One useful comparison is enough to inform the next choice; no blanket savings
+or benchmark claim is justified by the calibration post.
+
+### HARNESS-01 — prove the existing Pi path before extending it
+
+Owner: Foreman for execution; Floor only for its existing observation UI.
+Reacquire current source: the audit found Pi 0.84.4, fixed high thinking, disabled
+compaction, an in-memory session and a fixed proof task. These are inspection
+leads, not a claim that the current adapter is broken.
+
+First run one bounded Astra canary through the actual pinned Pi adapter: tools,
+request/response compatibility, selected effort, task progress, steering and
+cancellation. Check the Astra tool endpoint before making compatibility claims.
+Then replace only the fixed proof-task/effort assumptions that block current work
+with one useful current work profile. Reuse existing Pi events, steer and abort;
+keep Floor as the existing reader of progress. Evaluate compaction separately.
+
+Acceptance: one real bounded task can be followed, steered, stopped and reported
+through the current UI, with actual participant and measurement gaps visible.
+OpenRouter continuation must respect its actual adapter capabilities. No new
+broker, browser service, general workflow platform or invented transport layer.
+
+### CLEANUP-01 — reconcile folders and worktrees safely
+
+Owner: workspace maintenance across `/home/ned/ai` and `/home/ned/assembly`.
+Inventory can run independently of instruction implementation. Deletion cannot.
+
+Produce an exact keep/archive/remove/uncertain list tied to Git registration,
+local and remote commits, merged PR state, dirty/untracked files, evidence and
+current ownership. Preserve active and unique work, benchmark evidence, upstream
+references and dependency caches. The earlier readable inventory found 61 AGENTS
+and 49 CLAUDE files, including historical copies; protected proof directories
+were unreadable. Treat that uncertainty honestly.
+
+Prepare the concrete removal list for explicit authorization. At execution,
+recheck every approved path before removing it; preserve unique files/commits and
+confirm recovery evidence first. Do not infer permission from age or merged
+branch names. Never stash, reset, clean, switch or discard the protected primary
+checkout to make cleanup easier. No broad recursive deletion or remote-branch
+cleanup is authorized by this plan.
+
+Acceptance: intended worktrees still resolve, active repositories are intact,
+unique work and evidence remain recoverable, and the receipt names exactly what
+was removed, retained or blocked. Use existing Git/filesystem tools; no cleanup
+service or new registry.
+
+## Coordination and completion
+
+Only active Issues/PRs that directly advance Assembly belong in Project 1. Keep
+native repository ownership; do not create a parallel backlog or copy consumer
+product roadmaps. Reuse the existing planning index and treat older untracked
+plans as evidence leads, not competing execution authority.
+
+R-series remains: R0 aggregate proof uncertain, R1 comparison measurement
+blocked, R2 complete, R3 superseded, R4 complete, R5 source complete with live
+client proof unavailable. HL01/02 and capture source work are complete; automatic
+lesson application remains rejected. Retain those commitments alongside this
+program without building speculative replacements.
+
+Every plugin chunk records canonical version/marketplace, generated Codex
+surfaces, necessary dependency floors/index/fixtures, local and exact-head
+verification, then separately authorized trusted-main/tag/cache/consumer proof.
+Root consumer instructions ship through their own PRs. Keep output brief, fix
+retained findings, and preserve exact evidence instead of repeating whole reviews.
+
+The program is complete only when targeted current repositories load coherent
+instructions, shared plugin behavior is installed and consumer-proven, Pi's
+current path is demonstrated, the paid budget is truthfully observable or its
+limits stated, and approved cleanup has preserved recoverable work. A routing
+merge alone does not complete the instruction or harness migration.
+
+## Prior routing implementation evidence
+
 
 The focused implementation passed `validate-composition.sh --all` on September
 8. The affected router suite passed 141 assertions, the recommendation suite 24,
@@ -104,7 +279,8 @@ Initial validation exposed old dependency/version expectations and a candidate
 count that needed updating; those were fixed. The final full run had no failures.
 Its local log is `/tmp/astra-routing-evidence/composition-final.log`. Local proof
 does not establish exact-head hosted CI, trusted-main, publication, installation,
-or consumer delivery. No native Issue/PR or Project state changed in this task.
+or consumer delivery. That implementation turn changed no native Issue/PR or Project state; this
+planning follow-up opens a PR for the implementation and complete rollout plan.
 
 The read-only source recommendation resolves an attemptable native driver at
 low effort with the existing native baseline as fallback. It does not dispatch

--- a/plugins/model-router/.claude-plugin/plugin.json
+++ b/plugins/model-router/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "model-router",
   "description": "Internal deterministic role resolver and one-shot dispatcher for provider-neutral model work",
-  "version": "0.6.2",
+  "version": "0.7.0",
   "author": {
     "name": "Design Machines",
     "url": "https://designmachines.studio"

--- a/plugins/model-router/.codex-plugin/plugin.json
+++ b/plugins/model-router/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "model-router",
-  "version": "0.6.2",
+  "version": "0.7.0",
   "description": "Internal deterministic role resolver and one-shot dispatcher for provider-neutral model work",
   "author": {
     "name": "Design Machines",

--- a/plugins/model-router/skills/model-router/SKILL.md
+++ b/plugins/model-router/skills/model-router/SKILL.md
@@ -9,6 +9,11 @@ disable-model-invocation: true
 This internal skill owns cross-transport role resolution. It is a local policy
 bundle and one-shot dispatcher, not a service.
 
+For human-facing session setup and calibration, read
+`references/driver-worker-guidance.md`. It separates the operator's main driver
+from routed workers. Never copy its concrete identities into participant
+packets; explicit role effort and transport normalization remain separate.
+
 Callers provide only a role, required capabilities, normalized effort, the
 exact validated Workflow Kernel launcher for that invocation, prompt file,
 output destination, private receipt destination, an explicit complete

--- a/plugins/model-router/skills/model-router/references/driver-worker-guidance.md
+++ b/plugins/model-router/skills/model-router/references/driver-worker-guidance.md
@@ -1,0 +1,98 @@
+# Main driver and bounded workers
+
+Human-facing setup and calibration, observed 2026-09-08. Concrete identities in
+this reference are for the operator; never copy them into worker, reviewer,
+critic, or architect packets. The existing `role-policy.json` owns selection.
+
+| Work | Starting point | Escalation |
+|---|---|---|
+| Main driver and orchestration | GPT-6 Astra Low in Codex | Medium for demanding reasoning; High or above only for a named difficult architecture, debugging, or review problem |
+| Architecture and integration participant | `architect` or `builder-deep`; native Astra first | Medium for demanding work; explicit High/Max when justified |
+| Bounded execution | `builder-fast`; native GPT-5.6 Luna at High | Max for demonstrated difficulty; lower effort for simple mechanical work |
+| Final design, integration, and review decisions | Main driver | Keep applicable specialist review lanes and fix every retained P1/P2/P3 |
+| Optional fallback or comparison | GPT-5.6 Sol High | Existing fallback candidate, never the primary driver |
+| Specialist middle tier | Existing GPT-5.6 Terra critic/review candidates | No new tier, role, or orchestration branch |
+
+Luna execution requires settled requirements, exact file ownership, and
+verifiable acceptance criteria. The driver owns unresolved design and integrates
+the result. Workers do not inherit the driver identity or effort: agent cards
+remain `model: inherit` as neutral metadata, while actual dispatch uses each
+explicit role request. Routine review workers remain separate from the driver.
+
+The normalized request vocabulary stays `low|medium|high|max`. Explicit effort
+is preserved across candidate fallback, with only the existing transport mapping
+(OpenRouter `max` becomes `high`). Sol High is an optional operator starting
+point/comparison, not a hidden rewrite of a Low request during automatic fallback.
+Native host-only levels such as `xhigh` do not expand the routing contract.
+
+## Evidence and limits
+
+[Tibo's September 6 calibration](https://x.com/thsottiaux/status/2096688770523467947)
+recommends moving from satisfactory Sol High usage to Astra Low or Medium. This
+is first-party calibration guidance, not a guarantee on every Depot task. The
+post was retrieved through the public FxTwitter mirror when direct X retrieval
+failed. It supplies no evidence for Luna execution performance.
+
+Luna High/Max bounded execution is a workflow hypothesis. Validate it with an
+ordinary implementation chunk and its required review: accepted result, retained
+defects, corrections, elapsed time, tokens when measured, and actual paid cost.
+Do not call this a benchmark win or claim lower subscription usage without
+measurements. Use one useful comparison when evidence warrants it, not a model
+tournament. The [Astra migration guide](https://developers.openai.com/api/docs/guides/latest-model)
+also supports clear instructions, deliberate delegation, and proportionate tests.
+
+## Subscription and provider boundaries
+
+Prefer eligible subscription capacity for each role. Existing OpenRouter
+candidates remain available as usage extenders and for useful independent
+perspectives after capability and availability resolution. A quota response
+exhausts that native rail for the run; do not retry it under another model name.
+Unknown allowance mapping is not proof of exhaustion, and an active Codex driver
+is not unavailable merely because a nested CLI cannot identify its parent.
+
+Keep OpenAI and Anthropic on their native CLI rails; no Astra slug is added to
+the OpenRouter routing catalog. That catalog's 2026-08-27 evidence is unchanged.
+Astra's API-equivalent price is absent from the existing cost matrix, so report
+it as unavailable while labeling native use `included subscription`. A later
+native-cost refresh must handle current prices and long-input tiers rather than
+applying a short-input price to every request. Never report API-equivalent
+estimates as subscription charges.
+
+Use the existing bounded OpenRouter controls and exact terminal receipts. For
+the current operator, the target is at most $50/month; this is a budget goal,
+not an applied account limit or evidence of remaining headroom. No account-wide
+budget service is required. Respect known remaining budget, avoid speculative
+paid sweeps, and report missing monthly-spend measurements plainly.
+
+## Optional Codex context settings
+
+NED's user configuration already selected Astra Low on September 8:
+
+```toml
+model = "gpt-6-astra"
+model_reasoning_effort = "low"
+model_context_window = 1000000
+model_auto_compact_token_limit = 400000
+```
+
+This is a local observation, not a shared configuration template. Do not copy
+the context overrides into repositories, other models, Claude, or OpenRouter.
+Do not overwrite an operator's explicit model or effort selection.
+
+Codex CLI 0.153.4's cached catalog, fetched at 2026-09-07T23:20:32Z, advertises
+Astra's default window as 272,000, maximum as 872,000, and usable percentage as
+95. The matching release's [override code](https://github.com/openai/codex/blob/rust-v0.153.4/codex-rs/models-manager/src/model_info.rs)
+clamps the requested window to the catalog maximum. Its
+[context calculations](https://github.com/openai/codex/blob/rust-v0.153.4/codex-rs/protocol/src/openai_models.rs)
+therefore imply 872,000 total, 828,400 usable, and a 400,000 auto-compaction
+threshold (the smaller of the explicit threshold and 90% of the total window).
+These are source-and-catalog calculations, not an observed long-running session
+or proof that a remote service accepts every such request.
+
+The [API model card](https://developers.openai.com/api/docs/models/gpt-6-astra)
+advertises a larger API window; it does not override Codex's catalog cap. Larger
+context may reduce compaction frequency on long tasks while increasing retained
+input, latency, and usage. The 400,000 threshold still compacts before filling
+the maximum window. Keep this optional and compare real long tasks before
+claiming a performance improvement; see the
+[Codex configuration reference](https://developers.openai.com/codex/config-reference).

--- a/plugins/model-router/skills/model-router/references/role-policy.json
+++ b/plugins/model-router/skills/model-router/references/role-policy.json
@@ -12,6 +12,7 @@
   },
   "roles": {
 "architect": [
+      {"model": "gpt-6-astra", "provider": "openai", "transport": "codex-cli", "family": "openai", "billing": "included-subscription", "capabilities": ["read-repository", "tool-use", "long-context", "structured-output"]},
       {"model": "gpt-5.6-sol", "provider": "openai", "transport": "codex-cli", "family": "openai", "billing": "included-subscription", "capabilities": ["read-repository", "tool-use", "long-context", "structured-output"]},
       {"model": "opus", "servedIdentities": ["claude-opus-5"], "provider": "anthropic", "transport": "claude-cli", "family": "anthropic", "billing": "subscription-or-local-paid-credits", "capabilities": ["read-repository", "long-context", "structured-output"]},
       {"model": "qwen/qwen3.8-max", "provider": "openrouter", "transport": "openrouter", "family": "qwen", "billing": "api", "capabilities": ["read-repository", "long-context", "structured-output"]}
@@ -29,6 +30,7 @@
       {"model": "z-ai/glm-5.3-flash", "provider": "openrouter", "transport": "openrouter", "family": "z-ai", "billing": "api", "capabilities": ["read-repository", "write-repository", "structured-output"]}
     ],
     "builder-deep": [
+      {"model": "gpt-6-astra", "provider": "openai", "transport": "codex-cli", "family": "openai", "billing": "included-subscription", "capabilities": ["read-repository", "write-repository", "tool-use", "long-context", "structured-output"]},
       {"model": "gpt-5.6-sol", "provider": "openai", "transport": "codex-cli", "family": "openai", "billing": "included-subscription", "capabilities": ["read-repository", "write-repository", "tool-use", "long-context", "structured-output"]},
       {"model": "gpt-5.6-terra", "provider": "openai", "transport": "codex-cli", "family": "openai", "billing": "included-subscription", "capabilities": ["read-repository", "write-repository", "tool-use", "long-context", "structured-output"]},
       {"model": "deepseek/deepseek-v4-pro-0813", "provider": "openrouter", "transport": "openrouter", "family": "deepseek", "billing": "api", "capabilities": ["read-repository", "write-repository", "long-context", "structured-output"]},

--- a/plugins/pipeline/.claude-plugin/plugin.json
+++ b/plugins/pipeline/.claude-plugin/plugin.json
@@ -1,14 +1,14 @@
 {
   "name": "pipeline",
   "description": "Autonomous feature development pipeline with approved-scope intake, minimum-adequate planning, bounded adversarial review, fresh tiered verification, browser recovery, and isolated execution",
-  "version": "1.66.1",
+  "version": "1.67.0",
   "author": {
     "name": "Design Machines",
     "url": "https://designmachines.io"
   },
   "pluginDependencies": {
     "dm-review": ">=1.79.1",
-    "model-router": ">=0.6.0",
+    "model-router": ">=0.7.0",
     "workflow-kernel": ">=0.19.1"
   },
   "optionalPluginDependencies": {

--- a/plugins/pipeline/.codex-plugin/plugin.json
+++ b/plugins/pipeline/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pipeline",
-  "version": "1.66.1",
+  "version": "1.67.0",
   "description": "Autonomous feature development pipeline with approved-scope intake, minimum-adequate planning, bounded adversarial review, fresh tiered verification, browser recovery, and isolated execution",
   "author": {
     "name": "Design Machines",
@@ -164,7 +164,7 @@
   },
   "pluginDependencies": {
     "dm-review": ">=1.79.1",
-    "model-router": ">=0.6.0",
+    "model-router": ">=0.7.0",
     "workflow-kernel": ">=0.19.1"
   },
   "optionalPluginDependencies": {

--- a/plugins/pipeline/agents/workflow/execution-orchestrator.md
+++ b/plugins/pipeline/agents/workflow/execution-orchestrator.md
@@ -507,7 +507,7 @@ model-router bundle:
 ```bash
 : "${WORKFLOW_KERNEL:?resolve workflow-kernel-launcher.sh first}"
 MODEL_ROUTER_BUNDLE_JSON=$("$WORKFLOW_KERNEL" resolve-plugin-bundle \
-  --plugin model-router --minimum-version 0.6.0 \
+  --plugin model-router --minimum-version 0.7.0 \
   --required-executable skills/model-router/references/role-dispatch.sh \
   --required-executable skills/model-router/references/render-terminal-report.sh \
   --required-asset skills/model-router/references/role-request-schema.json \

--- a/plugins/pipeline/references/cascade-dispatch.sh
+++ b/plugins/pipeline/references/cascade-dispatch.sh
@@ -86,7 +86,7 @@ fi
 DISPATCHER="$DIR/../../model-router/skills/model-router/references/role-dispatch.sh"
 if [ ! -x "$DISPATCHER" ]; then
   BUNDLE_JSON="$("$WORKFLOW_KERNEL_LAUNCHER" resolve-plugin-bundle \
-    --plugin model-router --minimum-version 0.6.0 \
+    --plugin model-router --minimum-version 0.7.0 \
     --required-executable skills/model-router/references/role-dispatch.sh \
     --required-asset skills/model-router/references/role-request-schema.json \
     --required-asset skills/model-router/references/role-policy.json 2>/dev/null)" || BUNDLE_JSON=""

--- a/plugins/pipeline/references/routing-policy.json
+++ b/plugins/pipeline/references/routing-policy.json
@@ -5,9 +5,9 @@
     "docs": {"executorRole": "builder-fast", "executorCapabilities": ["read-repository", "write-repository", "structured-output"], "executorEffort": "low"},
     "config": {"executorRole": "builder-fast", "executorCapabilities": ["read-repository", "write-repository", "structured-output"], "executorEffort": "medium"},
     "mechanical-logic": {"executorRole": "builder-fast", "executorCapabilities": ["read-repository", "write-repository", "structured-output"], "executorEffort": "medium"},
-    "logic": {"executorRole": "builder-deep", "executorCapabilities": ["read-repository", "write-repository", "long-context", "structured-output"], "executorEffort": "high"},
-    "ui": {"executorRole": "builder-deep", "executorCapabilities": ["read-repository", "write-repository", "structured-output"], "executorEffort": "high"},
-    "integration": {"executorRole": "builder-deep", "executorCapabilities": ["read-repository", "write-repository", "long-context", "structured-output"], "executorEffort": "high"}
+    "logic": {"executorRole": "builder-deep", "executorCapabilities": ["read-repository", "write-repository", "long-context", "structured-output"], "executorEffort": "medium"},
+    "ui": {"executorRole": "builder-deep", "executorCapabilities": ["read-repository", "write-repository", "structured-output"], "executorEffort": "medium"},
+    "integration": {"executorRole": "builder-deep", "executorCapabilities": ["read-repository", "write-repository", "long-context", "structured-output"], "executorEffort": "medium"}
   },
   "legacyExecutorTranslation": {
     "openrouter": {"executorRole": "builder-fast", "executorCapabilities": ["read-repository", "write-repository", "structured-output"], "executorEffort": "medium"},

--- a/plugins/pipeline/skills/promptcraft/SKILL.md
+++ b/plugins/pipeline/skills/promptcraft/SKILL.md
@@ -51,6 +51,17 @@ A chunk is a logically complete unit (one feature aspect, one migration, one com
    - add `browser`, `tool-use`, `long-context`, or `structured-output` only
      when the chunk actually requires that capability.
 
+   Keep the main driver responsible for design decisions, integration, and
+   final review. A bounded implementation may use `builder-fast` at `high`
+   effort, with `max` reserved for a demonstrated difficulty, when its prompt
+   supplies settled requirements, exact file ownership, and verifiable
+   acceptance criteria. Use the existing `bounded-mechanical-work` override
+   only when that description is true; unresolved design stays `builder-deep`.
+   This is a workflow hypothesis to validate on real chunks, not a benchmark
+   claim. Simple docs and mechanical changes keep their lower policy effort.
+   Do not inherit the driver's model or effort for each worker. Raising effort
+   never adds a review lane or changes required verification.
+
    Planning HTML is an explicit narrow exception to the `.html` UI trigger: a chunk containing only planning Markdown/JSON/YAML plus unserved `plans/**.html` artifacts remains `config` and `builder-fast`. If splitting separates offline planning artifacts from served UI or live-tool work, split it; mixed or uncertain product surfaces classify up: `ui` > `integration` > `logic` > `config`.
 
    Then classify rendered-output applicability independently. Every new chunk

--- a/plugins/project-manager/.claude-plugin/plugin.json
+++ b/plugins/project-manager/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-manager",
   "description": "Project management: LT10 methodology, Notion-integrated sprint planning, and GitHub-native cross-repository Assembly coordination",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "author": {
     "name": "Design Machines"
   },
@@ -12,7 +12,7 @@
     "council": ">=1.5.0"
   },
   "optionalPluginDependencies": {
-    "model-router": ">=0.6.0"
+    "model-router": ">=0.7.0"
   },
   "capabilities": {
     "skills": [

--- a/plugins/project-manager/.codex-plugin/plugin.json
+++ b/plugins/project-manager/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "project-manager",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "description": "Project management: LT10 methodology, Notion-integrated sprint planning, and GitHub-native cross-repository Assembly coordination",
   "author": {
     "name": "Design Machines"
@@ -105,7 +105,7 @@
     "council": ">=1.5.0"
   },
   "optionalPluginDependencies": {
-    "model-router": ">=0.6.0"
+    "model-router": ">=0.7.0"
   },
   "interface": {
     "displayName": "Project Manager",

--- a/plugins/project-manager/skills/assembly-coordinator/SKILL.md
+++ b/plugins/project-manager/skills/assembly-coordinator/SKILL.md
@@ -135,6 +135,12 @@ Every prompt must state:
   configuration, and mechanical work; `builder-deep` for complex logic, UI,
   and integration; and the matching review role for verification. Add browser,
   tool-use, long-context, or structured-output capabilities only when required.
+  For a bounded implementation with settled requirements, exact file ownership,
+  and verifiable acceptance criteria, use `builder-fast` at `high`; reserve
+  `max` for a demonstrated difficulty and keep mechanical tasks lower. Use
+  `builder-deep` at `medium` for demanding design or integration, escalating
+  only when the task warrants it. The main driver retains design decisions,
+  integration, and final review; workers do not inherit its model or effort.
 
 The prompt must not call a direct provider command or contain a concrete
 routing override. Its role request is resolved later by model-router.
@@ -143,7 +149,7 @@ routing override. Its role request is resolved later by model-router.
 
 Whenever this coordinator produces an implementation or review copy-paste
 prompt, resolve one coherent model-router bundle through Workflow Kernel at
-minimum version `0.6.0`, requiring
+minimum version `0.7.0`, requiring
 `skills/model-router/references/operator-recommendation.sh`, `role-policy.json`,
 and `availability-probe.sh`. Resolve the current OpenRouter
 `model-matrix.json` through Workflow Kernel without changing it. Invoke the

--- a/plugins/project-manager/skills/assembly-coordinator/references/planning-opinions.md
+++ b/plugins/project-manager/skills/assembly-coordinator/references/planning-opinions.md
@@ -14,7 +14,7 @@ rankings, reputational claims, or one participant's output.
 ## Blind requests
 
 1. Request `architect` with `read-repository`, `long-context`, and
-   `structured-output` at `high` effort. Label its returned work `Plan A`.
+   `structured-output` at `medium` effort. Label its returned work `Plan A`.
 2. Request at most one `plan-critic` with `read-repository`, `long-context`,
    `structured-output`, and `independent-family` at `high` effort. Pass the
    architect's opaque private receipt ID, not its family or identity. Label its
@@ -23,11 +23,15 @@ rankings, reputational claims, or one participant's output.
 Send the evidence packet independently. Neither request receives the other's
 output. Do not run debate, rebuttal, convergence, or a third opinion.
 
+The main driver uses its operator-selected session effort independently. Raise
+the architect above medium only for a named difficult architecture, debugging,
+or review problem. Keep the critic's separate role effort and independence checks.
+
 ## Dispatch mechanics
 
 Resolve one coherent installed model-router bundle through Workflow Kernel and
 bind its `role-dispatch.sh`, request schema, policy, and terminal renderer at
-minimum model-router version `0.6.0`. Materialize Plan A and Plan B prompts
+minimum model-router version `0.7.0`. Materialize Plan A and Plan B prompts
 separately, use the same immutable evidence packet as each request's
 `--repository-evidence-file`, and allocate fresh private output and receipt
 paths in one mode-`0700` run-private directory. Create
@@ -36,7 +40,7 @@ actually requested.
 
 Pass the invocation's exact validated launcher to both calls with
 `--workflow-kernel "$WORKFLOW_KERNEL"`. Dispatch Plan A with `--role architect`, the three capabilities above, and
-`--effort high`. Dispatch Plan B with `--role plan-critic`, the four
+`--effort medium`. Dispatch Plan B with `--role plan-critic`, the four
 capabilities above, `--effort high`, `--independence-receipt-dir` set to that
 private directory, and Plan A's opaque `--independence-receipt-id`. Preserve
 only role-level public dispositions in planning output. The private receipts

--- a/tools/check-dependencies.sh
+++ b/tools/check-dependencies.sh
@@ -280,8 +280,8 @@ if dm_review_floor != ">=1.79.1":
 
 router_floors = {
     "dm-review": ("pluginDependencies", ">=0.4.0"),
-    "pipeline": ("pluginDependencies", ">=0.6.0"),
-    "project-manager": ("optionalPluginDependencies", ">=0.6.0"),
+    "pipeline": ("pluginDependencies", ">=0.7.0"),
+    "project-manager": ("optionalPluginDependencies", ">=0.7.0"),
 }
 for consumer, (dependency_kind, expected) in router_floors.items():
     manifest = manifests.get(consumer)

--- a/tools/test-assembly-coordinator-recommendation.sh
+++ b/tools/test-assembly-coordinator-recommendation.sh
@@ -22,11 +22,11 @@ JSON
 
 "$RECOMMEND" --role builder-deep --capability read-repository \
   --capability write-repository --capability tool-use --capability long-context \
-  --capability structured-output --effort high --matrix-file "$MATRIX" \
+  --capability structured-output --effort low --matrix-file "$MATRIX" \
   --availability-file "$TMP/healthy.json" --format json > "$TMP/builder.json"
-assert jq -e '.recommendedStart.model == "gpt-5.6-sol" and .recommendedStart.harness == "Codex" and .recommendedStart.effort == "high"' "$TMP/builder.json"
-assert jq -e '.recommendedStart.fallback.model == "gpt-5.6-terra" and (.recommendedStart.fallback | keys | length) == 3' "$TMP/builder.json"
-assert jq -e '.recommendedStart.cost.label == "included subscription" and .recommendedStart.cost.apiEquivalent.inputUsdPerM == 5 and .recommendedStart.cost.apiPrice == null' "$TMP/builder.json"
+assert jq -e '.recommendedStart.model == "gpt-6-astra" and .recommendedStart.harness == "Codex" and .recommendedStart.effort == "low"' "$TMP/builder.json"
+assert jq -e '.recommendedStart.fallback.model == "gpt-5.6-sol" and (.recommendedStart.fallback | keys | length) == 3' "$TMP/builder.json"
+assert jq -e '.recommendedStart.cost.label == "included subscription" and .recommendedStart.cost.apiEquivalent == null and .recommendedStart.cost.apiPrice == null' "$TMP/builder.json"
 
 "$RECOMMEND" --role review-fast --capability read-repository \
   --capability structured-output --effort medium --matrix-file "$MATRIX" \
@@ -152,7 +152,7 @@ assert jq -e '.recommendedStart.harness == "OpenRouter" and .recommendedStart.av
 
 assert grep -Fq 'Routine status-only coordination emits no empty block.' "$COORDINATOR"
 assert grep -Fq 'The block is for the human operator and primary executor only.' "$COORDINATOR"
-assert sh -c "! grep -Eq 'gpt-5\\.|deepseek/|qwen/|x-ai/|moonshotai/|Recommended start' '$OPINIONS' '$REVIEW_PROMPT'"
+assert sh -c "! grep -Eq 'gpt-[0-9]|deepseek/|qwen/|x-ai/|moonshotai/|Recommended start' '$OPINIONS' '$REVIEW_PROMPT'"
 assert grep -Fq 'tokenProvenance' "$TERMINAL"
 assert grep -Fq 'billedCostUsd' "$TERMINAL"
 

--- a/tools/test-model-router.sh
+++ b/tools/test-model-router.sh
@@ -478,7 +478,7 @@ assert jq -e '
 fixture healthy
 run_role fast builder-fast low --capability read-repository --capability write-repository --capability structured-output
 assert jq -e '.role == "builder-fast" and (.participantId | test("^participant-[a-f0-9]{8}$")) and .disposition == "completed"' "$TMP/fast.public"
-assert sh -c "! grep -Eq 'deepseek|openrouter|gpt-5|fable|kimi|qwen|grok' '$TMP/fast.public'"
+assert sh -c "! grep -Eq 'deepseek|openrouter|gpt-[0-9]|fable|kimi|qwen|grok' '$TMP/fast.public'"
 
 # Deep work prefers healthy native subscription capacity.
 run_role deep builder-deep high --capability read-repository --capability tool-use
@@ -512,7 +512,7 @@ jq -s '.[0] as $base | .[1].codex as $codex | $base | .codex = $codex' \
 mv "$TMP/availability.next" "$TMP/availability.json"
 run_role all-buckets-exhausted builder-deep high \
   --capability read-repository --capability long-context
-assert jq -e '.served.transport == "openrouter" and ([.attempts[] | select(.transport == "codex-cli" and .reason == "rate_limit_exhausted")] | length) == 2' \
+assert jq -e '.served.transport == "openrouter" and ([.attempts[] | select(.transport == "codex-cli" and .reason == "rate_limit_exhausted")] | length) == 3' \
   "$TMP/all-buckets-exhausted.receipt"
 
 # When authoritative policy metadata does name the applicable 0.147 bucket,
@@ -542,7 +542,7 @@ HOME="$FAKE_HOME" MODEL_ROUTER_AVAILABILITY_FILE="$TMP/availability.json" \
     --capability read-repository --capability long-context \
     --prompt-file "$TMP/prompt" --repository-evidence-file "$TMP/evidence" \
     --output-file "$TMP/missing-map.out" --receipt-file "$TMP/missing-map.receipt" >/dev/null
-assert jq -e '.served.transport == "openrouter" and ([.attempts[] | select(.transport == "codex-cli" and .reason == "rate_limit_mapping_unknown")] | length) == 2' "$TMP/missing-map.receipt"
+assert jq -e '.served.transport == "openrouter" and ([.attempts[] | select(.transport == "codex-cli" and .reason == "rate_limit_mapping_unknown")] | length) == 3' "$TMP/missing-map.receipt"
 
 # Safe availability reasons survive candidate attempts and the operator receipt
 # without carrying raw response/account/quota data.
@@ -573,27 +573,44 @@ assert jq -e '.served.transport == "openrouter" and .fallback == true' "$TMP/dee
 # A current quota response exhausts the native rail for this run; it is not
 # retried under a second model alias.
 fixture healthy
-jq '.candidateResults["gpt-5.6-sol"].outcome="quota"' "$TMP/availability.json" > "$TMP/availability.next"
+jq '.candidateResults["gpt-6-astra"].outcome="quota"' "$TMP/availability.json" > "$TMP/availability.next"
 mv "$TMP/availability.next" "$TMP/availability.json"
 run_role quota-fallback builder-deep high --capability read-repository --capability long-context
-assert jq -e '.served.transport == "openrouter" and .attempts[0].reason == "rate_limit_exhausted" and ([.attempts[].model] | index("gpt-5.6-terra") == null)' "$TMP/quota-fallback.receipt"
+assert jq -e '.served.transport == "openrouter" and .attempts[0].reason == "rate_limit_exhausted" and ([.attempts[].model] | index("gpt-5.6-terra") == null and index("gpt-5.6-sol") == null)' "$TMP/quota-fallback.receipt"
 
 # Failure reasons are attempt-local; an earlier quota cannot relabel a later transport failure.
 fixture healthy
-jq '.candidateResults["gpt-5.6-sol"].outcome="quota"
+jq '.candidateResults["gpt-6-astra"].outcome="quota"
   | .candidateResults["deepseek/deepseek-v4-pro-0813"].outcome="transport"
   | .candidateResults["x-ai/grok-4.6"].outcome="success"' "$TMP/availability.json" > "$TMP/availability.next"
 mv "$TMP/availability.next" "$TMP/availability.json"
 run_role local-failure builder-deep high --capability read-repository --capability long-context
 assert jq -e '.served.model == "x-ai/grok-4.6" and .fallbackReason == "transport-unavailable"' "$TMP/local-failure.receipt"
 
+# Driver requests preserve their own effort; bounded workers do not inherit it.
+fixture healthy
+for effort in low medium high max; do
+  run_role "astra-$effort" architect "$effort" --capability read-repository --capability structured-output
+  assert jq -e --arg effort "$effort" '.served.model == "gpt-6-astra" and .requested.effort == $effort and .normalizedEffort == $effort' "$TMP/astra-$effort.receipt"
+done
+for effort in high max; do
+  run_role "luna-$effort" builder-fast "$effort" --capability read-repository --capability structured-output
+  assert jq -e --arg effort "$effort" '.served.model == "gpt-5.6-luna" and .requested.effort == $effort and .normalizedEffort == $effort' "$TMP/luna-$effort.receipt"
+done
+# Model-specific transport failure can use the optional native baseline; a
+# quota response above must instead skip the entire exhausted subscription rail.
+jq '.candidateResults["gpt-6-astra"].outcome="transport"' "$TMP/availability.json" > "$TMP/availability.next"
+mv "$TMP/availability.next" "$TMP/availability.json"
+run_role sol-baseline architect high --capability read-repository --capability structured-output
+assert jq -e '.served.model == "gpt-5.6-sol" and .normalizedEffort == "high" and .fallback == true' "$TMP/sol-baseline.receipt"
+
 # Two eligible operators receive identical subscription-first behavior from one policy.
 fixture healthy
-run_role architect-a architect max --capability read-repository --capability structured-output
-assert jq -e '.served.model == "gpt-5.6-sol" and .served.billingMode == "included-subscription"' "$TMP/architect-a.receipt"
+run_role architect-a architect low --capability read-repository --capability structured-output
+assert jq -e '.served.model == "gpt-6-astra" and .served.billingMode == "included-subscription"' "$TMP/architect-a.receipt"
 fixture second-eligible-operator
-run_role architect-b architect max --capability read-repository --capability structured-output
-assert jq -e '.served.model == "gpt-5.6-sol" and .served.billingMode == "included-subscription"' "$TMP/architect-b.receipt"
+run_role architect-b architect medium --capability read-repository --capability structured-output
+assert jq -e '.served.model == "gpt-6-astra" and .served.billingMode == "included-subscription"' "$TMP/architect-b.receipt"
 
 # Claude allowance states remain distinct when the subscription-first Codex
 # candidate is unavailable.
@@ -659,7 +676,7 @@ assert jq -e '.served.model == "qwen/qwen3.8-max" and .served.transport == "open
 fixture healthy
 run_role security security-review high --capability read-repository --capability structured-output
 assert jq -e '.served.model == "gpt-5.6-terra" and .served.transport == "codex-cli"' "$TMP/security.receipt"
-assert sh -c "! grep -Eq 'kimi|moonshot|openrouter|deepseek|gpt-5|fable|qwen|grok' '$TMP/security.public'"
+assert sh -c "! grep -Eq 'kimi|moonshot|openrouter|deepseek|gpt-[0-9]|fable|qwen|grok' '$TMP/security.public'"
 
 # Human-authored work excludes no family, so subscription-first remains the
 # head even when OpenRouter is unavailable.
@@ -688,7 +705,7 @@ jq '.probeSource="live" | .transportStub=false' "$TMP/implementer.receipt" > "$T
 run_role independent plan-critic high --capability read-repository --capability independent-family --independence-receipt-dir "$TMP/implementation-registry" --independence-receipt-id "$implementer_id"
 assert jq -e '.familyIndependence.required == true and .familyIndependence.passed == true and (.served.family != "openai")' "$TMP/independent.receipt"
 assert jq -e '.participantId | test("^planner-[a-f0-9]{8}$")' "$TMP/independent.public"
-assert sh -c "! grep -Eq 'openai|qwen|deepseek|grok|anthropic|moonshot|openrouter|gpt-5|fable|kimi' '$TMP/independent.public'"
+assert sh -c "! grep -Eq 'openai|qwen|deepseek|grok|anthropic|moonshot|openrouter|gpt-[0-9]|fable|kimi' '$TMP/independent.public'"
 
 # Fixture/stub receipts cannot be laundered into family-independence evidence.
 mkdir "$TMP/simulated-registry"
@@ -774,7 +791,7 @@ printf '%s\n' 'initial' > "$TMP/write-repo/tracked.txt"
 git -C "$TMP/write-repo" add tracked.txt
 git -C "$TMP/write-repo" -c user.name=test -c user.email=test@example.invalid commit -qm initial
 fixture healthy
-jq '.candidateResults["gpt-5.6-sol"].outcome="mutate-fail"' "$TMP/availability.json" > "$TMP/availability.next"
+jq '.candidateResults["gpt-6-astra"].outcome="mutate-fail"' "$TMP/availability.json" > "$TMP/availability.next"
 mv "$TMP/availability.next" "$TMP/availability.json"
 set +e
 (
@@ -842,7 +859,7 @@ git -C "$TMP/publication-write-repo" add tracked.txt
 git -C "$TMP/publication-write-repo" -c user.name=test -c user.email=test@example.invalid commit -qm initial
 write_initial_head="$(git -C "$TMP/publication-write-repo" rev-parse HEAD)"
 fixture healthy
-jq '.candidateResults["gpt-5.6-sol"].outcome="commit-success"' "$TMP/availability.json" > "$TMP/availability.next"
+jq '.candidateResults["gpt-6-astra"].outcome="commit-success"' "$TMP/availability.json" > "$TMP/availability.next"
 mv "$TMP/availability.next" "$TMP/availability.json"
 mkdir "$TMP/publication-write"
 set +e

--- a/tools/validate-dm-review-codex-perspective.sh
+++ b/tools/validate-dm-review-codex-perspective.sh
@@ -397,7 +397,7 @@ for zero_deferral_surface in \
 done
 require_text "$REPO_ROOT/plugins/dm-review/.claude-plugin/plugin.json" '"version": "1.80.0"' "canonical dm-review version is 1.80.0"
 require_text "$REPO_ROOT/plugins/dm-review/.codex-plugin/plugin.json" '"version": "1.80.0"' "generated dm-review version is 1.80.0"
-require_text "$REPO_ROOT/plugins/pipeline/.claude-plugin/plugin.json" '"version": "1.66.1"' "canonical Pipeline version is 1.66.1"
+require_text "$REPO_ROOT/plugins/pipeline/.claude-plugin/plugin.json" '"version": "1.67.0"' "canonical Pipeline version is 1.67.0"
 require_text "$REPO_ROOT/plugins/pipeline/.codex-plugin/plugin.json" '"dm-review": ">=1.79.1"' "generated Pipeline dependency floor is current"
 
 printf "Synthesis identity fixtures\n"

--- a/tools/validate-provider-neutral-routing.sh
+++ b/tools/validate-provider-neutral-routing.sh
@@ -115,7 +115,7 @@ runtime_files=(
   "$ROOT/plugins/project-manager/skills/assembly-coordinator/SKILL.md"
   "$ROOT/plugins/project-manager/skills/assembly-coordinator/references/planning-opinions.md"
 )
-if grep -Ein -- '(deepseek/|qwen/|x-ai/|moonshotai/|gpt-5\.|claude-fable|(^|[^[:alnum:]_])(fable|kimi|opus|sonnet|haiku)([^[:alnum:]_]|$)|openrouter/model/agent|codex-fallback/agent|kimi-security|claude-planner|/openrouter[^[:cntrl:]]*--model|codex[[:space:]]+exec([^[:alnum:]_-]|$)|claude[[:space:]]+-p([^[:alnum:]_-]|$))' "${runtime_files[@]}" > "$TMP/leaks"; then
+if grep -Ein -- '(deepseek/|qwen/|x-ai/|moonshotai/|gpt-[0-9]|claude-fable|(^|[^[:alnum:]_])(fable|kimi|opus|sonnet|haiku)([^[:alnum:]_]|$)|openrouter/model/agent|codex-fallback/agent|kimi-security|claude-planner|/openrouter[^[:cntrl:]]*--model|codex[[:space:]]+exec([^[:alnum:]_-]|$)|claude[[:space:]]+-p([^[:alnum:]_-]|$))' "${runtime_files[@]}" > "$TMP/leaks"; then
   sed -n '1,20p' "$TMP/leaks" >&2
   fail 'concrete participant leaked into orchestrator-facing runtime files'
 fi
@@ -140,7 +140,7 @@ done < <(find "$ROOT/plugins/pipeline/agents" "$ROOT/plugins/dm-review/agents" "
 # concrete invocation instructions. OpenRouter's own transport cards remain in
 # its explicit provider allowlist above this orchestration boundary.
 while IFS= read -r card; do
-  if grep -Ein -- '(model tier|(^|[^[:alnum:]_])(opus|sonnet|haiku|fable|kimi)([^[:alnum:]_]|$)|deepseek/|qwen/|x-ai/|moonshotai/|gpt-5\.|claude-fable|codex exec|claude -p)' "$card" > "$TMP/card-leaks"; then
+  if grep -Ein -- '(model tier|(^|[^[:alnum:]_])(opus|sonnet|haiku|fable|kimi)([^[:alnum:]_]|$)|deepseek/|qwen/|x-ai/|moonshotai/|gpt-[0-9]|claude-fable|codex exec|claude -p)' "$card" > "$TMP/card-leaks"; then
     sed -n '1,10p' "$TMP/card-leaks" >&2
     fail "concrete participant leaked into routed card: ${card#$ROOT/}"
   fi
@@ -227,6 +227,31 @@ if CASCADE_CONTACT_FILE="$TMP/cascade-contacts" MODEL_ROUTER_TEST_MODE=1 MODEL_R
   fail 'invalid legacy receipt template accepted'
 fi
 [ ! -s "$TMP/cascade-contacts" ] || fail 'invalid legacy receipt template contacted a transport'
+
+# An installed compatibility adapter has no checkout-local sibling router.
+# If no bundle meets the new floor, fail closed instead of using older policy.
+mkdir -p "$TMP/installed-pipeline/references" "$TMP/floor-kernel"
+cp "$CASCADE" "$TMP/installed-pipeline/references/cascade-dispatch.sh"
+cat > "$TMP/floor-kernel/workflow-kernel-launcher.sh" <<'STUB'
+#!/usr/bin/env bash
+printf '%s\n' "$@" > "$CASCADE_RESOLVER_LOG"
+exit 76
+STUB
+chmod +x "$TMP/floor-kernel/workflow-kernel-launcher.sh"
+if CASCADE_RESOLVER_LOG="$TMP/resolver-args" \
+  "$TMP/installed-pipeline/references/cascade-dispatch.sh" --kind logic --prompt x \
+    --workflow-kernel "$TMP/floor-kernel/workflow-kernel-launcher.sh" \
+    > "$TMP/floor-output" 2> "$TMP/floor-error"; then
+  fail 'missing eligible installed router did not fail closed'
+fi
+python3 - "$TMP/resolver-args" <<'PY'
+import pathlib, sys
+args = pathlib.Path(sys.argv[1]).read_text().splitlines()
+assert args[0] == "resolve-plugin-bundle"
+assert args[args.index("--minimum-version") + 1] == "0.7.0"
+assert args[args.index("--plugin") + 1] == "model-router"
+PY
+grep -Fq 'role router unavailable' "$TMP/floor-error" || fail 'missing router reason lost'
 
 # Routing never weakens zero-deferral.
 grep -q 'Every retained P1, P2, and P3 finding is mandatory work' "$ROOT/plugins/dm-review/skills/review/SKILL.md" || fail 'dm-review zero-deferral missing'

--- a/tools/validate-routing-economics.sh
+++ b/tools/validate-routing-economics.sh
@@ -27,12 +27,25 @@ check 'builder-fast starts with the bounded fast candidate' jq -e '
   .roles["builder-fast"][0].transport == "codex-cli"' "$POLICY"
 
 check 'builder-deep starts on native subscription capacity' jq -e '
-  .roles["builder-deep"][0].model == "gpt-5.6-sol" and
+  .roles["builder-deep"][0].model == "gpt-6-astra" and
   .roles["builder-deep"][0].billing == "included-subscription"' "$POLICY"
 
-check 'architect begins with native Sol subscription capacity' jq -e '
-  .roles.architect[0].model == "gpt-5.6-sol" and
+check 'architect begins with native Astra subscription capacity' jq -e '
+  .roles.architect[0].model == "gpt-6-astra" and
   .roles.architect[0].transport == "codex-cli"' "$POLICY"
+
+check 'driver policy retains the baseline and distinct specialist workers' jq -e '
+  .roles.architect[1].model == "gpt-5.6-sol" and
+  .roles["builder-deep"][1].model == "gpt-5.6-sol" and
+  .roles["builder-deep"][2].model == "gpt-5.6-terra" and
+  .roles["review-fast"][0].model == "gpt-5.6-luna" and
+  .roles["review-deep"][0].model == "gpt-5.6-terra"' "$POLICY"
+
+check 'demanding execution is medium while mechanical and security defaults stay distinct' jq -e '
+  all(.chunkKinds | to_entries[] | select(.key | IN("logic","ui","integration")); .value.executorEffort == "medium") and
+  .chunkKinds.docs.executorEffort == "low" and
+  .chunkKinds["mechanical-logic"].executorEffort == "medium" and
+  .reviewRoles.security.effort == "high"' "$ROOT/plugins/pipeline/references/routing-policy.json"
 
 check 'declared native aliases bind to exact approved served identities' jq -e '
   ([.roles[][] | select(has("servedIdentities"))] | length) > 0 and

--- a/tools/validate-workflow-contracts.sh
+++ b/tools/validate-workflow-contracts.sh
@@ -791,7 +791,7 @@ require_text "$selective_allowlist" "Any validation failure discards the entire 
 require_text "$REPO_ROOT/plugins/dm-review/.claude-plugin/plugin.json" '"workflow-kernel": ">=0.19.1"' "dm-review requires portable repository-scope observation support"
 require_text "$REPO_ROOT/plugins/pipeline/.claude-plugin/plugin.json" '"dm-review": ">=1.79.1"' "pipeline requires the quiet observation-index reporting contract"
 require_text "$REPO_ROOT/plugins/dm-review/.claude-plugin/plugin.json" '"model-router": ">=0.4.0"' "dm-review requires provider-neutral role routing"
-require_text "$REPO_ROOT/plugins/pipeline/.claude-plugin/plugin.json" '"model-router": ">=0.6.0"' "pipeline requires the current routing runtime"
+require_text "$REPO_ROOT/plugins/pipeline/.claude-plugin/plugin.json" '"model-router": ">=0.7.0"' "pipeline requires the current routing runtime"
 require_text "$review_skill" 'Implementation origin is not a coverage field or eligibility condition.' "dm-review makes implementation origin ineligible as a review filter"
 require_text "$review_skill" 'never request, infer, or pass implementation-origin declarations' "dm-review never collects implementation origin for lane routing"
 require_text "$orchestrator" 'one cumulative implementation receipt set' "Pipeline keeps implementation receipts for terminal reporting"


### PR DESCRIPTION
Depot still selects the older primary candidate for architecture and deep implementation, while the wider Astra migration has no clear execution sequence. This change adds the new native driver candidate, separates driver and worker effort, and turns the cross-project audit into an implementation plan linked from README.

The plan names the owning repository, smallest change, and acceptance checks for scaffolded instructions, Baseplate and other consumer instructions, shared skills, native costs and the $50/month OpenRouter goal, the Pi harness, and safe workspace cleanup. Those later changes remain planned; the next development chunk is INSTRUCTIONS-01 in Depot.

Routing changes preserve subscription preference, provider boundaries, explicit effort transmission, specialist review roles, and all retained P1/P2/P3 obligations. Updated versions: model-router 0.7.0, Pipeline 1.67.0, project-manager 1.14.0. Luna execution performance and larger-context benefits remain hypotheses.

Validation: full composition passed on implementation commit `0b3e84a65a1f85e8a7584f521f46540c102f9703`, including 141 router assertions and 41 OpenRouter tests. Recommendation and terminal-report suites passed 24 and 37 assertions. The current head adds only README/plan documentation; runtime, generated manifests and tests are byte-identical to that validated commit. Local links and diff checks pass. One retained P2 in the installed-router fallback floor was fixed and covered.

No paid OpenRouter calls ran. No merge, tag, release or installation refresh was performed. Release preflight still flags older installed caches and the inherited dm-review equal-version warning; it is not a claimed release pass. Main has since advanced through #130; retain its OpenRouter 1.20.3 benchmark changes when integrating. Existing #129 remains a separately owned browser/Compose lane.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Design-Machines-Studio/codesmith/depot/pr/131"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791418246&installation_model_id=428410&pr_number=131&repository=Design-Machines-Studio%2Fdepot&return_to=https%3A%2F%2Fgithub.com%2FDesign-Machines-Studio%2Fdepot%2Fpull%2F131&signature=0cd84989cf27f57c9469e3dc0beccc9605076fa8acdaf1cc3c569f9e89a70f8d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->