### PR TITLE
INSTRUCTIONS-01: Repair shared instruction and hook defaults

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -234,7 +234,7 @@
     {
       "name": "project-scaffolder",
       "source": "./plugins/project-scaffolder",
-      "version": "1.9.3",
+      "version": "1.9.4",
       "author": {
         "name": "Design Machines"
       },

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -234,7 +234,7 @@
     {
       "name": "project-scaffolder",
       "source": "./plugins/project-scaffolder",
-      "version": "1.9.2",
+      "version": "1.9.3",
       "author": {
         "name": "Design Machines"
       },

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,6 +89,16 @@ When editing cache lookups, always include both roots. Validate with:
 ./tools/check-dependencies.sh            # plugin dependency resolution
 ```
 
+## Verification boundaries
+
+- Documentation-only changes use focused source/template checks, placeholder and link checks, hook fixtures, `git diff --check`, and the relevant generated-surface checks. They do not require the full Pipeline or an automatic agent roster.
+- Changes to plugin source still run `./tools/validate-composition.sh --all` before commit. This is composition proof, not release or installed-consumer proof.
+- Release publication has a separate `./tools/check-release-preflight.sh` gate. An ordinary source-branch commit or push does not require installed caches to equal an unreleased branch; cache synchronization and installed consumer proof follow authorized publication.
+
+## Role requests and model guidance
+
+Shared requests stay provider-neutral: ask for a closed role, required capabilities, and normalized effort. Human-facing model recommendations belong in the current [model-router guidance](plugins/model-router/skills/model-router/references/driver-worker-guidance.md), not in participant prompts or generated agent cards.
+
 ## Editing Rules
 
 1. **Claude manifests are canonical.** Edit `.claude-plugin/plugin.json`, then run `./tools/generate-codex-manifests.py` to sync.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,7 +84,13 @@ mappings), `validate-composition.sh` (composition references), and
 `validate-workflow-contracts.sh` (repository cleanup, Datastar-first,
 Baseplate evidence, and workflow-kernel integration anchors).
 
-Before tagging or pushing a release, run the preflight. It is read-only and prints a release receipt:
+For a documentation-only correction, use focused source/template checks,
+placeholder and link checks, temporary hook fixtures, `git diff --check`, and
+the relevant generated-surface checks. The full Pipeline and an automatic
+agent roster are not required for instruction edits. Plugin source changes
+still retain `./tools/validate-composition.sh --all` as composition proof.
+
+Before publishing or tagging a release, run the preflight. It is read-only and prints a release receipt:
 
 ```shell
 ./tools/check-release-preflight.sh
@@ -98,12 +104,14 @@ authenticated. When Codex or its installed-cache evidence is unavailable,
 `REQ-CODEX-CACHE-GATE` reports an explicit `SKIP` rather than failing the
 preflight. That `SKIP` is a coverage gap: report it, and do not claim installed
 Codex-cache verification unless the receipt contains the corresponding `OK`.
-**Never claim a release, tag, or push completed unless the preflight passed, and
-always include its coverage gaps in the release evidence.** It is not part of
-`--all` -- release hygiene is separate from composition validity. `--no-net` is
-local-only evidence: it skips both the remote equal-bump inspection and the
-origin authentication probe, so neither push safety nor cross-lane
-version-collision safety is verified.
+**Never claim a release or tag completed unless the preflight passed, and always
+include its coverage gaps in the release evidence.** An ordinary source-branch
+commit or push does not require installed caches to equal an unreleased source
+branch. Publication, cache synchronization, and installed consumer proof are
+separate claims. The preflight is not part of `--all` -- release hygiene is
+separate from composition validity. `--no-net` is local-only evidence: it skips
+both the remote equal-bump inspection and the origin authentication probe, so
+neither push safety nor cross-lane version-collision safety is verified.
 
 ## Plugin Versioning
 
@@ -202,12 +210,11 @@ Use sparingly. The full validator (`bash tools/validate-composition.sh --all`) r
 
 ## Model & Effort Tuning
 
-For Codex operator sessions, default to GPT-6 Astra Low; use Medium for demanding
-work and High or above only for a named difficult problem. Bounded workers have
-separate roles and effort. The human-facing calibration and optional context
-tradeoffs live in
-`plugins/model-router/skills/model-router/references/driver-worker-guidance.md`.
-This does not change Claude host settings or select identities in agent cards.
+Human-facing model recommendations and optional context tradeoffs live in the
+current [model-router guidance](plugins/model-router/skills/model-router/references/driver-worker-guidance.md).
+Shared requests stay provider-neutral: ask for a closed role, required
+capabilities, and normalized effort. This does not change Claude host settings
+or select identities in agent cards.
 
 **Review origin evidence is not a prerequisite.** Ordinary review lanes must
 run without historical implementation receipts or family exclusions. Missing

--- a/plugins/project-scaffolder/.claude-plugin/plugin.json
+++ b/plugins/project-scaffolder/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-scaffolder",
   "description": "Claude Code project infrastructure scaffolding with hooks, agents, settings, and CLAUDE.md templates (project-type-specific plus generic/DM-standard starters)",
-  "version": "1.9.2",
+  "version": "1.9.3",
   "author": {
     "name": "Design Machines"
   },

--- a/plugins/project-scaffolder/.claude-plugin/plugin.json
+++ b/plugins/project-scaffolder/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-scaffolder",
   "description": "Claude Code project infrastructure scaffolding with hooks, agents, settings, and CLAUDE.md templates (project-type-specific plus generic/DM-standard starters)",
-  "version": "1.9.3",
+  "version": "1.9.4",
   "author": {
     "name": "Design Machines"
   },

--- a/plugins/project-scaffolder/.codex-plugin/plugin.json
+++ b/plugins/project-scaffolder/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "project-scaffolder",
-  "version": "1.9.3",
+  "version": "1.9.4",
   "description": "Claude Code project infrastructure scaffolding with hooks, agents, settings, and CLAUDE.md templates (project-type-specific plus generic/DM-standard starters)",
   "author": {
     "name": "Design Machines"

--- a/plugins/project-scaffolder/.codex-plugin/plugin.json
+++ b/plugins/project-scaffolder/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "project-scaffolder",
-  "version": "1.9.2",
+  "version": "1.9.3",
   "description": "Claude Code project infrastructure scaffolding with hooks, agents, settings, and CLAUDE.md templates (project-type-specific plus generic/DM-standard starters)",
   "author": {
     "name": "Design Machines"

--- a/plugins/project-scaffolder/skills/scaffolding/SKILL.md
+++ b/plugins/project-scaffolder/skills/scaffolding/SKILL.md
@@ -15,21 +15,22 @@ Standardize Claude Code setup across all Design Machines projects. Generate `.cl
 
 | Type | Stack | Docker | Hooks | Agents |
 |------|-------|--------|-------|--------|
-| `go-templ-datastar` | Go + Templ + Datastar + Live Wires | Yes | all 4 + a11y-check | go-builder, css-reviewer, doc-sync, security-auditor, a11y-html-reviewer, a11y-css-reviewer, a11y-dynamic-content-reviewer |
-| `go-library` | Go module (no frontend) | Optional | commit-push, pre-stop, post-edit | doc-sync |
-| `css-framework` | CSS + npm build | No | commit-push, pre-stop, post-edit, a11y-check | css-reviewer, doc-sync, a11y-css-reviewer |
-| `craft-cms` | Craft CMS + DDEV + Twig | DDEV | commit-push, pre-stop, post-edit, block-bare-craft, a11y-check | doc-sync, security-auditor, a11y-html-reviewer, a11y-css-reviewer |
+| `go-templ-datastar` | Go + Templ + Datastar + Live Wires | Yes | Docker safety, contextual reminders, a11y-check | go-builder, css-reviewer, doc-sync, security-auditor, a11y-html-reviewer, a11y-css-reviewer, a11y-dynamic-content-reviewer |
+| `go-library` | Go module (no frontend) | Optional | contextual reminders | doc-sync |
+| `css-framework` | CSS + npm build | No | contextual reminders, a11y-check | css-reviewer, doc-sync, a11y-css-reviewer |
+| `craft-cms` | Craft CMS + DDEV + Twig | DDEV | DDEV safety, contextual reminders, a11y-check | doc-sync, security-auditor, a11y-html-reviewer, a11y-css-reviewer |
 
 ### Hook Inventory
 
 | Hook | Event | Matcher | Default | Purpose |
 |------|-------|---------|---------|---------|
 | `block-bare-go.sh` | PreToolUse | Bash | Go projects | Prevent Go/Templ outside Docker |
-| `commit-push-reminder.sh` | PostToolUse | Edit\|Write | ALL | Nudge commits at 3+ files, push at 2+ commits |
-| `post-edit-context.sh` | PostToolUse | Edit\|Write | ALL | Agent reminders based on file type |
-| `a11y-check.sh` | PostToolUse | Edit\|Write | Frontend projects | A11y agent reminders after template/CSS/JS changes |
+| `block-bare-craft.sh` | PreToolUse | Bash | Craft projects | Prevent Craft/Composer outside DDEV |
+| `commit-push-reminder.sh` | PostToolUse | Edit\|Write | ALL | Once-per-session reminder when changes are ready to commit or push |
+| `post-edit-context.sh` | PostToolUse | Edit\|Write | ALL | Optional, once-per-session context based on file type |
+| `a11y-check.sh` | PostToolUse | Edit\|Write | Frontend projects | Once-per-session reminder when applicable accessibility review is useful |
 | `nats-safety.sh` | PostToolUse | Edit\|Write | `go-templ-datastar` | NATS config safety reminders after editing NATS-related files |
-| `pre-stop-check.sh` | Stop | -- | ALL | Uncommitted work check + agent compliance |
+| `pre-stop-check.sh` | Stop | -- | ALL | Once-per-session uncommitted-work reminder; silent when clean |
 
 ### Agent Inventory
 
@@ -37,7 +38,7 @@ Standardize Claude Code setup across all Design Machines projects. Generate `.cl
 |-------|-----------|---------|
 | `go-builder.md` | Go projects | Docker-safe build, test, generate |
 | `css-reviewer.md` | Live Wires projects | CSS compliance (layers, naming, tokens) |
-| `doc-sync.md` | ALL projects | Documentation freshness after code changes |
+| `doc-sync.md` | ALL projects | Focused documentation-impact review when behavior or operating instructions change |
 | `security-auditor.md` | Backend projects | OWASP review + project-specific concerns |
 | `a11y-html-reviewer.md` | Frontend projects | WCAG HTML/template compliance |
 | `a11y-css-reviewer.md` | Frontend projects | WCAG visual accessibility (contrast, focus, motion) |
@@ -82,6 +83,7 @@ Create the following in the target project:
   settings.json              <- from project-configs.md, based on project type
   hooks/
     block-bare-go.sh         <- Go projects only (from hooks.md)
+    block-bare-craft.sh      <- Craft projects only (from hooks.md)
     commit-push-reminder.sh  <- always (from hooks.md)
     post-edit-context.sh     <- always, customized per type (from hooks.md)
     a11y-check.sh            <- frontend projects (from hooks.md)
@@ -99,16 +101,15 @@ CLAUDE.md                    <- routing doc (from project-configs.md)
 tests/
   a11y/
     pages.spec.js            <- frontend projects (from project-configs.md)
-tasks/
-  todo.md                    <- empty task file
-  lessons.md                 <- empty lessons file
+  tasks/
+    todo.md                    <- optional workboard for multi-step tasks
 ```
 
 ### Step 4: Finalize
 
 1. Replace all `{{PROJECT_PREFIX}}` and `{{PROJECT_NAME}}` placeholders in generated files
 2. For `post-edit-context.sh`: remove sections that don't apply to the project type (marked with comments)
-3. For `pre-stop-check.sh`: set the `AGENTS` array to only include applicable agents
+3. Create `tasks/todo.md` only when a multi-step workboard is useful; do not create a lessons store automatically
 4. Run `chmod +x .claude/hooks/*.sh`
 5. Print a summary of what was generated
 
@@ -119,6 +120,12 @@ Tell the user:
 - Review `settings.json` -- add project-specific permissions to `settings.local.json` if needed
 - Add any project-specific agents to `.claude/agents/`
 - The `post-edit-context.sh` hook can be extended with project-specific file type -> agent mappings
+- Use plan mode and focused agents when task scope or risk warrants them; routine documentation and configuration edits need focused verification only
+- Update documentation when behavior or operating instructions change, and record only reusable lessons if the project maintains a lessons file
+
+### Role requests and model guidance
+
+Generated instructions should stay provider-neutral. When delegation is useful, request a role, required capabilities, and normalized effort (`low`, `medium`, `high`, or `max`); keep concrete model and rail recommendations in the human-facing operator context. See the [current model-router guidance](https://github.com/Design-Machines-Studio/depot/blob/main/plugins/model-router/skills/model-router/references/driver-worker-guidance.md) instead of copying a model portfolio into a project template.
 
 ## Generic CLAUDE.md Starters
 
@@ -149,7 +156,7 @@ Replace all placeholders before writing files. Remove any remaining placeholder 
 
 The `dm-review` depot plugin provides a full code review orchestrator that launches up to 15 parallel agents across accessibility, security, architecture, CSS, voice, and governance domains. It detects project type automatically from marker files (`go.mod`, `craft/`, `.ddev/`, `package.json`) and selects applicable agents -- no per-project configuration needed.
 
-For projects with the depot installed, run `/dm-review` for a full review or `/dm-review quick` for core agents only.
+For projects with the depot installed, use `/dm-review` or `/dm-review quick` when the task's risk and scope call for code or integration review. A documentation-only correction normally needs focused checks, not the full Pipeline or an automatic agent roster.
 
 ## Hook Design Principles
 
@@ -180,8 +187,8 @@ Official and third-party Claude Code plugins that complement this skill:
 
 | File | Contains |
 |------|----------|
-| [${CLAUDE_SKILL_DIR}/references/hooks.md](${CLAUDE_SKILL_DIR}/references/hooks.md) | All 5 hook script templates with full source and customization notes |
+| [${CLAUDE_SKILL_DIR}/references/hooks.md](${CLAUDE_SKILL_DIR}/references/hooks.md) | All hook script templates with full source and customization notes |
 | [${CLAUDE_SKILL_DIR}/references/agents.md](${CLAUDE_SKILL_DIR}/references/agents.md) | Agent definition templates (go-builder, css-reviewer, doc-sync, security-auditor) |
-| [${CLAUDE_SKILL_DIR}/references/project-configs.md](${CLAUDE_SKILL_DIR}/references/project-configs.md) | settings.json templates, CLAUDE.md routing doc templates, tasks file starters -- organized by project type |
+| [${CLAUDE_SKILL_DIR}/references/project-configs.md](${CLAUDE_SKILL_DIR}/references/project-configs.md) | settings.json templates, CLAUDE.md routing doc templates, and optional task-file starters -- organized by project type |
 | [${CLAUDE_SKILL_DIR}/references/claude-md-templates/minimal.md](${CLAUDE_SKILL_DIR}/references/claude-md-templates/minimal.md) | Drop-in CLAUDE.md starter for any stack -- Karpathy's four principles, verbatim, with MIT attribution |
 | [${CLAUDE_SKILL_DIR}/references/claude-md-templates/dm-standard.md](${CLAUDE_SKILL_DIR}/references/claude-md-templates/dm-standard.md) | Drop-in CLAUDE.md starter for DM projects that don't match a project-type template -- paraphrased principles plus DM conventions |

--- a/plugins/project-scaffolder/skills/scaffolding/SKILL.md
+++ b/plugins/project-scaffolder/skills/scaffolding/SKILL.md
@@ -101,8 +101,8 @@ CLAUDE.md                    <- routing doc (from project-configs.md)
 tests/
   a11y/
     pages.spec.js            <- frontend projects (from project-configs.md)
-  tasks/
-    todo.md                    <- optional workboard for multi-step tasks
+tasks/
+  todo.md                    <- optional workboard for multi-step tasks
 ```
 
 ### Step 4: Finalize

--- a/plugins/project-scaffolder/skills/scaffolding/references/agents.md
+++ b/plugins/project-scaffolder/skills/scaffolding/references/agents.md
@@ -23,8 +23,8 @@ Copy to `.claude/agents/go-builder.md`:
 ````markdown
 ---
 name: go-builder
-description: Runs Go, Templ, and build commands safely inside Docker. Use proactively for ANY Go compilation, Templ generation, test execution, or binary building task.
-model: haiku
+description: Runs Go, Templ, and build commands safely inside Docker when Docker-wrapped verification is needed.
+model: inherit
 ---
 
 You are a Go build agent for the {{PROJECT_NAME}} project. Your sole purpose is to run Go and Templ commands safely inside Docker.
@@ -105,8 +105,8 @@ Copy to `.claude/agents/css-reviewer.md`:
 ````markdown
 ---
 name: css-reviewer
-description: Reviews CSS changes for Live Wires compliance. Use after any CSS or HTML template modification to verify cascade layers, naming conventions, token usage, and class invention detection.
-model: haiku
+description: Reviews CSS or HTML changes for Live Wires compliance when cascade layers, naming conventions, token usage, or class invention need checking.
+model: inherit
 ---
 
 You are a CSS reviewer for the {{PROJECT_NAME}} project, enforcing Live Wires framework conventions.
@@ -181,8 +181,8 @@ Copy to `.claude/agents/doc-sync.md`:
 ````markdown
 ---
 name: doc-sync
-description: Verifies documentation is in sync with code changes. Use after ANY code modification that touches file structure, components, or configuration. Checks CLAUDE.md, README.md, and relevant docs.
-model: haiku
+description: Checks documentation impact when behavior, file structure, components, configuration, or operating instructions change.
+model: inherit
 ---
 
 You are a documentation sync checker for the {{PROJECT_NAME}} project. Your job is to verify that code changes are reflected in all relevant documentation files.
@@ -193,7 +193,7 @@ You are a documentation sync checker for the {{PROJECT_NAME}} project. Your job 
 |------|-------------------|
 | `CLAUDE.md` | Primary technical reference (architecture, conventions, directory structure) |
 | `README.md` | User-facing project overview |
-| `tasks/lessons.md` | Patterns and corrections learned during development |
+| `tasks/lessons.md` | Optional reusable patterns and corrections, when the project maintains this file |
 
 ## Sync Checklist
 
@@ -217,9 +217,9 @@ You are a documentation sync checker for the {{PROJECT_NAME}} project. Your job 
 ## Workflow
 
 1. Identify what changed (recent git diff or just-modified files)
-2. Categorize the change type
-3. Search each doc file for references to changed items
-4. Report findings as a checklist
+2. Decide whether behavior, structure, configuration, or operating instructions changed
+3. Search relevant documentation for references to changed items
+4. Report findings as a checklist; do not require a docs edit when no documentation impact exists
 
 ## Output Format
 
@@ -234,7 +234,7 @@ You are a documentation sync checker for the {{PROJECT_NAME}} project. Your job 
 - [x] `README.md`: Up to date
 
 ### No Changes Needed
-- `tasks/lessons.md`: Not affected
+- `tasks/lessons.md`: Not affected, or not maintained by this project
 ```
 ````
 
@@ -255,6 +255,7 @@ Copy to `.claude/agents/security-auditor.md`:
 ---
 name: security-auditor
 description: Reviews code for security vulnerabilities with focus on backend, database queries, templates, and user input handling. Use before committing authentication, authorization, or data-handling code.
+model: inherit
 ---
 
 You are a security auditor for the {{PROJECT_NAME}} project. You review code for common web security vulnerabilities.
@@ -342,8 +343,8 @@ Copy to `.claude/agents/a11y-html-reviewer.md`:
 ````markdown
 ---
 name: a11y-html-reviewer
-description: Reviews HTML, Templ, and Twig templates for WCAG 2.2 accessibility violations. Use after any template modification, new page creation, or form changes. Checks semantic structure, heading hierarchy, ARIA attributes, form labeling, image alt text, and landmark regions.
-model: haiku
+description: Reviews HTML, Templ, and Twig templates for WCAG 2.2 accessibility when a template, page, or form change affects semantic structure, headings, ARIA, labels, images, or landmarks.
+model: inherit
 ---
 
 You are an accessibility reviewer for the {{PROJECT_NAME}} project. You enforce WCAG 2.2 Level AA compliance in HTML templates.
@@ -410,8 +411,8 @@ Copy to `.claude/agents/a11y-css-reviewer.md`:
 ````markdown
 ---
 name: a11y-css-reviewer
-description: Reviews CSS for WCAG 2.2 visual accessibility. Use after CSS changes, color updates, animation additions, or focus style modifications. Checks contrast, focus visibility, reduced motion, touch targets, and reflow.
-model: haiku
+description: Reviews CSS for WCAG 2.2 visual accessibility when color, animation, focus styles, touch targets, or reflow may be affected.
+model: inherit
 ---
 
 You are a CSS accessibility reviewer for the {{PROJECT_NAME}} project. You enforce WCAG 2.2 AA visual compliance.
@@ -467,8 +468,8 @@ Copy to `.claude/agents/a11y-dynamic-content-reviewer.md`:
 ````markdown
 ---
 name: a11y-dynamic-content-reviewer
-description: Reviews Datastar interactions and SSE responses for accessibility. Use after adding Datastar attributes, SSE endpoints, or dynamic content. Checks live regions, focus management, loading states, and keyboard operability.
-model: haiku
+description: Reviews Datastar interactions and SSE responses for accessibility when dynamic content affects live regions, focus, loading states, or keyboard operability.
+model: inherit
 ---
 
 You are a dynamic content accessibility reviewer for the {{PROJECT_NAME}} project. You ensure Datastar SSE interactions and DOM morphing are accessible.
@@ -535,7 +536,7 @@ You are a dynamic content accessibility reviewer for the {{PROJECT_NAME}} projec
 ---
 name: {{PROJECT_PREFIX}}-nats-reviewer
 description: Reviews NATS usage patterns for embedded NATS safety, ScopedEventBus usage, subject naming, KV bucket naming, and event-after-commit ordering.
-model: sonnet
+model: inherit
 ---
 
 You are a NATS code reviewer. Verify NATS patterns follow safety and architectural rules.
@@ -590,7 +591,7 @@ If all checks pass: `**APPROVED** -- NATS patterns follow conventions.`
 ---
 name: {{PROJECT_PREFIX}}-go-test-runner
 description: Runs Go tests with race detection via Docker, reports coverage, and flags missing test files.
-model: sonnet
+model: inherit
 ---
 
 You are a Go test runner. Execute the test suite and report results.
@@ -643,7 +644,7 @@ Flag handler files (`*_handler.go`, `handlers.go`) and service files (`*_service
 ---
 name: {{PROJECT_PREFIX}}-migration-validator
 description: Validates database migration files for goose format, transaction safety, PII detection, table prefix compliance, and cross-fixture FK constraints.
-model: sonnet
+model: inherit
 ---
 
 You are a migration file reviewer for projects using pressly/goose with SQLite.

--- a/plugins/project-scaffolder/skills/scaffolding/references/claude-md-templates/dm-standard.md
+++ b/plugins/project-scaffolder/skills/scaffolding/references/claude-md-templates/dm-standard.md
@@ -7,6 +7,15 @@ pitfalls (https://x.com/karpathy/status/2015883857489522876).
 
 This file tells Claude Code how to work in this repository. Read it at the start of every session.
 
+## Workflow and Safety
+
+- Choose the lightest workflow that fits the task. A small documentation, configuration, or bounded content edit needs focused verification, not plan mode, a full pipeline, or an automatic agent roster.
+- Use plan mode when work is multi-step, architectural, cross-cutting, or higher risk and a written sequence clarifies the acceptance criteria.
+- Use focused agents only when their checks apply. Update documentation when behavior, commands, setup, or operating instructions change; record lessons only when a finding is reusable beyond this task.
+- Preserve repository-owned command restrictions and real checks for credentials, authentication/authorization, destructive or data-loss actions, release integrity, and applicable accessibility.
+- Keep ordinary source-branch commits/pushes, release publication, and any post-publication verification separate. Follow the project's documented release checks when publishing; do not treat an unreleased source branch as a published release.
+- When delegating, request only a role, required capabilities, and normalized effort (`low`, `medium`, `high`, or `max`). Keep concrete model and rail recommendations in human-facing operator context; see the [current model-router guidance](https://github.com/Design-Machines-Studio/depot/blob/main/plugins/model-router/skills/model-router/references/driver-worker-guidance.md).
+
 ## How to Work Here
 
 ### 1. Think before coding

--- a/plugins/project-scaffolder/skills/scaffolding/references/claude-md-templates/minimal.md
+++ b/plugins/project-scaffolder/skills/scaffolding/references/claude-md-templates/minimal.md
@@ -34,6 +34,15 @@ Behavioral guidelines to reduce common LLM coding mistakes. Merge with project-s
 
 **Tradeoff:** These guidelines bias toward caution over speed. For trivial tasks, use judgment.
 
+## Workflow and Safety
+
+- Choose the lightest workflow that fits the task. A small documentation, configuration, or bounded content edit needs focused verification, not plan mode, a full pipeline, or an automatic agent roster.
+- Use plan mode when work is multi-step, architectural, cross-cutting, or higher risk and a written sequence clarifies the acceptance criteria.
+- Use focused agents only when their checks apply. Update documentation when behavior, commands, setup, or operating instructions change; record lessons only when a finding is reusable beyond this task.
+- Preserve repository-owned command restrictions and real checks for credentials, authentication/authorization, destructive or data-loss actions, release integrity, and applicable accessibility.
+- Keep ordinary source-branch commits/pushes, release publication, and any post-publication verification separate. Follow the project's documented release checks when publishing; do not treat an unreleased source branch as a published release.
+- When delegating, request only a role, required capabilities, and normalized effort (`low`, `medium`, `high`, or `max`). Keep concrete model and rail recommendations in human-facing operator context; see the [current model-router guidance](https://github.com/Design-Machines-Studio/depot/blob/main/plugins/model-router/skills/model-router/references/driver-worker-guidance.md).
+
 ## 1. Think Before Coding
 
 **Don't assume. Don't hide confusion. Surface tradeoffs.**

--- a/plugins/project-scaffolder/skills/scaffolding/references/hooks.md
+++ b/plugins/project-scaffolder/skills/scaffolding/references/hooks.md
@@ -6,10 +6,12 @@ All hook scripts for Claude Code project scaffolding. Each template uses `{{PROJ
 
 - [General Notes](#general-notes) (line 15) -- Exit codes, stdin format, permissions
 - [1. block-bare-go.sh](#1-block-bare-gosh) (line 26) -- Prevents Go commands outside Docker
-- [2. commit-push-reminder.sh](#2-commit-push-remindersh) -- Nudges frequent commits and pushes
-- [3. post-edit-context.sh](#3-post-edit-contextsh) -- Context-aware agent reminders after edits
-- [4. pre-stop-check.sh](#4-pre-stop-checksh) -- Verifies commits and agents before stopping
-- [5. a11y-check.sh](#5-a11y-checksh) -- Accessibility agent reminders for frontend files
+- [2. block-bare-craft.sh](#2-block-bare-craftsh) -- Prevents Craft and Composer commands outside DDEV
+- [3. commit-push-reminder.sh](#3-commit-push-remindersh) -- Once-per-session commit and push reminder
+- [4. post-edit-context.sh](#4-post-edit-contextsh) -- Optional context reminders after edits
+- [5. pre-stop-check.sh](#5-pre-stop-checksh) -- Once-per-session uncommitted-work reminder
+- [6. a11y-check.sh](#6-a11y-checksh) -- Once-per-session accessibility reminder for frontend files
+- [7. nats-safety.sh](#7-nats-safetysh) -- Once-per-session NATS safety reminder
 
 ## General Notes
 
@@ -40,11 +42,11 @@ COMMAND=$(jq -r '.tool_input.command')
 # Allows: docker compose exec app go build, echo "go build" (quoted), comments
 if printf '%s\n' "$COMMAND" | grep -qE '(^|\&\&|\|\||;)\s*(go |templ )' && \
    ! printf '%s\n' "$COMMAND" | grep -q 'docker compose'; then
-  echo "BLOCKED: Go/Templ commands must run inside Docker." >&2
-  echo "" >&2
-  echo "Use: docker compose exec app <command>" >&2
-  echo "Example: docker compose exec app go build -o bin/app ./cmd/api" >&2
-  echo "Example: docker compose exec app templ generate" >&2
+  printf '%s\n' "BLOCKED: Go/Templ commands must run inside Docker." >&2
+  printf '%s\n' "" >&2
+  printf '%s\n' "Use: docker compose exec app <command>" >&2
+  printf '%s\n' "Example: docker compose exec app go build -o bin/app ./cmd/api" >&2
+  printf '%s\n' "Example: docker compose exec app templ generate" >&2
   exit 2
 fi
 
@@ -58,87 +60,88 @@ exit 0
 
 ---
 
-## 2. commit-push-reminder.sh
+## 2. block-bare-craft.sh
 
-**Event:** PostToolUse | **Matcher:** Edit|Write | **Applies to:** ALL projects
+**Event:** PreToolUse | **Matcher:** Bash | **Applies to:** `craft-cms`
 
-Nudges toward frequent commits and pushes. Fires after every file edit.
+Prevents Craft and Composer commands from running outside DDEV. Create this file for Craft projects and register it in `settings.json`.
 
 ```bash
 #!/bin/bash
-# commit-push-reminder.sh -- Nudge toward frequent commits and pushes
-#
-# Checks:
-# 1. Uncommitted file count -> suggest commit at 2+ files, insist at 3+
-# 2. Unpushed commit count -> suggest push at 2+ commits
-#
-# Uses HEAD-keyed markers so nudges reset after each commit.
+# block-bare-craft.sh -- Prevent Craft/Composer commands from running outside DDEV
 
-INPUT=$(cat)
+COMMAND=$(jq -r '.tool_input.command // empty' 2>/dev/null)
 
-HEAD=$(git -C "${CLAUDE_PROJECT_DIR}" rev-parse --short HEAD 2>/dev/null)
-if [ -z "$HEAD" ]; then
-  exit 0
-fi
-
-# Count uncommitted changes (unstaged + staged, deduplicated)
-CHANGED=$(git -C "${CLAUDE_PROJECT_DIR}" diff --name-only 2>/dev/null)
-STAGED=$(git -C "${CLAUDE_PROJECT_DIR}" diff --cached --name-only 2>/dev/null)
-TOTAL=$(printf "%s\n%s" "$CHANGED" "$STAGED" | sort -u | grep -c -v '^$')
-
-# Count unpushed commits (0 if no upstream tracking)
-UNPUSHED=$(git -C "${CLAUDE_PROJECT_DIR}" log @{u}..HEAD --oneline 2>/dev/null | wc -l | tr -d ' ')
-[ -z "$UNPUSHED" ] && UNPUSHED=0
-
-MSG=""
-
-# Strong nudge at 3+ files -- fires every time
-if [ "$TOTAL" -ge 3 ]; then
-  MSG="You have $TOTAL uncommitted file changes. Run /simplify on the changed files, then stop and commit with a focused message. Keep commits to 1-4 files."
-
-# Gentle nudge at 2+ files -- fires once per HEAD (resets after each commit)
-elif [ "$TOTAL" -ge 2 ]; then
-  MARKER="/tmp/{{PROJECT_PREFIX}}-commit-nudge-${HEAD}"
-  if [ ! -f "$MARKER" ]; then
-    touch "$MARKER"
-    MSG="$TOTAL files changed since last commit. Consider running /simplify, then commit before making more changes."
-  fi
-fi
-
-# Push nudge at 2+ unpushed commits -- fires once per count
-if [ "$UNPUSHED" -ge 2 ]; then
-  PUSH_MARKER="/tmp/{{PROJECT_PREFIX}}-push-nudge-${UNPUSHED}"
-  if [ ! -f "$PUSH_MARKER" ]; then
-    touch "$PUSH_MARKER"
-    PUSH_MSG="You have $UNPUSHED unpushed commits -- push to remote."
-    if [ -n "$MSG" ]; then
-      MSG="$MSG $PUSH_MSG"
-    else
-      MSG="$PUSH_MSG"
-    fi
-  fi
-fi
-
-if [ -n "$MSG" ]; then
-  MSG_JSON=$(echo "$MSG" | jq -Rs '.')
-  echo "{\"systemMessage\": $MSG_JSON}"
+# Match bare php craft or composer commands. Commands already using ddev are allowed.
+if printf '%s\n' "$COMMAND" | grep -qE '(^|&&|\|\||;)\s*(php[[:space:]]+craft|composer([[:space:]]|$))' && \
+   ! printf '%s\n' "$COMMAND" | grep -q 'ddev'; then
+  printf '%s\n' "BLOCKED: Craft and Composer commands must run inside DDEV." >&2
+  printf '%s\n' "Use: ddev craft <command> or ddev composer <command>" >&2
+  exit 2
 fi
 
 exit 0
 ```
 
 ### Customization
-- Replace `{{PROJECT_PREFIX}}` with the project's lowercase directory name
-- Adjust thresholds (2/3) if needed -- these match the Assembly defaults
-- The gentle nudge fires once per HEAD (resets after each commit); the strong nudge fires every time
+- For projects with a different DDEV command policy, keep the real repository-owned restriction and adjust only the command pattern.
 
 ---
 
-## 3. post-edit-context.sh
+## 3. commit-push-reminder.sh
+
+**Event:** PostToolUse | **Matcher:** Edit|Write | **Applies to:** ALL projects
+
+Provides one quiet reminder per session when the working tree has changes. It does not count files or commits, and it is silent when there is nothing to act on.
+
+```bash
+#!/bin/bash
+# commit-push-reminder.sh -- Once-per-session reminder for verified changes
+#
+# Emits no output for a clean tree. The session marker prevents repeated nudges.
+
+INPUT=$(cat)
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-}"
+if [ -z "$PROJECT_DIR" ]; then
+  exit 0
+fi
+
+if ! git -C "$PROJECT_DIR" rev-parse --show-toplevel >/dev/null 2>&1; then
+  exit 0
+fi
+
+CHANGES=$(git -C "$PROJECT_DIR" status --short 2>/dev/null)
+if [ -z "$CHANGES" ]; then
+  exit 0
+fi
+
+SESSION_ID=$(printf '%s\n' "$INPUT" | jq -r '.session_id // "nosession"' 2>/dev/null || printf '%s\n' 'nosession')
+SESSION_ID=$(printf '%s' "$SESSION_ID" | tr -c '[:alnum:]_.-' '_')
+STATE_DIR="${TMPDIR:-/tmp}/claude-hook-state"
+MARKER="$STATE_DIR/{{PROJECT_PREFIX}}-${SESSION_ID}-commit-push"
+mkdir -p "$STATE_DIR" 2>/dev/null
+if [ -f "$MARKER" ]; then
+  exit 0
+fi
+touch "$MARKER" 2>/dev/null
+
+MSG="Changes are present. When this coherent change is verified, commit it; push when the branch is ready or sharing and recovery benefit from it."
+MSG_JSON=$(printf '%s\n' "$MSG" | jq -Rs '.')
+printf '{"systemMessage": %s}\n' "$MSG_JSON"
+exit 0
+```
+
+### Customization
+- Replace `{{PROJECT_PREFIX}}` with the project's lowercase directory name.
+- Keep the reminder conditional and once per session. Do not add file-count or commit-count thresholds.
+
+---
+
+## 4. post-edit-context.sh
 
 **Event:** PostToolUse | **Matcher:** Edit|Write | **Applies to:** ALL projects (content varies by type)
 
-Provides context-aware agent reminders after file edits. The template includes all possible blocks -- remove the ones that don't apply to your project type.
+Provides optional context after file edits. The template includes all possible blocks -- remove the ones that don't apply to your project type.
 
 **Silence discipline (required).** This hook fires on a broad matcher (every Edit|Write), so each reminder category fires **once per session** via a marker file under `$TMPDIR/claude-hook-state` keyed on `session_id`, then stays silent. Emitting the same static reminder on every edit only burns context tokens -- the assembly-baseplate project hit exactly this and fixed it the same way (2026-07-04). A hook that reminds on a broad matcher must be silent on the second and later occurrences; output only on first occurrence (or on a genuine violation).
 
@@ -152,7 +155,7 @@ Provides context-aware agent reminders after file edits. The template includes a
 # reminder on every edit only burns context tokens. Silent on every repeat.
 
 INPUT=$(cat)
-FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
+FILE_PATH=$(printf '%s\n' "$INPUT" | jq -r '.tool_input.file_path // empty' 2>/dev/null)
 
 if [ -z "$FILE_PATH" ]; then
   exit 0
@@ -166,32 +169,32 @@ MESSAGE=""
 # --- GO PROJECTS: keep for go-templ-datastar, go-library ---
 if printf '%s\n' "$FILE_PATH" | grep -qE '1_tokens/'; then
   CATEGORY="tokens"
-  MESSAGE="Design tokens modified: Reference livewires theming.md for token guidelines. Run css-reviewer to verify compliance."
+  MESSAGE="Design tokens changed: if this changes styling behavior, consult Live Wires theming guidance and use css-reviewer as needed."
 elif printf '%s\n' "$FILE_PATH" | grep -qE 'src/css/|\.css$'; then
   CATEGORY="css"
-  MESSAGE="CSS modified: Consider running the css-reviewer agent to verify Live Wires compliance (cascade layers, naming, tokens)."
+  MESSAGE="CSS changed: use css-reviewer when the change needs a Live Wires review (cascade layers, naming, or tokens)."
 elif printf '%s\n' "$FILE_PATH" | grep -qE '\.templ$'; then
   CATEGORY="templ"
-  MESSAGE="Templ template modified: Run templ generate + go build via the go-builder agent. Check documentation via doc-sync."
+  MESSAGE="Templ changed: use go-builder for generation/build verification when relevant; update docs if behavior or operating instructions changed."
 elif printf '%s\n' "$FILE_PATH" | grep -qE '\.go$'; then
   CATEGORY="go"
-  MESSAGE="Go source modified: Rebuild via the go-builder agent (docker compose exec app go build)."
+  MESSAGE="Go source changed: use go-builder for Docker-wrapped build or test verification when relevant."
 # --- END GO PROJECTS ---
 # --- CRAFT CMS PROJECTS: keep for craft-cms ---
 elif printf '%s\n' "$FILE_PATH" | grep -qE '\.twig$|\.html\.twig$'; then
   CATEGORY="twig"
-  MESSAGE="Twig template modified: Check if documentation needs updating via doc-sync."
+  MESSAGE="Twig template changed: update docs if behavior or operating instructions changed; use doc-sync when impact is unclear."
 elif printf '%s\n' "$FILE_PATH" | grep -qE '\.php$'; then
   CATEGORY="php"
-  MESSAGE="PHP modified: Clear caches if needed (ddev craft clear-caches/all). Run security-auditor for handler/controller changes."
+  MESSAGE="PHP changed: preserve auth and data boundaries; use security-auditor for auth, authorization, credential, input, or data-handling changes."
 # --- END CRAFT CMS PROJECTS ---
 # --- UNIVERSAL: keep for all project types ---
 elif printf '%s\n' "$FILE_PATH" | grep -qE '\.sql$|migrations/'; then
   CATEGORY="sql"
-  MESSAGE="Migration/SQL modified: Run security-auditor to check for injection risks. Update documentation via doc-sync."
+  MESSAGE="Migration/SQL changed: check authorization and data behavior; use security-auditor when the change affects those boundaries and update docs when behavior changes."
 elif printf '%s\n' "$FILE_PATH" | grep -qE '\.(yaml|yml|json|toml)$'; then
   CATEGORY="config"
-  MESSAGE="Config file modified: Check if CLAUDE.md or other documentation needs updating via doc-sync."
+  MESSAGE="Config changed: update CLAUDE.md or other operating documentation when behavior or setup changes; use doc-sync if impact is unclear."
 fi
 # --- END UNIVERSAL ---
 
@@ -200,17 +203,19 @@ if [ -z "$CATEGORY" ]; then
 fi
 
 # Fire each category at most once per session -- silent on every repeat.
-SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // "nosession"')
+SESSION_ID=$(printf '%s\n' "$INPUT" | jq -r '.session_id // "nosession"' 2>/dev/null || printf '%s\n' 'nosession')
+SESSION_ID=$(printf '%s' "$SESSION_ID" | tr -c '[:alnum:]_.-' '_')
 STATE_DIR="${TMPDIR:-/tmp}/claude-hook-state"
 mkdir -p "$STATE_DIR" 2>/dev/null
-MARKER="$STATE_DIR/${SESSION_ID}-postedit-${CATEGORY}"
+MARKER="$STATE_DIR/{{PROJECT_PREFIX}}-${SESSION_ID}-postedit-${CATEGORY}"
 
 if [ -f "$MARKER" ]; then
   exit 0
 fi
 touch "$MARKER" 2>/dev/null
 
-echo "{\"systemMessage\": \"$MESSAGE\"}"
+MSG_JSON=$(printf '%s\n' "$MESSAGE" | jq -Rs '.')
+printf '{"systemMessage": %s}\n' "$MSG_JSON"
 exit 0
 ```
 
@@ -228,145 +233,102 @@ Add project-specific blocks as needed (e.g., governance code detection for Assem
 
 ---
 
-## 4. pre-stop-check.sh
+## 5. pre-stop-check.sh
 
 **Event:** Stop | **Matcher:** -- (fires on all stops) | **Applies to:** ALL projects
 
-Checks for uncommitted work before stopping. Reminds about agent compliance and session end workflow.
+Checks for uncommitted work before stopping. It is silent when the tree is clean and reminds at most once per session.
 
 ```bash
 #!/bin/bash
-# pre-stop-check.sh -- Before stopping, verify work is committed and agents ran
-#
-# Uses a diff-hash marker to prevent infinite loops.
+# pre-stop-check.sh -- Before stopping, remind about uncommitted work
 
 INPUT=$(cat)
-
-# --- CONFIGURE THESE PER PROJECT ---
-# List agents that should be checked based on file types changed
-# Format: "file_pattern:agent_name:description"
-AGENT_CHECKS=(
-  '\.css$:css-reviewer:CSS files changed'
-  '\.(go|templ)$:go-builder:Go/Templ files changed -- verify build succeeded'
-  '(handlers/|middleware/|auth|migrations/):security-auditor:Handler/auth/data code changed'
-  '\.(go|templ|css|js|sql|yaml|yml|html|twig|php)$:doc-sync:Code changed -- verify documentation is fresh'
-)
-# --- END CONFIGURATION ---
-
-# Check for uncommitted changes
-UNSTAGED=$(git -C "${CLAUDE_PROJECT_DIR}" diff --name-only 2>/dev/null)
-STAGED=$(git -C "${CLAUDE_PROJECT_DIR}" diff --cached --name-only 2>/dev/null)
-CHANGES=$(printf "%s\n%s" "$UNSTAGED" "$STAGED" | sort -u | grep -v '^$')
-
-# Check recent commits (changes already committed this session)
-TODAY=$(date +%Y-%m-%d)
-COMMITTED_TODAY=$(git -C "${CLAUDE_PROJECT_DIR}" log --since="$TODAY" --name-only --pretty=format: 2>/dev/null | sort -u | grep -v '^$')
-ALL_CHANGES=$(printf "%s\n%s" "$CHANGES" "$COMMITTED_TODAY" | sort -u | grep -v '^$')
-
-if [ -z "$ALL_CHANGES" ]; then
-  # No changes at all -- just remind about session end
-  TODAY_MARKER="/tmp/{{PROJECT_PREFIX}}-session-${TODAY}"
-  if [ -f "$TODAY_MARKER" ]; then
-    echo "{\"systemMessage\": \"Session end: Append session summary to memory/sessions.md.\"}"
-  fi
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-}"
+if [ -z "$PROJECT_DIR" ]; then
   exit 0
 fi
 
-# Prevent infinite loops -- hash the changes and check if we already reminded
-find /tmp -name "{{PROJECT_PREFIX}}-stop-review-*" -type f -mmin +60 -delete 2>/dev/null
-DIFF_HASH=$(echo "$ALL_CHANGES" | md5 -q 2>/dev/null || echo "$ALL_CHANGES" | md5sum | cut -d' ' -f1)
-REVIEW_MARKER="/tmp/{{PROJECT_PREFIX}}-stop-review-${DIFF_HASH}"
-
-if [ -f "$REVIEW_MARKER" ]; then
+if ! git -C "$PROJECT_DIR" rev-parse --show-toplevel >/dev/null 2>&1; then
   exit 0
 fi
-touch "$REVIEW_MARKER"
 
-# Build agent reminders from AGENT_CHECKS
-AGENT_REMINDERS=""
-for check in "${AGENT_CHECKS[@]}"; do
-  IFS=':' read -r pattern agent desc <<< "$check"
-  if printf '%s\n' "$ALL_CHANGES" | grep -qE "$pattern"; then
-    AGENT_REMINDERS="${AGENT_REMINDERS}\n- ${agent}: ${desc}"
-  fi
-done
-
-FILE_COUNT=$(echo "$ALL_CHANGES" | wc -l | tr -d ' ')
-MSG="STOP -- ${FILE_COUNT} files changed this session. Before finishing:"
-
-if [ -n "$AGENT_REMINDERS" ]; then
-  MSG="${MSG}\n\nAgents to run (if not already done):${AGENT_REMINDERS}"
+CHANGES=$(git -C "$PROJECT_DIR" status --short 2>/dev/null)
+if [ -z "$CHANGES" ]; then
+  exit 0
 fi
 
-# Simplification reminder
-MSG="${MSG}\n\nRun /simplify on changed files before finishing to catch complexity creep."
-
-# Uncommitted changes warning
-if [ -n "$CHANGES" ]; then
-  UNCOMMITTED_COUNT=$(echo "$CHANGES" | wc -l | tr -d ' ')
-  MSG="${MSG}\n\nWARNING: ${UNCOMMITTED_COUNT} uncommitted files. Commit before stopping."
+SESSION_ID=$(printf '%s\n' "$INPUT" | jq -r '.session_id // "nosession"' 2>/dev/null || printf '%s\n' 'nosession')
+SESSION_ID=$(printf '%s' "$SESSION_ID" | tr -c '[:alnum:]_.-' '_')
+STATE_DIR="${TMPDIR:-/tmp}/claude-hook-state"
+MARKER="$STATE_DIR/{{PROJECT_PREFIX}}-${SESSION_ID}-prestop-uncommitted"
+mkdir -p "$STATE_DIR" 2>/dev/null
+if [ -f "$MARKER" ]; then
+  exit 0
 fi
+touch "$MARKER" 2>/dev/null
 
-# Session end workflow (only if session was started)
-TODAY_MARKER="/tmp/{{PROJECT_PREFIX}}-session-${TODAY}"
-if [ -f "$TODAY_MARKER" ]; then
-  MSG="${MSG}\n\nSession end workflow:"
-  MSG="${MSG}\n- Append session summary to memory/sessions.md"
-fi
-
-MSG_JSON=$(printf "%b" "$MSG" | jq -Rs '.')
-echo "{\"systemMessage\": $MSG_JSON}"
+MSG="Uncommitted changes remain. Before stopping, verify the work is complete and commit it when ready."
+MSG_JSON=$(printf '%s\n' "$MSG" | jq -Rs '.')
+printf '{"systemMessage": %s}\n' "$MSG_JSON"
 
 exit 0
 ```
 
 ### Customization
 
-**AGENT_CHECKS array**: Edit this to match the project's agents. Each entry is `pattern:agent_name:description`.
-
-**By project type:**
-
-- **go-templ-datastar**: All 4 default checks + a11y agents. Add governance/domain-specific checks as needed.
-- **go-library**: Keep go-builder and doc-sync. Remove css-reviewer and a11y agents.
-- **css-framework**: Keep css-reviewer, doc-sync, and a11y-css-reviewer. Remove go-builder and security-auditor.
-- **craft-cms**: Replace go-builder with a craft-builder check (`\.php$:craft-builder:PHP changed`). Keep doc-sync, security-auditor, and a11y agents.
+Replace `{{PROJECT_PREFIX}}` with the project's lowercase directory name. No per-project agent-compliance list is needed. Keep this hook focused on the real uncommitted-work boundary; choose implementation, documentation, security, and accessibility agents from the task and risk.
 
 ---
 
-## 5. a11y-check.sh
+## 6. a11y-check.sh
 
 **Event:** PostToolUse | **Matcher:** Edit|Write | **Applies to:** Frontend projects (go-templ-datastar, css-framework, craft-cms)
 
-Triggers accessibility agent reminders after template, CSS, or JavaScript file modifications.
+Provides an accessibility review reminder after relevant template, CSS, or JavaScript changes. Each category fires once per session and the hook is silent for unrelated files.
 
 ```bash
 #!/bin/bash
-# a11y-check.sh -- Remind about accessibility after frontend file changes
+# a11y-check.sh -- Once-per-session accessibility reminder after frontend changes
 #
-# Returns systemMessage JSON that reminds Claude to run a11y review agents.
+# Returns systemMessage JSON only when an applicable review may help.
 
 INPUT=$(cat)
-FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
+FILE_PATH=$(printf '%s\n' "$INPUT" | jq -r '.tool_input.file_path // empty' 2>/dev/null)
 
 if [ -z "$FILE_PATH" ]; then
   exit 0
 fi
 
-# Template files -> HTML accessibility review
+SESSION_ID=$(printf '%s\n' "$INPUT" | jq -r '.session_id // "nosession"' 2>/dev/null || printf '%s\n' 'nosession')
+SESSION_ID=$(printf '%s' "$SESSION_ID" | tr -c '[:alnum:]_.-' '_')
+STATE_DIR="${TMPDIR:-/tmp}/claude-hook-state"
+mkdir -p "$STATE_DIR" 2>/dev/null
+
+remind_once() {
+  CATEGORY="$1"
+  MESSAGE="$2"
+MARKER="$STATE_DIR/{{PROJECT_PREFIX}}-${SESSION_ID}-a11y-${CATEGORY}"
+  if [ -f "$MARKER" ]; then
+    return 0
+  fi
+  touch "$MARKER" 2>/dev/null
+  MSG_JSON=$(printf '%s\n' "$MESSAGE" | jq -Rs '.')
+  printf '{"systemMessage": %s}\n' "$MSG_JSON"
+}
+
 if printf '%s\n' "$FILE_PATH" | grep -qE '\.(templ|twig|html)$'; then
-  echo "{\"systemMessage\": \"Template modified: Run the a11y-html-reviewer agent to check WCAG 2.2 compliance (landmarks, headings, forms, ARIA, alt text).\"}"
+  remind_once "html" "Template changed: use a11y-html-reviewer when the change affects semantics, forms, landmarks, ARIA, or alt text."
   exit 0
 fi
 
-# CSS files -> Visual accessibility review
 if printf '%s\n' "$FILE_PATH" | grep -qE '\.css$'; then
-  echo "{\"systemMessage\": \"CSS modified: Run the a11y-css-reviewer agent to verify contrast, focus visibility, motion safety, and touch targets.\"}"
+  remind_once "css" "CSS changed: use a11y-css-reviewer when the change affects contrast, focus visibility, motion safety, touch targets, or reflow."
   exit 0
 fi
 
-# JavaScript/Datastar files -> Dynamic content review
 if printf '%s\n' "$FILE_PATH" | grep -qE '\.(js|ts)$'; then
-  echo "{\"systemMessage\": \"JavaScript modified: Run the a11y-dynamic-content-reviewer agent to check live regions, focus management, and keyboard operability.\"}"
+  remind_once "dynamic" "JavaScript or Datastar changed: use a11y-dynamic-content-reviewer when the change affects live regions, focus management, or keyboard operability."
   exit 0
 fi
 
@@ -378,7 +340,7 @@ exit 0
 - No placeholders needed -- this hook is universal for frontend projects
 - For go-library projects (no frontend): skip this hook entirely
 - For projects using Datastar heavily, the JS check will fire on Datastar signal files too
-- **Note:** This hook fires alongside `post-edit-context.sh` on `.css` and template files. That's intentional -- post-edit-context reminds about build/CSS agents while this hook reminds about accessibility agents. Both systemMessages are useful.
+- **Note:** This hook may fire alongside `post-edit-context.sh` on `.css` and template files. Both reminders are once per session and optional; use the accessibility reviewer when the change actually affects an accessibility boundary.
 
 ---
 
@@ -392,14 +354,13 @@ Fires when NATS-related Go files are edited. Reminds about DontListen enforcemen
 
 ```bash
 #!/usr/bin/env bash
-# PostToolUse hook: NATS safety reminders
-# Fires after editing Go files related to NATS/events
+# PostToolUse hook: NATS safety reminder
+# Fires once per session after editing Go files related to NATS/events
 
 set -euo pipefail
 
-# Read the tool result from stdin
 INPUT=$(cat)
-FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // .tool_input.command // empty' 2>/dev/null || echo "")
+FILE_PATH=$(printf '%s\n' "$INPUT" | jq -r '.tool_input.file_path // .tool_input.command // empty' 2>/dev/null || printf '%s\n' '')
 
 # Only check Go files related to NATS
 if [[ -z "$FILE_PATH" ]] || [[ "$FILE_PATH" != *.go ]]; then
@@ -411,17 +372,19 @@ if ! grep -qE '(nats\.|embeddednats|jetstream|ScopedEventBus|EventBus|KVStore|kv
   exit 0
 fi
 
-# Provide context-aware reminder
-cat <<'REMINDER'
+SESSION_ID=$(printf '%s\n' "$INPUT" | jq -r '.session_id // "nosession"' 2>/dev/null || printf '%s\n' 'nosession')
+SESSION_ID=$(printf '%s' "$SESSION_ID" | tr -c '[:alnum:]_.-' '_')
+STATE_DIR="${TMPDIR:-/tmp}/claude-hook-state"
+MARKER="$STATE_DIR/{{PROJECT_PREFIX}}-${SESSION_ID}-nats"
+mkdir -p "$STATE_DIR" 2>/dev/null
+if [ -f "$MARKER" ]; then
+  exit 0
+fi
+touch "$MARKER" 2>/dev/null
 
-🔒 NATS file changed. Remember:
-- DontListen: true must be set on embedded NATS server (P1 if missing)
-- Events publish AFTER db.WithTx() commit, never inside the transaction
-- Fixtures use ScopedEventBus, not raw nats.Conn
-- Subject pattern: assembly.{scope}.{entity}.{event}
-- Run nats-reviewer agent to validate patterns
-
-REMINDER
+MESSAGE="NATS-related Go file changed: preserve DontListen=true, publish events after db.WithTx() commit, use ScopedEventBus in fixtures, and keep assembly.{scope}.{entity}.{event} subjects. Use nats-reviewer when this change needs a focused check."
+MSG_JSON=$(printf '%s\n' "$MESSAGE" | jq -Rs '.')
+printf '{"systemMessage": %s}\n' "$MSG_JSON"
 
 exit 0
 ```

--- a/plugins/project-scaffolder/skills/scaffolding/references/hooks.md
+++ b/plugins/project-scaffolder/skills/scaffolding/references/hooks.md
@@ -72,9 +72,13 @@ Prevents Craft and Composer commands from running outside DDEV. Create this file
 
 COMMAND=$(jq -r '.tool_input.command // empty' 2>/dev/null)
 
-# Match bare php craft or composer commands. Commands already using ddev are allowed.
-if printf '%s\n' "$COMMAND" | grep -qE '(^|&&|\|\||;)\s*(php[[:space:]]+craft|composer([[:space:]]|$))' && \
-   ! printf '%s\n' "$COMMAND" | grep -q 'ddev'; then
+# Match each command boundary, including pipelines and subshells. A DDEV
+# invocation does not match; unrelated DDEV text never exempts a host command.
+# Include common wrappers and environment assignments before the executable.
+ENV_OPTION='(-i|--ignore-environment|--|(-u|--unset)[[:space:]]+[A-Za-z_][A-Za-z0-9_]*|--unset=[A-Za-z_][A-Za-z0-9_]*)'
+WRAPPER="(env([[:space:]]+${ENV_OPTION})*|command([[:space:]]+-p)?([[:space:]]+--)?|exec([[:space:]]+--)?)"
+PREFIX="(^|[;&|()])[[:space:]]*(${WRAPPER}[[:space:]]+|[A-Za-z_][A-Za-z0-9_]*=[^[:space:];&|()]+[[:space:]]+)*"
+if printf '%s\n' "$COMMAND" | grep -qE "${PREFIX}(php[[:space:]]+craft|composer)([[:space:];&|()]|$)"; then
   printf '%s\n' "BLOCKED: Craft and Composer commands must run inside DDEV." >&2
   printf '%s\n' "Use: ddev craft <command> or ddev composer <command>" >&2
   exit 2

--- a/plugins/project-scaffolder/skills/scaffolding/references/project-configs.md
+++ b/plugins/project-scaffolder/skills/scaffolding/references/project-configs.md
@@ -7,7 +7,7 @@ settings.json, CLAUDE.md, and starter files for each project type. Replace all `
   - go-templ-datastar (line 9), go-library (line 113), css-framework (line 148), craft-cms (line 183)
 - [CLAUDE.md Templates](#claudemd-templates) (line 234)
   - go-templ-datastar (line 236), go-library (line 345), css-framework (line 405), craft-cms (line 477)
-- [Starter Files](#starter-files) -- todo.md, lessons.md, sessions.md
+- [Starter Files](#starter-files) -- optional todo.md, lessons.md, sessions.md
 
 ---
 
@@ -95,7 +95,7 @@ settings.json, CLAUDE.md, and starter files for each project type. Replace all `
 }
 ```
 
-### css-framework (no Docker gate, no session gate)
+### css-framework (no Docker gate)
 
 ```json
 {
@@ -177,7 +177,7 @@ settings.json, CLAUDE.md, and starter files for each project type. Replace all `
 }
 ```
 
-**Note:** `block-bare-craft.sh` is a variant of `block-bare-go.sh` that blocks bare `php craft` and `composer` commands, requiring `ddev craft` and `ddev composer` instead. Create it by adapting the go hook pattern.
+**Note:** `block-bare-craft.sh` is the hook template in `references/hooks.md`. It blocks bare `php craft` and `composer` commands, requiring `ddev craft` and `ddev composer` instead.
 
 ---
 
@@ -199,34 +199,34 @@ This file is the routing document for Claude Code. Critical rules live here; det
 
 ## Workflow Orchestration
 
-### Plan Mode Default
-- Enter plan mode for ANY non-trivial task (3+ steps or architectural decisions)
-- If something goes sideways, STOP and re-plan immediately
+### Workflow Selection
+- Choose the lightest workflow that fits the task. For a small documentation, configuration, or bounded content edit, inspect the affected files, make the change, and run focused checks; plan mode and agents are optional.
+- Use plan mode when a task is multi-step, architectural, cross-cutting, or higher risk and a written sequence clarifies the acceptance criteria.
+- Keep focused agents available as tools. Use the go-builder, CSS, security, documentation, and accessibility agents when their checks apply; none is required after every edit.
+- Update documentation when behavior, commands, configuration, file structure, or operating instructions change. Use doc-sync when the impact is non-obvious, not as a post-edit ritual.
+- Record a lesson only when a finding is reusable beyond this task. Do not create routine lesson entries or a lessons store just to complete a workflow.
+- Preserve repository-owned command restrictions and real checks for credentials, authentication/authorization, destructive or data-loss actions, release integrity, and applicable accessibility.
+- When delegating, request only a role, required capabilities, and normalized effort (`low`, `medium`, `high`, or `max`). Keep concrete model and rail recommendations in operator context; see the [current model-router guidance](https://github.com/Design-Machines-Studio/depot/blob/main/plugins/model-router/skills/model-router/references/driver-worker-guidance.md).
 
-### Agent Delegation
+### Focused Agents
 
 | Agent | Trigger | What it does |
 |-------|---------|-------------|
-| **go-builder** | Any Go/Templ compilation, testing, or generation | Runs commands safely inside Docker |
-| **css-reviewer** | After any CSS or HTML template change | Enforces Live Wires compliance |
-| **doc-sync** | After ANY code change | Checks documentation freshness |
-| **security-auditor** | Before committing auth or data-handling code | Reviews for OWASP vulnerabilities |
+| **go-builder** | Go/Templ compilation, testing, or generation when needed | Runs commands safely inside Docker |
+| **css-reviewer** | CSS or HTML changes that need a Live Wires review | Checks cascade layers, naming, and tokens |
+| **doc-sync** | Behavior, structure, configuration, or operating-instruction changes with unclear documentation impact | Checks relevant documentation |
+| **security-auditor** | Auth, authorization, credentials, input, data handling, or destructive changes | Reviews real security boundaries |
 
-### Self-Improvement Loop
-- After ANY correction: update `tasks/lessons.md`
-- Write rules that prevent the same mistake
-- Review lessons at session start
+Use the applicable accessibility reviewers for frontend changes. Agents are focused tools, not a required roster after every edit.
 
 ### Git Discipline
-- **Commit early and often.** Target 1-4 files per commit.
-- **Push after every 2 commits.**
-- **Feature branches** for work touching 3+ files.
-- **The commit-push-reminder hook insists at 3+ files.** Obey immediately.
+- Commit a coherent, verified change with a focused message; do not use file-count thresholds.
+- Push when the branch is ready or sharing/recovery benefits from it; do not treat an ordinary source-branch push as publication.
+- Use a feature branch or worktree when isolation, collaboration, or task risk warrants it.
 
-### Task Management
-1. Plan first -> `tasks/todo.md`
-2. Track progress: mark items complete as you go
-3. Capture lessons -> `tasks/lessons.md`
+### Work Notes
+- Use `tasks/todo.md` only when a multi-step workboard or handoff is useful.
+- Follow the repository's documented release checks for publication; publication is separate from ordinary source work.
 
 ## Critical Rules
 
@@ -234,7 +234,7 @@ This file is the routing document for Claude Code. Critical rules live here; det
 **NEVER run Go commands directly on the host.** Always `docker compose exec app`. Enforced by `block-bare-go.sh` hook.
 
 ### Documentation Sync
-After code changes, run the `doc-sync` agent. Checks CLAUDE.md, README.md, and related docs.
+When behavior or operating instructions change, update the relevant documentation. Use the `doc-sync` agent when the impact is non-obvious; it is not required after every code change.
 
 ### [ADD PROJECT-SPECIFIC RULES HERE]
 <!-- e.g., naming conventions, module architecture rules, deployment constraints -->
@@ -302,7 +302,7 @@ docker compose up     # Start with hot reload
 
 ## Documentation Sync Checklist
 
-After modifying code, check if updates are needed in:
+When behavior or operating instructions change, check if updates are needed in:
 - [ ] CLAUDE.md (this file)
 - [ ] README.md
 - [ ] Any skill files (flag changes for depot, don't edit directly)
@@ -351,24 +351,31 @@ This file is the routing document for Claude Code.
 
 ## Workflow Orchestration
 
-### Plan Mode Default
-- Enter plan mode for ANY non-trivial task (3+ steps)
+### Workflow Selection
+- Choose the lightest workflow that fits the task. For a small documentation, configuration, or bounded content edit, inspect the affected files, make the change, and run focused checks; plan mode and agents are optional.
+- Use plan mode when a task is multi-step, architectural, cross-cutting, or higher risk and a written sequence clarifies the acceptance criteria.
+- Keep focused agents available as tools. Use the go-builder and documentation agents when their checks apply; none is required after every edit.
+- Update documentation when behavior, commands, configuration, file structure, or operating instructions change. Use doc-sync when the impact is non-obvious, not as a post-edit ritual.
+- Record a lesson only when a finding is reusable beyond this task. Do not create routine lesson entries or a lessons store just to complete a workflow.
+- Preserve repository-owned command restrictions and real checks for credentials, authentication/authorization, destructive or data-loss actions, release integrity, and applicable accessibility.
+- When delegating, request only a role, required capabilities, and normalized effort (`low`, `medium`, `high`, or `max`). Keep concrete model and rail recommendations in operator context; see the [current model-router guidance](https://github.com/Design-Machines-Studio/depot/blob/main/plugins/model-router/skills/model-router/references/driver-worker-guidance.md).
 
-### Agent Delegation
+### Focused Agents
 
 | Agent | Trigger | What it does |
 |-------|---------|-------------|
-| **doc-sync** | After ANY code change | Checks documentation freshness |
+| **doc-sync** | Behavior, structure, configuration, or operating-instruction changes with unclear documentation impact | Checks relevant documentation |
+
+Use the go-builder for Go verification when the project provides a Docker workflow. Agents are focused tools, not a required roster after every edit.
 
 ### Git Discipline
-- Commit early and often. Target 1-4 files per commit.
-- Push after every 2 commits.
-- Feature branches for work touching 3+ files.
+- Commit a coherent, verified change with a focused message; do not use file-count thresholds.
+- Push when the branch is ready or sharing/recovery benefits from it; do not treat an ordinary source-branch push as publication.
+- Use a feature branch or worktree when isolation, collaboration, or task risk warrants it.
 
-### Task Management
-1. Plan first -> `tasks/todo.md`
-2. Track progress: mark items complete as you go
-3. Capture lessons -> `tasks/lessons.md`
+### Work Notes
+- Use `tasks/todo.md` only when a multi-step workboard or handoff is useful.
+- Follow the repository's documented release checks for publication; publication is separate from ordinary source work.
 
 ## Critical Rules
 
@@ -391,7 +398,7 @@ go vet ./...
 
 ## Documentation Sync Checklist
 
-After modifying code, check if updates are needed in:
+When behavior or operating instructions change, check if updates are needed in:
 - [ ] CLAUDE.md (this file)
 - [ ] README.md
 - [ ] Go doc comments
@@ -434,25 +441,32 @@ This file is the routing document for Claude Code.
 
 ## Workflow Orchestration
 
-### Plan Mode Default
-- Enter plan mode for ANY non-trivial task (3+ steps)
+### Workflow Selection
+- Choose the lightest workflow that fits the task. For a small documentation, configuration, or bounded content edit, inspect the affected files, make the change, and run focused checks; plan mode and agents are optional.
+- Use plan mode when a task is multi-step, architectural, cross-cutting, or higher risk and a written sequence clarifies the acceptance criteria.
+- Keep focused agents available as tools. Use the CSS, documentation, and accessibility agents when their checks apply; none is required after every edit.
+- Update documentation when behavior, commands, configuration, file structure, or operating instructions change. Use doc-sync when the impact is non-obvious, not as a post-edit ritual.
+- Record a lesson only when a finding is reusable beyond this task. Do not create routine lesson entries or a lessons store just to complete a workflow.
+- Preserve repository-owned command restrictions and real checks for credentials, authentication/authorization, destructive or data-loss actions, release integrity, and applicable accessibility.
+- When delegating, request only a role, required capabilities, and normalized effort (`low`, `medium`, `high`, or `max`). Keep concrete model and rail recommendations in operator context; see the [current model-router guidance](https://github.com/Design-Machines-Studio/depot/blob/main/plugins/model-router/skills/model-router/references/driver-worker-guidance.md).
 
-### Agent Delegation
+### Focused Agents
 
 | Agent | Trigger | What it does |
 |-------|---------|-------------|
-| **css-reviewer** | After any CSS change | Enforces naming conventions, layers, token usage |
-| **doc-sync** | After ANY code change | Checks documentation freshness |
+| **css-reviewer** | CSS changes that need a Live Wires review | Enforces naming conventions, layers, and token usage |
+| **doc-sync** | Behavior, structure, configuration, or operating-instruction changes with unclear documentation impact | Checks relevant documentation |
+
+Use the accessibility reviewers when a frontend change affects semantics, visual accessibility, or dynamic interaction. Agents are focused tools, not a required roster after every edit.
 
 ### Git Discipline
-- Commit early and often. Target 1-4 files per commit.
-- Push after every 2 commits.
-- Feature branches for work touching 3+ files.
+- Commit a coherent, verified change with a focused message; do not use file-count thresholds.
+- Push when the branch is ready or sharing/recovery benefits from it; do not treat an ordinary source-branch push as publication.
+- Use a feature branch or worktree when isolation, collaboration, or task risk warrants it.
 
-### Task Management
-1. Plan first -> `tasks/todo.md`
-2. Track progress: mark items complete as you go
-3. Capture lessons -> `tasks/lessons.md`
+### Work Notes
+- Use `tasks/todo.md` only when a multi-step workboard or handoff is useful.
+- Follow the repository's documented release checks for publication; publication is separate from ordinary source work.
 
 ## Critical Rules
 
@@ -486,7 +500,7 @@ npm run build  # Production build
 
 ## Documentation Sync Checklist
 
-After modifying code, check if updates are needed in:
+When behavior or operating instructions change, check if updates are needed in:
 - [ ] CLAUDE.md (this file)
 - [ ] README.md
 - [ ] Documentation site pages
@@ -535,25 +549,32 @@ This file is the routing document for Claude Code.
 
 ## Workflow Orchestration
 
-### Plan Mode Default
-- Enter plan mode for ANY non-trivial task (3+ steps)
+### Workflow Selection
+- Choose the lightest workflow that fits the task. For a small documentation, configuration, or bounded content edit, inspect the affected files, make the change, and run focused checks; plan mode and agents are optional.
+- Use plan mode when a task is multi-step, architectural, cross-cutting, or higher risk and a written sequence clarifies the acceptance criteria.
+- Keep focused agents available as tools. Use the documentation, security, and accessibility agents when their checks apply; none is required after every edit.
+- Update documentation when behavior, commands, configuration, file structure, or operating instructions change. Use doc-sync when the impact is non-obvious, not as a post-edit ritual.
+- Record a lesson only when a finding is reusable beyond this task. Do not create routine lesson entries or a lessons store just to complete a workflow.
+- Preserve repository-owned DDEV restrictions and real checks for credentials, authentication/authorization, destructive or data-loss actions, release integrity, and applicable accessibility.
+- When delegating, request only a role, required capabilities, and normalized effort (`low`, `medium`, `high`, or `max`). Keep concrete model and rail recommendations in operator context; see the [current model-router guidance](https://github.com/Design-Machines-Studio/depot/blob/main/plugins/model-router/skills/model-router/references/driver-worker-guidance.md).
 
-### Agent Delegation
+### Focused Agents
 
 | Agent | Trigger | What it does |
 |-------|---------|-------------|
-| **doc-sync** | After ANY code change | Checks documentation freshness |
-| **security-auditor** | Before committing auth or data-handling code | Reviews for vulnerabilities |
+| **doc-sync** | Behavior, structure, configuration, or operating-instruction changes with unclear documentation impact | Checks relevant documentation |
+| **security-auditor** | Auth, authorization, credentials, input, data handling, or destructive changes | Reviews real security boundaries |
+
+Use the accessibility reviewers when a frontend change affects semantics or visual accessibility. Agents are focused tools, not a required roster after every edit.
 
 ### Git Discipline
-- Commit early and often. Target 1-4 files per commit.
-- Push after every 2 commits.
-- Feature branches for work touching 3+ files.
+- Commit a coherent, verified change with a focused message; do not use file-count thresholds.
+- Push when the branch is ready or sharing/recovery benefits from it; do not treat an ordinary source-branch push as publication.
+- Use a feature branch or worktree when isolation, collaboration, or task risk warrants it.
 
-### Task Management
-1. Plan first -> `tasks/todo.md`
-2. Track progress: mark items complete as you go
-3. Capture lessons -> `tasks/lessons.md`
+### Work Notes
+- Use `tasks/todo.md` only when a multi-step workboard or handoff is useful.
+- Follow the repository's documented release checks for publication; publication is separate from ordinary source work.
 
 ## Critical Rules
 
@@ -591,7 +612,7 @@ npm run build
 
 ## Documentation Sync Checklist
 
-After modifying code, check if updates are needed in:
+When behavior or operating instructions change, check if updates are needed in:
 - [ ] CLAUDE.md (this file)
 - [ ] README.md
 - [ ] Template documentation
@@ -644,12 +665,12 @@ Add `.serena` to `.gitignore`. Register the project path in `~/.serena/serena_co
 <!-- Completed tasks (move here when done) -->
 ```
 
-### tasks/lessons.md
+### Optional tasks/lessons.md
 
 ```markdown
 # Lessons Learned
 
-Patterns and corrections from development sessions. Review at session start.
+Optional notes for reusable project-specific patterns and corrections. Create this file only when the project benefits from keeping such findings between sessions; routine corrections do not belong here.
 
 ## Conventions
 <!-- Project conventions discovered during work -->

--- a/tests/test_scaffolder_hooks.py
+++ b/tests/test_scaffolder_hooks.py
@@ -1,0 +1,90 @@
+"""Execute the shipped Craft hook template without running its input commands."""
+
+import json
+from pathlib import Path
+import re
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+HOOKS = ROOT / "plugins/project-scaffolder/skills/scaffolding/references/hooks.md"
+
+
+@unittest.skipUnless(shutil.which("bash") and shutil.which("jq"), "bash and jq required")
+class CraftHookTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        section = HOOKS.read_text().split("## 2. block-bare-craft.sh\n", 1)[1]
+        cls.script = re.search(r"```bash\n(.*?)\n```", section, re.S).group(1)
+
+    def run_hook(self, command):
+        with tempfile.TemporaryDirectory() as directory:
+            hook = Path(directory) / "block-bare-craft.sh"
+            hook.write_text(self.script)
+            return subprocess.run(
+                ["bash", str(hook)],
+                input=json.dumps({"tool_input": {"command": command}}),
+                text=True, capture_output=True, check=False,
+            )
+
+    def test_rejects_host_commands_without_global_ddev_exemption(self):
+        for command in (
+            "composer install",
+            "php craft migrate/all",
+            "ddev start && composer install",
+            "ddev describe; php craft migrate/all",
+            "composer install && ddev describe",
+            "composer install --working-dir=.ddev",
+            "php craft migrate/all # ddev",
+            "printf 'ddev ready'; composer install",
+            "ddev describe\nphp craft migrate/all",
+            "env composer install",
+            "env -i composer install",
+            "env -- composer install",
+            "env -u APP_ENV composer install",
+            "env APP_ENV=dev php craft migrate/all",
+            "APP_ENV=dev composer install",
+            "command composer install",
+            "command -p composer install",
+            "command -- composer install",
+            "command -- php craft migrate/all",
+            "command -p -- composer install",
+            "exec php craft migrate/all",
+            "exec -- composer install",
+            "printf x | composer install",
+            "(composer install)",
+        ):
+            with self.subTest(command=command):
+                result = self.run_hook(command)
+                self.assertEqual(result.returncode, 2, result.stderr)
+                self.assertIn("BLOCKED", result.stderr)
+
+    def test_allows_wrapped_commands_and_unrelated_text_silently(self):
+        for command in (
+            "ddev composer install",
+            "ddev craft migrate/all",
+            "ddev start && ddev composer install",
+            "env APP_ENV=dev ddev craft migrate/all",
+            "env -i ddev composer install",
+            "command -p ddev craft migrate/all",
+            "command -- ddev composer install",
+            "exec -- ddev craft migrate/all",
+            "command -v composer",
+            "echo 'composer install'",
+            "printf '%s\\n' 'php craft migrate/all'",
+            "git diff -- composer.json",
+            "php -v",
+            "",
+        ):
+            with self.subTest(command=command):
+                result = self.run_hook(command)
+                self.assertEqual(result.returncode, 0, result.stderr)
+                self.assertEqual(result.stdout, "")
+                self.assertEqual(result.stderr, "")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Outcome

Implements INSTRUCTIONS-01 for the shared project-scaffolder defaults.

- Replaces blanket plan-mode, doc-sync, lesson, and file-count commit chores with task/risk-based workflow selection.
- Keeps focused Go, CSS, documentation, security, and accessibility agents available without forcing an automatic roster; generated agent cards use `model: inherit`.
- Makes commit, post-edit, stop, accessibility, and NATS reminders silent on pass and once per session.
- Retains Docker/DDEV denial boundaries and adds the missing portable Craft/Composer hook template.
- Adds a proportional docs-only verification path and separates ordinary source work, release preflight, publication, cache sync, and installed-consumer proof.
- Keeps role/capability/effort requests provider-neutral and links to current model-router guidance.
- Removes automatic lesson-store creation from the scaffold output while retaining an optional reusable-lessons format.
- Bumps project-scaffolder from 1.9.2 to 1.9.4 and regenerates the Codex manifest.

## Evidence

- Exact base: `7e54c1d318a92f23cace041daff8ef07ee0e2754`
- Exact head: `accfb0a4e93a658c37cfb993aacfd76f7668df25`
- Temporary source/template canary: all four project types, both generic starters, both Depot harness entrypoints, placeholder/link checks, and seven hook scripts.
- Hook behavior: clean silence, once-per-session normal/post-edit/accessibility/stop reminders, Go/Craft denied exits `2`, Docker/DDEV wrapped commands allowed.
- `./tools/generate-codex-manifests.py --check`
- `./tools/generate-codex-command-skills.py --check`
- `./tools/check-dependencies.sh`
- `./tools/validate-dual-compat.sh`
- `./tools/eval-descriptions.sh` (45 skills; scaffolder 95.0%)
- `./tools/validate-composition.sh --all`
- `git diff --check`

## Boundaries

PR #129 remains separately owned and no dm-review or Workflow Kernel implementation was changed. No consumer repository, release tag, publication, cache synchronization, installation refresh, native Issue, or merge was performed.

Assembly Coordination Project 1 disposition: Review / P1 / Tooling. Project inspection was attempted with authenticated `gh project list --owner @me --format json --limit 100` but GraphQL was rate-limited; no substitute Project or backlog was created.

Routing: repair reviews used provider-neutral security-review, review-deep, review-fast and plan-critic roles. Host commands performed deterministic verification; the complete review evidence is retained locally.

## Review repairs

The Craft hook now checks each protected command boundary. Unrelated DDEV text no longer exempts host commands, and the matcher handles environment assignments plus supported env, command and exec wrapper forms, including end-of-options markers. The optional workboard is correctly shown at root-level tasks/todo.md.

Added executable regression tests covering 38 command inputs. The final affected-lane review is clean with no retained P1/P2/P3 findings. Full composition validation passed on the final source.

Repair commit: accfb0a4e93a658c37cfb993aacfd76f7668df25. No release tag, cache sync, installed-consumer update, or merge was performed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Design-Machines-Studio/codesmith/depot/pr/133"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791426405&installation_model_id=428410&pr_number=133&repository=Design-Machines-Studio%2Fdepot&return_to=https%3A%2F%2Fgithub.com%2FDesign-Machines-Studio%2Fdepot%2Fpull%2F133&signature=800677de71c5c82b86ead333f334456031a4ca514a32916d08d75bc0ee08e642"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
