### PR TITLE
Plan prototype fidelity and reviews on existing development sites

### DIFF
--- a/plans/astra-routing-and-system-rollout.md
+++ b/plans/astra-routing-and-system-rollout.md
@@ -1,24 +1,26 @@
 # Assembly development improvements — implementation plan
 
-**Current plan, refreshed 2026-09-08.** This covers the entire instruction,
+**Program audit: 2026-09-08; next-chunk update: 2026-09-10.** This covers the entire instruction,
 model, skill, harness, and workspace audit. It supersedes the sequence in the
 [earlier alignment audit](https://github.com/Design-Machines-Studio/depot/blob/docs/depot-planning-20260907/plans/astra-alignment-20260908.md),
 which remains the detailed source inventory. Routing is source-complete. Later
 project completion must be reconciled from each returned exact PR/result; do not
 rerun a successful task merely because this planning snapshot has not caught up.
 
-**Next Depot implementation chunk: INSTRUCTIONS-01 — repair shared instruction
-and workflow defaults.** Updating the generator prevents future scaffolding from
-reintroducing the old chores. Consumer-local repairs can proceed independently
-using the agreed policy in their execution packet; no new generator artifact
-is required. The routing source is merged; publication and consumer proof remain separate;
-PR #129 retains its own browser/Compose closeout owner. Neither the native price
-refresh nor a model benchmark tournament is a prerequisite for instruction work.
+**Next Depot chunk: UI-DEFAULTS-01 — finish definitive prototype fidelity and
+reviews on established development sites.** The existing
+`fix/prototype-review-defaults` implementation worktree already owns these
+surfaces. Use the [current decision and evidence](prototype-and-development-site-review.md)
+and [complete continuation prompt](prompts/ui-defaults-01.md); do not start a
+competing writer. INSTRUCTIONS-01 merged in #133; browser/Compose #129 merged
+in `7e5475195ecab8c626b03ee79185d3b863852c82`. Those are no longer open
+dependencies. The remaining audit below is historical unless explicitly refreshed.
 
 ## Execution prompts
 
-Use [INSTRUCTIONS-01](prompts/assembly-improvements/01-instructions-01.md) for
-the Depot generator. A previously blocked consumer session should resume its
+Use [UI-DEFAULTS-01](prompts/ui-defaults-01.md) for the current owning session
+or a fresh session after handoff. Retain the old generator packet as history;
+do not rerun its merged work. A previously blocked consumer session should resume its
 updated project prompt; the old generator-merge gate has been removed.
 The [fresh-session prompt pack](prompts/assembly-improvements/README.md) contains
 complete prompts and installed-router model recommendations for each affected
@@ -26,7 +28,7 @@ project, shared skill pass, cost/harness task and optional maintenance operation
 Bring back exact PR results for inspection. Stop only for a real dependency or
 file-ownership conflict, not an unrelated instruction or prompt-pack merge.
 
-## Current status and authority
+## September 8 audit status and authority
 
 Depot main is `386b98e26f493cc220047c981cd5c01b1513b24d` after merged PR #131.
 Routing branch `feat/astra-driver-routing` was implemented and locally validated
@@ -118,6 +120,9 @@ current planning task. Existing PR #129 remains a separate browser-review lane.
 
 ### INSTRUCTIONS-01 — fix the shared generator first
 
+Source complete through merged PR #133, with project-scaffolder 1.9.4 on
+September 10 main. The specification below is retained; it is not a new task.
+
 Owner: Depot `project-scaffolder`, plus Depot's root workflow guidance.
 Likely surfaces: scaffolding SKILL.md, `references/project-configs.md`, generated
 instruction/hook templates, associated fixtures, AGENTS.md and CLAUDE.md.
@@ -173,7 +178,8 @@ Owner: Depot, one plugin per branch in this order:
    requirements, deterministic verification, cleanup and delivery contracts.
 3. dm-review: consolidate repeated guidance, retain applicable lanes, all retained
    findings, repository-owned browser discovery and honest unavailable outcomes.
-   Begin after the active #129 owner has finished its shared review surfaces.
+   #129 has merged. Coordinate with the current UI-DEFAULTS-01 owner before
+   changing its shared review surfaces.
 4. Design Machines strategy/discovery: narrow the oversized trigger description
    and load task-specific references without losing company constraints.
 

--- a/plans/prompts/ui-defaults-01.md
+++ b/plans/prompts/ui-defaults-01.md
@@ -1,8 +1,8 @@
 # UI-DEFAULTS-01 — complete prototype fidelity and existing-site review defaults
 
-Prepared 2026-09-10 from authenticated Depot main. This is a continuation for
-the existing implementation owner, or a fresh session after its handoff. Do not
-start a second writer in the implementation worktree.
+Prepared 2026-09-10 from authenticated Depot main. Complete replacement prompt
+for a fresh Depot session, including existing prototype UX tasks and personas.
+It does not require the previous session or planning PR to complete first.
 
 Recommended start
 
@@ -25,8 +25,8 @@ Existing implementation worktree:
   /home/ned/ai/depot-worktrees/prototype-review-defaults
 Prepared implementation HEAD: 7e5475195ecab8c626b03ee79185d3b863852c82
 Its uncommitted changes already cover this task. Continue them; do not replace
-them or start a competing implementation. Use this prompt in that owning
-session, or after its handoff. A dirty implementation tree is expected.
+them or start a competing implementation. A dirty implementation tree is expected.
+This fresh session is authorized to continue that task's existing diff.
 
 executorRole: builder-deep
 executorCapabilities: [read-repository, write-repository, tool-use, structured-output]
@@ -34,10 +34,20 @@ executorEffort: medium
 Browser execution belongs to the host's actual tools, separately from routing.
 
 OWNERSHIP AND START
+Even if this session starts in another project, first set the working directory
+to the exact Depot implementation worktree above. Before editing, verify
+git rev-parse --show-toplevel and git remote get-url origin identify that
+worktree and Design-Machines-Studio/depot. Accept equivalent SSH/HTTPS remotes.
+Do not create or edit files in the project where the earlier prompt was run;
+do not undo its work. Apply the instructions governing Depot files.
+
 Refresh main, branch state, open PRs and actual file ownership. Read applicable
 AGENTS/CLAUDE instructions and references, Assembly Coordinator, Design Machines
 strategy, affected skills, and existing validation/release guidance.
 PR #129 is merged; retain dm-review 1.80.2 / Kernel 0.22.0 repairs.
+PR #135 is planning only, not an implementation prerequisite. Do not convert
+that planning PR into the implementation PR. A dirty task-owned diff is not
+an active-owner conflict; pause only for evidence of a concurrent writer.
 
 Keep existing edits and all other worktrees intact. Do not stash, reset, clean,
 force-push, delete worktrees or modify the protected primary checkout.
@@ -80,6 +90,34 @@ Production auth, CSRF, storage and SDK wiring may differ without redesigning
 the experience. A necessary security/accessibility correction must be narrow
 and evidenced. Other design divergence requires explicit approved scope.
 If there is no counterpart, identify what was inspected; do not invent one.
+
+REUSE PROTOTYPE UX TASKS AND PERSONAS
+Resolve the canonical Design-Machines-Studio/assembly prototype at the exact
+reviewed commit. Local discovery path: /home/ned/assembly/assembly.
+Read tests/ux/README.md, coverage-matrix.md, applicable tasks/**/*.md,
+personas/_index.md, the selected persona files, and referenced heuristics.
+Task frontmatter and steps are authoritative over the generated coverage matrix.
+These are content-defined browser scenarios, not an invented CLI test runner.
+
+Select the existing task IDs and persona/role/state/device combinations affected
+by the change, including handler-only Datastar changes. Carry those references,
+preconditions, steps, success criteria and screenshot points through Pipeline
+planning/prompts into dm-review's existing case selection and evidence packet.
+Do not duplicate the suite or run the full persona/task cross-product by default.
+
+Execute the selected scenarios in both prototype and app with comparable demo
+accounts, permissions and initial data. Explicitly map different route/account/
+record IDs without weakening the scenario or production authorization. Record
+prototype result, app result and observed difference for each selected case.
+Include save/reload where relevant. Reading tasks or imagining a persona's
+experience does not count as browser execution or real-user research.
+
+An expected permission denial is a successful boundary check when verified,
+not unavailable infrastructure. Expected FRICTION is a hypothesis to assess,
+not an automatic finding. Report stale task/source conflicts and approved
+production differences explicitly. Unimplemented out-of-scope product areas
+do not become new feature requirements; selected required cases remain
+incomplete if missing data/access prevents their execution.
 
 REQUIRED REVIEW-SITE RULE
 Default to the project's established development domain and designated serving
@@ -133,13 +171,17 @@ Extend existing focused contract tests for:
 - existing-instance retention versus justified isolated-resource cleanup;
 - exact structure/classes and handler-only Datastar interaction changes;
 - save/reload behavior, theme differences, and approved minimal adaptations.
+- existing UX task/persona selection and propagation from an external prototype,
+  expected denial versus coverage failure, and paired browser observations.
 
 Run relevant trigger tests only where descriptions change, affected readiness/
 discovery/UI/Pipeline/scaffolder/coordinator checks, generated checks, and
 ./tools/validate-composition.sh --all. Fix every retained P1/P2/P3 finding.
 Use one proportional review and affected rechecks; no repeated full rosters.
 
-Canary with one existing Governance UI flow and its exact prototype counterpart:
+Canary with an applicable existing Governance UX task and its mapped personas
+against the exact prototype counterpart (GOV-PL-003 draft editing is a candidate
+only if that flow exists in the target's approved scope):
 use dm027/dm006 through verified current bindings, build the selected source
 through documented commands, and compare desktop/mobile interaction plus
 save/reload on designated demo records. Do not change consumer product code.

--- a/plans/prompts/ui-defaults-01.md
+++ b/plans/prompts/ui-defaults-01.md
@@ -1,0 +1,180 @@
+# UI-DEFAULTS-01 — complete prototype fidelity and existing-site review defaults
+
+Prepared 2026-09-10 from authenticated Depot main. This is a continuation for
+the existing implementation owner, or a fresh session after its handoff. Do not
+start a second writer in the implementation worktree.
+
+Recommended start
+
+- Model: GPT-6 Astra
+- Harness/rail: Codex subscription (attemptable)
+- Effort: medium
+- Why: Reconcile existing cross-plugin guidance and verify the real browser path.
+- Cost: included subscription; API-equivalent estimate unavailable
+- Fallback: GPT-5.6 Sol via Codex subscription, medium (attemptable)
+- Matrix evidence: 2026-08-27; installed-router recommendation refreshed 2026-09-10
+
+```text
+Task: UI-DEFAULTS-01 — finish prototype fidelity and existing-site review defaults
+
+Repository: Design-Machines-Studio/depot
+Prepared origin/main: 7e5475195ecab8c626b03ee79185d3b863852c82
+Primary checkout: /home/ned/ai/depot — preserve exactly.
+Existing implementation branch: fix/prototype-review-defaults
+Existing implementation worktree:
+  /home/ned/ai/depot-worktrees/prototype-review-defaults
+Prepared implementation HEAD: 7e5475195ecab8c626b03ee79185d3b863852c82
+Its uncommitted changes already cover this task. Continue them; do not replace
+them or start a competing implementation. Use this prompt in that owning
+session, or after its handoff. A dirty implementation tree is expected.
+
+executorRole: builder-deep
+executorCapabilities: [read-repository, write-repository, tool-use, structured-output]
+executorEffort: medium
+Browser execution belongs to the host's actual tools, separately from routing.
+
+OWNERSHIP AND START
+Refresh main, branch state, open PRs and actual file ownership. Read applicable
+AGENTS/CLAUDE instructions and references, Assembly Coordinator, Design Machines
+strategy, affected skills, and existing validation/release guidance.
+PR #129 is merged; retain dm-review 1.80.2 / Kernel 0.22.0 repairs.
+
+Keep existing edits and all other worktrees intact. Do not stash, reset, clean,
+force-push, delete worktrees or modify the protected primary checkout.
+If a newer main must be incorporated, use a normal merge in the owned
+implementation branch. No unrelated Issue/PR or planning-PR merge is a prerequisite.
+
+PROBLEM AND BOUNDED OWNERS
+Assembly's design authority is buried under prototype-era advice. Existing
+parity guidance is too easy to satisfy with screenshots without exercising
+Datastar saving. The installed review contract also forbids rebuilding any
+pre-existing target, conflicting with the user's intended development loop.
+
+Finish the existing changes in:
+- assembly:development — definitive design authority and correct early scoping.
+- Pipeline prototype-authority, promptcraft and execution/browser guidance.
+- dm-review discovery, readiness, visual and source-review entrypoints.
+- Assembly Coordinator prompt preparation.
+- project-scaffolder's existing instruction templates.
+
+These are the surfaces already being edited. Keep changes proportional.
+Do not redesign Kernel, model routing, application code or shared components.
+
+REQUIRED DESIGN RULE
+For an existing prototype counterpart, inspect exact templates, rendered HTML,
+Live Wires class strings, livewires-templ composition, and Datastar behavior
+before implementing. Preserve the exact affected hierarchy, wrappers, classes,
+copy and control placement. Do not substitute new UI or custom CSS because it
+looks similar. Bring this rule into the early Assembly entrypoint and scope
+prototype-only instructions explicitly.
+
+Trace event -> signals/bindings -> request timing/payload -> handler/response
+-> feedback -> persisted result. Exercise the same affected interaction in
+prototype and app, including save/autosave and reload/revisit. Compare matching
+desktop/mobile states, keyboard/focus and validation when affected.
+A prototype stub is not proof of durable production storage.
+
+Themes may change colors and small pixel measurements; they do not excuse
+different structure, layout classes, spacing decisions or interaction flow.
+Production auth, CSRF, storage and SDK wiring may differ without redesigning
+the experience. A necessary security/accessibility correction must be narrow
+and evidenced. Other design divergence requires explicit approved scope.
+If there is no counterpart, identify what was inspected; do not invent one.
+
+REQUIRED REVIEW-SITE RULE
+Default to the project's established development domain and designated serving
+checkout. Project codes map to [project-code].asmbly.app, but verify the exact
+local binding. Record the URL, served checkout and existing build/status commands
+in root instructions or a directly linked runbook. Notion is optional; missing
+catalog access must never block a known local mapping.
+
+Known declarations: prototype dm006.asmbly.app; Governance dm027.asmbly.app.
+Verify each runtime's actual source binding rather than assuming a folder name.
+
+Use ordinary Git to select the feature branch in the clean, available serving
+checkout and run its documented rebuild/restart. This maintenance is authorized
+as part of the requested implementation/review; no repetitive approval.
+Changing Git HEAD alone does not update a compiled binary.
+
+If the feature branch is registered in a separate development worktree, a normal
+detached checkout of its exact committed head in the free serving checkout is
+acceptable; identify it honestly. Never force duplicate checkout or move another
+worker's branch. Preserve owned in-progress edits with an exact source
+fingerprint when reviewing them in place. Preserve unrelated dirty/concurrent
+work and report that concrete collision instead of silently creating a harness.
+
+Keep the same domain, service, data and configuration. Do not reconfigure DNS,
+Caddy, tunnels, ports, env files or Compose topology. Do not reset shared data.
+Check for concrete incompatible data migrations before a branch switch/rebuild;
+ordinary development is not a blanket destructive-action approval.
+
+Existing service maintenance is not review-owned infrastructure creation.
+Do not adopt or tear down the established instance during cleanup.
+Bind browser evidence to the source actually served, including build/assets,
+not just the analysis worktree. Leave the reviewed state for the operator and
+report it; restore/rebuild only when an agreed handoff requires restoration.
+
+Use T3 first as transport, then an available suitable host browser fallback.
+An attached tab or unavailable routed browser candidate does not determine
+which project to review or whether host tools exist.
+New browser environments require a concrete test need, such as simultaneous
+federation peers. Ordinary isolated unit-test containers remain valid.
+Preserve exact evidence reuse and honest incomplete-coverage reporting.
+
+ACCEPTANCE AND VERIFICATION
+Remove contradictions across the affected full/quick/visual and Pipeline paths.
+Reuse existing readiness/parity evidence; add no service, broker, parser,
+global registry, second ledger or new approval system.
+
+Extend existing focused contract tests for:
+- wrong attached tab versus the declared project site;
+- clean branch selection/rebuild and the exact served source;
+- branch already in another worktree, unrelated dirty work, and stale binary;
+- existing-instance retention versus justified isolated-resource cleanup;
+- exact structure/classes and handler-only Datastar interaction changes;
+- save/reload behavior, theme differences, and approved minimal adaptations.
+
+Run relevant trigger tests only where descriptions change, affected readiness/
+discovery/UI/Pipeline/scaffolder/coordinator checks, generated checks, and
+./tools/validate-composition.sh --all. Fix every retained P1/P2/P3 finding.
+Use one proportional review and affected rechecks; no repeated full rosters.
+
+Canary with one existing Governance UI flow and its exact prototype counterpart:
+use dm027/dm006 through verified current bindings, build the selected source
+through documented commands, and compare desktop/mobile interaction plus
+save/reload on designated demo records. Do not change consumer product code.
+Record source versus installed-plugin execution. If access, data, runtime
+binding or prototype evidence is genuinely unavailable, name the exact gap,
+continue independent verification/delivery, and do not claim the canary passed.
+
+VERSION AND DELIVERY
+At the prepared base: Assembly 3.16.0, Pipeline 1.67.0, dm-review 1.80.2,
+project-manager 1.14.0, project-scaffolder 1.9.4, Kernel 0.22.0.
+Bump only changed plugins according to actual scope from refreshed main.
+Update canonical Claude plugin/marketplace versions; regenerate Codex manifests
+and changed command aliases. Refresh the index/dependency graph as necessary.
+Avoid dependency cycles or new dependencies merely to share prose.
+
+Commit, push, and open/update one proper implementation PR against main.
+Do not merge, tag, publish, or synchronize Claude/Codex caches. Report those
+remaining release steps and the later installed-consumer canary separately.
+Source push must not require caches to match unreleased code.
+
+Use only Project 1, Assembly Coordination: Review / P1 / Tooling when ready.
+Do not mutate native Issues. REST fallback is valid if GraphQL is limited;
+Project access must not block verified commit/push/PR delivery.
+
+Request optional participants by role/capabilities/effort through the installed
+router. Prefer available subscription capacity; paid calls at most $0.25 total
+within known remaining budget. The $50/month target is not observed headroom.
+
+About 40 tool calls is an exploration checkpoint, not a reason to abandon
+repair, verification, commit, push or PR creation.
+
+FINAL
+Report actual base/head, changes, tests, consumer coverage, versions, PR/Project
+state, delivery level and one next action. Include SIMPLICITY-CHECK, NOT-COVERED
+and COMMANDS-RUN. For routed work report role, attempted/served participant,
+rail, effort, duration, outcome, measured tokens/cost, subscription calls,
+fallbacks and unavailable measurements. No invented clean passes or costs.
+```

--- a/plans/prototype-and-development-site-review.md
+++ b/plans/prototype-and-development-site-review.md
@@ -9,7 +9,8 @@ Parent program: [Assembly development improvements](astra-routing-and-system-rol
 Finish the existing `fix/prototype-review-defaults` work as **UI-DEFAULTS-01**.
 It already spans the two reported problems; do not launch competing browser
 or prototype rewrites. The [complete continuation prompt](prompts/ui-defaults-01.md)
-is for its current owner or a fresh session after handoff.
+now supports a fresh Depot session and explicitly verifies the correct remote
+before editing. Preserve any work from a session started in the wrong project.
 
 At inspection, the branch was based on
 `7e5475195ecab8c626b03ee79185d3b863852c82` with uncommitted changes in 18 files.
@@ -55,6 +56,45 @@ authorization, CSRF, storage and SDK wiring must remain correct; use only the
 minimal necessary adaptation, with evidence. Other design changes require
 explicit approved scope and start from the prototype. No counterpart requires
 an inspected-source explanation rather than an invented redesign.
+
+## Reuse the prototype's UX tasks and personas
+
+The prototype's `tests/ux/` is an existing content-defined browser test suite.
+Read its README and coverage matrix for discovery, then use individual task
+frontmatter/steps, selected persona profiles and referenced heuristics as the
+scenario authority. Carry existing task/persona IDs into Pipeline prompts and
+dm-review's existing case selection; do not copy the suite into Depot or add
+a runner, persona framework, second report format or full-matrix default.
+
+For each affected scenario, preserve preconditions, role expectations, steps,
+success criteria and screenshot points. Run it in both prototype and target
+with comparable demo accounts/data, mapping route/account/record IDs explicitly.
+Record each side's observed interactions and outcomes, including save/reload
+when applicable. Reading a task is not executing it. Agent persona evaluation
+is not a human usability study.
+
+An expected authorization denial is a successful boundary check when observed;
+it is not missing browser coverage. An expected FRICTION outcome is a hypothesis,
+not proof of a defect. Generated indexes do not override task source. If a task
+disagrees with exact prototype source or approved production scope, preserve
+and name that discrepancy rather than silently changing either authority.
+Unrelated unimplemented product areas are excluded with a reason; missing
+setup for an already selected required case remains an honest coverage gap.
+
+Evidence inspected at prototype `cb355281d6e065dac257e4f3ac89241a9ad77072`
+with no `tests/ux/` working-tree changes:
+
+- `tests/ux/README.md` defines browser execution of persona-task scenarios.
+- `tests/ux/personas/_index.md` maps six personas to seed accounts, roles,
+  behavioral expectations and devices.
+- `GOV-PL-003` exercises draft editing, autosave feedback and edited-by metadata.
+- `GOV-PP-007` exercises changing a position, immediate distribution updates
+  and activity feedback. Its exact task wording must be compared with the
+  selected current prototype and approved target before reuse.
+
+These examples are discovery evidence, not completed browser tests. The
+continuation prompt includes focused case-propagation checks and a canary
+using applicable existing tasks and personas.
 
 ## Existing development-site contract
 

--- a/plans/prototype-and-development-site-review.md
+++ b/plans/prototype-and-development-site-review.md
@@ -1,0 +1,131 @@
+# Prototype fidelity and existing development-site reviews
+
+Coordination snapshot: 2026-09-10. User requirements are authoritative; this
+document records their implementation ownership and proof boundaries.
+Parent program: [Assembly development improvements](astra-routing-and-system-rollout.md).
+
+## Decision
+
+Finish the existing `fix/prototype-review-defaults` work as **UI-DEFAULTS-01**.
+It already spans the two reported problems; do not launch competing browser
+or prototype rewrites. The [complete continuation prompt](prompts/ui-defaults-01.md)
+is for its current owner or a fresh session after handoff.
+
+At inspection, the branch was based on
+`7e5475195ecab8c626b03ee79185d3b863852c82` with uncommitted changes in 18 files.
+The implementation worktree is
+`/home/ned/ai/depot-worktrees/prototype-review-defaults`.
+This is ownership evidence, not verified completion. No implementation PR was
+open at the initial authenticated check. Refresh these facts before continuing.
+
+## What belongs where
+
+| Owner | Responsibility |
+|---|---|
+| Assembly development | Make the prototype definitive for production Fixture/Baseplate UI; distinguish prototype-only implementation examples early |
+| Pipeline | Carry exact source, structure/classes/components, Datastar interaction and persistence expectations into bounded execution prompts |
+| dm-review | Select the established project site, follow its existing author loop, and compare source plus actual browser interactions |
+| Assembly Coordinator | Include the exact prototype and development-site authorities when preparing an affected task |
+| Project Scaffolder | Put a short development-site and prototype declaration into existing generated instruction entrypoints |
+| Consumer repository | Own its actual URL, served checkout, build/status/restart procedure, authentication/setup references and current prototype mapping |
+| Workflow Kernel | Retain existing evidence/resource mechanics; no new environment manager or domain catalog |
+
+Design Machines strategy supplies the small-team/product constraint. Live Wires
+and livewires-templ own reusable components, not the review site's lifecycle.
+Keep the existing reference structure and concise owner-specific instructions;
+do not create dependency cycles to centralize a paragraph.
+
+## Definitive prototype contract
+
+For a counterpart, reproduce the affected HTML hierarchy, wrappers, Live Wires
+class strings, shared livewires-templ composition, literal copy and control
+placement. Reuse source/components; do not reinterpret a screenshot or substitute
+custom CSS. Implementation reuse is allowed even though prompt packets should
+not duplicate whole templates.
+
+Read Datastar attributes/signals and relevant handlers. Trace event, timing,
+payload, response, feedback and saved state. Try each affected interaction in
+both prototype and application at matching desktop/mobile states. Test
+save/autosave, reload/revisit, keyboard/focus, cancel and validation when affected.
+Label prototype stubs separately from real persistence.
+
+Theme values and small pixel differences are acceptable. They do not waive
+structure/classes/spacing or interaction comparison. Production authentication,
+authorization, CSRF, storage and SDK wiring must remain correct; use only the
+minimal necessary adaptation, with evidence. Other design changes require
+explicit approved scope and start from the prototype. No counterpart requires
+an inspected-source explanation rather than an invented redesign.
+
+## Existing development-site contract
+
+The normal review path is the established `[project-code].asmbly.app` site
+serving the selected feature source from its designated checkout. Root
+instructions or a directly linked runbook must identify the actual binding and
+existing status/build/restart command. The private Project Codes catalog can
+help find a code, but is never a shared workflow dependency. Its supplied link
+was inaccessible to the public browser tool during this pass; no complete
+catalog mapping was verified.
+
+Local evidence names `dm006.asmbly.app` for the prototype and
+`dm027.asmbly.app` for Governance. These are declared URLs, not current runtime
+source proof. A Fixture's running Baseplate consumer may use a recorded source
+checkout; inspect that binding before assuming the primary folder is served.
+
+Switch the clean, available serving checkout with ordinary Git and rebuild
+through its existing command. That maintenance is authorized by the requested
+development/review task. Preserve unrelated changes and another session's work.
+When the branch is already checked out elsewhere, a normal detached checkout of
+the exact committed feature head is sufficient for a free serving checkout;
+do not force duplicate branch checkout. Bind owned dirty-source reviews to the
+actual fingerprint. A missing/stale binary is not repaired merely by changing HEAD.
+
+Keep the same domain, service, data, configuration and topology. Do not change
+DNS, Caddy, tunnels, ports or environment files. Do not reset shared data or
+silently run incompatible migrations. A maintained service is not adopted into
+review cleanup just because it was rebuilt. Leave the reviewed state available;
+restore/rebuild only according to an agreed handoff.
+
+Separate browser transport from target selection. Prefer T3, recover through
+actual available host browser tools, and never use an unrelated attached tab as
+project authority. New environments need a concrete test requirement, such as
+simultaneous federation peers; development worktrees and unit-test containers
+do not themselves require new browser instances.
+
+## Evidence and remaining proof
+
+- Authenticated main: `7e5475195ecab8c626b03ee79185d3b863852c82`.
+- [PR #129](https://github.com/Design-Machines-Studio/depot/pull/129) merged exact
+  head `52f4e2717dc1529c7bbd9cc39c3c06f79cc36da8`; main matches that feature tree.
+  It added fixed-project author-loop support, not the new maintained-site default.
+  Its [Governance canary](../docs/ui-ready-03-governance.md) used a disposable
+  instance and did not complete all populated/prototype comparisons.
+- Current source versions: dm-review 1.80.2, Kernel 0.22.0, Pipeline 1.67.0,
+  Assembly 3.16.0, project-manager 1.14.0, project-scaffolder 1.9.4.
+- The existing [prototype authority](../plugins/pipeline/references/prototype-authority.md)
+  already requires source/rendered comparison, but lacks explicit save-event
+  and persistence traces. Assembly's production rule is deep in its entrypoint.
+- The merged [target discovery](../plugins/dm-review/skills/review/references/repository-browser-target-discovery.md)
+  forbids rebuilding pre-existing targets. The prototype repository explicitly
+  assigns browser review to its main checkout and existing container.
+- User reports establish repeated drift. This pass did not reproduce or assign
+  new product findings against a particular Fixture diff.
+
+Acceptance for UI-DEFAULTS-01: no contradictory entrypoints; focused behavioral
+contracts for maintained-site identity/retention and prototype interaction
+parity; full composition on the implementation; one real comparison using
+existing sites and designated demo data. Retain every P1/P2/P3 finding and honest
+coverage gaps. Existing evidence is reused only when still exact.
+
+## Sequence and completion
+
+One active implementation owner; no parallel writer on these plugin surfaces.
+The general SKILLS-01/02/03 reduction passes must account for this file ownership.
+The merged generator and #129 are no longer prerequisites awaiting completion.
+
+After exact implementation review: proper PR, then separately authorized merge,
+tags, Claude/Codex cache synchronization and installed-consumer proof. Consumer
+instruction corrections, if needed, get repository-owned PRs after inspecting
+actual declarations; no blanket generator-merge gate.
+
+This coordination PR changes plans/prompts only. It does not change plugin
+behavior, consumer checkouts, running services or installed caches.


### PR DESCRIPTION
Fixture implementations must preserve the prototype's HTML, Live Wires components/classes, and Datastar interaction and saving behavior. Browser review should use the established development site and its serving checkout through the existing build commands.

The fresh-session prompt now verifies the Depot remote before editing and requires reuse of the prototype’s existing UX task/persona scenarios, including paired browser outcomes. Individual task files remain authoritative over the generated coverage matrix; expected permission denials are distinguished from missing coverage.

This planning change records those requirements and the existing `fix/prototype-review-defaults` implementation owner, supplies a complete continuation prompt with a current model recommendation, and updates the rollout plan now that #133 and #129 have merged. It avoids starting a competing implementation.

Validation: local link and Markdown checks, required prompt fields, provider-neutral execution content, one human-facing fallback, and `git diff --cached --check` passed. Only three planning documents changed; plugin composition and browser tests were not run for this documentation change.

Plugin implementation, consumer-site verification, version movement, publication, and installation remain separate delivery steps. No consumer checkout, running service, plugin source, or cache was changed here.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Design-Machines-Studio/codesmith/depot/pr/135"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791605893&installation_model_id=428410&pr_number=135&repository=Design-Machines-Studio%2Fdepot&return_to=https%3A%2F%2Fgithub.com%2FDesign-Machines-Studio%2Fdepot%2Fpull%2F135&signature=7899aa33d1551c74da6d6efcd790c9899a207f37a3d61f97344ec9f869ccbaee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->